### PR TITLE
ci: archive all main binaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,10 @@ concurrency:
   group: rust-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: write
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -123,10 +127,51 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
-          name: logmancer-tui-${{ matrix.target }}
+          name: logmancer-binaries-${{ matrix.target }}
           path: |
-            target/${{ matrix.target }}/release/*.exe
             target/${{ matrix.target }}/release/logmancer-tui
-          retention-days: 7
+            target/${{ matrix.target }}/release/logmancer-web
+            target/${{ matrix.target }}/release/logmancer-desktop
+            target/${{ matrix.target }}/release/logmancer-tui.exe
+            target/${{ matrix.target }}/release/logmancer-web.exe
+            target/${{ matrix.target }}/release/logmancer-desktop.exe
+          if-no-files-found: error
+
+  cleanup-artifacts:
+    name: Keep only latest main artifacts
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Delete older main binary artifacts
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const artifacts = await github.paginate(
+              github.rest.actions.listArtifactsForRepo,
+              { owner, repo, per_page: 100 }
+            );
+
+            const currentRunId = context.runId;
+            const staleArtifacts = artifacts.filter((artifact) => {
+              const isLogmancerBinaryArtifact = artifact.name.startsWith('logmancer-binaries-')
+                || artifact.name.startsWith('logmancer-tui-');
+
+              return isLogmancerBinaryArtifact
+                && artifact.workflow_run?.head_branch === 'main'
+                && artifact.workflow_run?.id !== currentRunId;
+            });
+
+            for (const artifact of staleArtifacts) {
+              core.info(`Deleting artifact ${artifact.name} from run ${artifact.workflow_run?.id}`);
+              await github.rest.actions.deleteArtifact({
+                owner,
+                repo,
+                artifact_id: artifact.id,
+              });
+            }


### PR DESCRIPTION
Closes #5

## Type
- [x] Maintenance/tooling

## Summary
- Uploads all raw Cargo-built Logmancer binaries for successful `main` pushes.
- Removes the explicit 7-day artifact retention override.
- Deletes older main binary artifacts, including legacy `logmancer-tui-*` artifacts.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/rust.yml` | Upload all raw TUI/web/desktop binaries and clean up stale main artifacts. |

## Test Plan
- [x] Validated workflow YAML parses successfully with Ruby.
- [ ] GitHub Actions workflow run validates artifact upload behavior after merge to `main`.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers