### PR TITLE
fix(web): stabilize release assets and uploads

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+LEPTOS_OUTPUT_NAME = "logmancer-web"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,7 +65,7 @@ jobs:
           pkg-config --exists webkit2gtk-4.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: clippy
 
@@ -124,7 +124,7 @@ jobs:
           pkg-config --exists webkit2gtk-4.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.95.0
         with:
           targets: ${{ matrix.target }},wasm32-unknown-unknown
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,6 +32,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  LEPTOS_OUTPUT_NAME: logmancer-web
 
 jobs:
   test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -75,9 +77,16 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --verbose
 
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Build workspace
+        run: cargo build --workspace --verbose
+
   build:
-    name: Build for ${{ matrix.target }}
+    name: Package for ${{ matrix.target }}
     needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -172,7 +181,6 @@ jobs:
           EOF
 
           chmod +x "$package_root/run-web.sh" "$package_root/run-desktop.sh"
-          (cd dist && zip -r "logmancer-${{ matrix.target }}.zip" "logmancer-${{ matrix.target }}")
 
       - name: Package Windows artifacts
         if: runner.os == 'Windows'
@@ -205,14 +213,11 @@ jobs:
           "%~dp0logmancer-desktop.exe" %*
           "@ | Set-Content -Path "$packageRoot/run-desktop.cmd"
 
-          Compress-Archive -Path "$packageRoot/*" -DestinationPath "dist/logmancer-${{ matrix.target }}.zip" -Force
-
       - name: Upload artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v7
         with:
           name: logmancer-package-${{ matrix.target }}
-          path: dist/logmancer-${{ matrix.target }}.zip
+          path: dist/logmancer-${{ matrix.target }}
           if-no-files-found: error
 
   cleanup-artifacts:

--- a/logmancer-core/src/file_ops/write.rs
+++ b/logmancer-core/src/file_ops/write.rs
@@ -40,7 +40,7 @@ impl FileWriteOps {
     pub fn index_lines(&mut self) -> io::Result<bool> {
         let mut file_lock = self.log_file.write().unwrap();
         
-        let start_pos = file_lock.index.last().unwrap().clone();
+        let start_pos = *file_lock.index.last().unwrap();
         let end_pos = min(file_lock.mmap.len(), start_pos + INDEX_MAX_BYTES);
         let end_reached = file_lock.mmap.len() <= start_pos + INDEX_MAX_BYTES;
         let content = &file_lock.mmap[start_pos..end_pos];

--- a/logmancer-core/src/file_ops/write.rs
+++ b/logmancer-core/src/file_ops/write.rs
@@ -84,10 +84,10 @@ impl FileWriteOps {
             let end_pos = file_lock.index[i + 1];
             let line = &file_lock.mmap[start_pos..end_pos];
             let mut match_filter = false;
-            if let Ok(text) = std::str::from_utf8(line) {
-                if re.is_match(text) {
-                    match_filter = true;
-                }
+            if let Ok(text) = std::str::from_utf8(line)
+                && re.is_match(text)
+            {
+                match_filter = true;
             }
             file_lock.filter.push(match_filter);
         }

--- a/logmancer-core/src/handler.rs
+++ b/logmancer-core/src/handler.rs
@@ -20,7 +20,7 @@ impl LogFileHandler {
         let (reload_sender, reload_receiver) = unbounded::<()>();
         let (filter_sender, filter_receiver) = unbounded::<Option<String>>();
         let log_file = Arc::new(RwLock::new(LogFile::new(path.clone())?));
-        info!("File {} loaded", path);
+        info!("File {path} loaded");
 
         let reload_write_ops = FileWriteOps::new(Arc::clone(&log_file));
         let filter_write_ops = FileWriteOps::new(Arc::clone(&log_file));

--- a/logmancer-core/src/handler.rs
+++ b/logmancer-core/src/handler.rs
@@ -51,7 +51,7 @@ impl LogFileHandler {
         }
     }
 
-    pub fn read_ops(&self) -> FileReadOps {
+    pub fn read_ops(&self) -> FileReadOps<'_> {
         FileReadOps::new(self.log_file.read().unwrap())
     }
 

--- a/logmancer-core/src/reader.rs
+++ b/logmancer-core/src/reader.rs
@@ -24,13 +24,13 @@ impl LogReader {
             total_lines: read_ops.total_lines()?,
             indexing_progress: read_ops.indexing_progress()?,
         };
-        debug!("{:?}", file_info);
+        debug!("{file_info:?}");
         Ok(file_info)
     }
 
     /// Reads a page from the file, starting at `start_line` and reading up to `max_lines` lines.
     pub fn read_page(&mut self, start_line: usize, max_lines: usize) -> io::Result<PageResult> {
-        debug!("Reading from line {} to max {}", start_line, max_lines);
+        debug!("Reading from line {start_line} to max {max_lines}");
         let read_ops = self.handler.read_ops();
         let to_line = min(start_line + max_lines, read_ops.total_lines()?);
         let from_line = to_line.saturating_sub(max_lines);
@@ -51,7 +51,7 @@ impl LogReader {
 
     // Reads the last `max_lines` lines from the file. If `follow` is true the file is reloaded
     pub fn tail(&mut self, max_lines: usize, follow: bool) -> io::Result<PageResult> {
-        debug!("Reading last {} lines to the end", max_lines);
+        debug!("Reading last {max_lines} lines to the end");
         if follow {
             self.handler.reload();
         }
@@ -78,10 +78,7 @@ impl LogReader {
     }
 
     pub fn read_filter(&mut self, start_line: usize, max_lines: usize) -> io::Result<PageResult> {
-        debug!(
-            "Reading filter from line {} to max {}",
-            start_line, max_lines
-        );
+        debug!("Reading filter from line {start_line} to max {max_lines}");
         let read_ops = self.handler.read_ops();
 
         let total_lines = read_ops.filtered_lines()?;
@@ -111,7 +108,7 @@ impl LogReader {
     }
 
     pub fn tail_filter(&mut self, max_lines: usize, follow: bool) -> io::Result<PageResult> {
-        debug!("Reading last {} lines to the end", max_lines);
+        debug!("Reading last {max_lines} lines to the end");
         if follow {
             self.handler.filter(None);
         }

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -34,3 +34,9 @@ impl LogRegistry {
         }
     }
 }
+
+impl Default for LogRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -26,7 +26,7 @@ impl LogRegistry {
     }
 
     /// Gets a LogReader by UUID
-    pub fn get_reader(&self, file_id: &str) -> Option<RefMut<Uuid,LogReader>> {
+    pub fn get_reader(&self, file_id: &str) -> Option<RefMut<'_, Uuid, LogReader>> {
         if let Ok(uuid) = Uuid::parse_str(file_id) {
             self.open_files.get_mut(&uuid)
         } else {

--- a/logmancer-core/src/worker.rs
+++ b/logmancer-core/src/worker.rs
@@ -23,13 +23,13 @@ pub fn spawn_reload_worker(
                                         wait(1);
                                     }
                                     Err(error) => {
-                                        panic!("Error indexing file: {}", error)
+                                        panic!("Error indexing file: {error}")
                                     }
                                 }
                             }
                         }
                         Err(error) => {
-                            panic!("Error reloading file: {}", error)
+                            panic!("Error reloading file: {error}")
                         }
                     }
                 }
@@ -59,7 +59,7 @@ pub fn spawn_filter_worker(
                                         wait(1);
                                     }
                                     Err(error) => {
-                                        panic!("Error indexing filtered lines: {}", error)
+                                        panic!("Error indexing filtered lines: {error}")
                                     }
                                 }
                             }

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -30,8 +30,8 @@ pub fn run() {
                 });
                 let window = app.get_webview_window("main").unwrap();
                 let target = match initial_file_id {
-                    Some(file_id) => format!("http://127.0.0.1:{}/log/{}", port, file_id),
-                    None => format!("http://127.0.0.1:{}", port),
+                    Some(file_id) => format!("http://127.0.0.1:{port}/log/{file_id}"),
+                    None => format!("http://127.0.0.1:{port}"),
                 };
                 info!("Navigating desktop window to {}", target);
                 window.navigate(Url::parse(target.as_str()).unwrap())?;

--- a/logmancer-tui/src/main.rs
+++ b/logmancer-tui/src/main.rs
@@ -4,13 +4,14 @@ mod print_utils;
 use crossterm::{
     cursor,
     event::{self, Event, KeyCode},
-    execute, terminal,
-    style::{Print}
+    execute,
+    style::Print,
+    terminal,
 };
 use log::{debug, error, LevelFilter};
 use logmancer_core::LogReader;
 use std::env;
-use std::fs::{OpenOptions};
+use std::fs::OpenOptions;
 use std::io::{stdout, Write};
 use std::{process, time};
 
@@ -27,7 +28,7 @@ fn main() -> std::io::Result<()> {
     execute!(stdout(), terminal::EnterAlternateScreen)?;
     terminal::enable_raw_mode()?;
     std::panic::set_hook(Box::new(|panic_info| {
-        error!("{}", panic_info);
+        error!("{panic_info}");
         terminal::disable_raw_mode().unwrap();
         process::exit(1);
     }));
@@ -35,7 +36,7 @@ fn main() -> std::io::Result<()> {
     let mut reader = match LogReader::new(filepath.to_string()) {
         Ok(r) => r,
         Err(e) => {
-            error!("Error opening file: {}", e);
+            error!("Error opening file: {e}");
             process::exit(1);
         }
     };
@@ -73,7 +74,7 @@ fn main() -> std::io::Result<()> {
                 page_result
             },
             Err(e) => {
-                error!("Error reading file: {}", e);
+                error!("Error reading file: {e}");
                 break;
             }
         };
@@ -83,7 +84,7 @@ fn main() -> std::io::Result<()> {
 
         if last_page_result.as_ref() != Some(&page_result) || dimensions_changed {
             let indexed = if indexing_progress < 100.0 {
-                format!(" ({:.2}% indexed)", indexing_progress)
+                format!(" ({indexing_progress:.2}% indexed)")
             } else {
                 "".to_owned()
             };
@@ -119,38 +120,36 @@ fn main() -> std::io::Result<()> {
         } else {
             Some(event::read()?)
         };
-        if let Some(evt) = event {
-            if let Event::Key(key_event) = evt {
-                match key_event.code {
-                    KeyCode::Char('q') => break,
-                    KeyCode::Char('f') | KeyCode::Char('F') => follow_mode = !follow_mode,
-                    KeyCode::Char('g') => {
-                        end_reached = false;
-                        page_first_line = 0;
-                    }
-                    KeyCode::Char('G') => {
-                        end_reached = true;
-                    }
-                    KeyCode::Down => {
-                        if !end_reached {
-                            page_first_line += 1;
-                        }
-                    }
-                    KeyCode::Up => {
-                        end_reached = false;
-                        page_first_line = page_first_line.saturating_sub(1);
-                    }
-                    KeyCode::PageDown => {
-                        if !end_reached {
-                            page_first_line += page_size;
-                        }
-                    }
-                    KeyCode::PageUp => {
-                        end_reached = false;
-                        page_first_line = page_first_line.saturating_sub(page_size);
-                    }
-                    _ => {}
+        if let Some(Event::Key(key_event)) = event {
+            match key_event.code {
+                KeyCode::Char('q') => break,
+                KeyCode::Char('f') | KeyCode::Char('F') => follow_mode = !follow_mode,
+                KeyCode::Char('g') => {
+                    end_reached = false;
+                    page_first_line = 0;
                 }
+                KeyCode::Char('G') => {
+                    end_reached = true;
+                }
+                KeyCode::Down => {
+                    if !end_reached {
+                        page_first_line += 1;
+                    }
+                }
+                KeyCode::Up => {
+                    end_reached = false;
+                    page_first_line = page_first_line.saturating_sub(1);
+                }
+                KeyCode::PageDown => {
+                    if !end_reached {
+                        page_first_line += page_size;
+                    }
+                }
+                KeyCode::PageUp => {
+                    end_reached = false;
+                    page_first_line = page_first_line.saturating_sub(page_size);
+                }
+                _ => {}
             }
         }
     }
@@ -175,7 +174,6 @@ fn trunc_str(s: &str, max_len: usize) -> &str {
 fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     let file = OpenOptions::new()
         .create(true)
-        .write(true)
         .append(true)
         .open("logmancer.log")?;
 

--- a/logmancer-tui/src/main.rs
+++ b/logmancer-tui/src/main.rs
@@ -131,19 +131,15 @@ fn main() -> std::io::Result<()> {
                 KeyCode::Char('G') => {
                     end_reached = true;
                 }
-                KeyCode::Down => {
-                    if !end_reached {
-                        page_first_line += 1;
-                    }
+                KeyCode::Down if !end_reached => {
+                    page_first_line += 1;
                 }
                 KeyCode::Up => {
                     end_reached = false;
                     page_first_line = page_first_line.saturating_sub(1);
                 }
-                KeyCode::PageDown => {
-                    if !end_reached {
-                        page_first_line += page_size;
-                    }
+                KeyCode::PageDown if !end_reached => {
+                    page_first_line += page_size;
                 }
                 KeyCode::PageUp => {
                     end_reached = false;

--- a/logmancer-web/build.rs
+++ b/logmancer-web/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("cargo:rustc-env=LEPTOS_OUTPUT_NAME=logmancer-web");
-}

--- a/logmancer-web/src/api/config.rs
+++ b/logmancer-web/src/api/config.rs
@@ -3,10 +3,13 @@ use crate::api::filter::{apply_filter, read_filter_page};
 use crate::api::open_server_file::open_server_file;
 use crate::api::read_page::{read_page, tail};
 use crate::api::upload_file::upload_file;
+use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
 use logmancer_core::LogRegistry;
 use std::sync::Arc;
+
+const LOG_UPLOAD_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -22,6 +25,7 @@ pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
         .route("/tail", get(tail))
         .route("/apply-filter", post(apply_filter))
         .route("/read-filter-page", get(read_filter_page))
+        .layer(DefaultBodyLimit::max(LOG_UPLOAD_BODY_LIMIT_BYTES))
         .with_state(AppState { registry })
 }
 

--- a/logmancer-web/src/api/file_info.rs
+++ b/logmancer-web/src/api/file_info.rs
@@ -12,7 +12,7 @@ pub async fn file_info(State(app_state): State<AppState>, query: Query<FileInfoR
         Some(reader) => {
             match reader.file_info() {
                 Ok(file_info) => (StatusCode::OK, Json(file_info)).into_response(),
-                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Error reading file: {}", e))).into_response()
+                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Error reading file: {e}"))).into_response()
             }
         }
         None => (StatusCode::NOT_FOUND, Json("File not opened")).into_response()

--- a/logmancer-web/src/api/filter.rs
+++ b/logmancer-web/src/api/filter.rs
@@ -25,7 +25,7 @@ pub async fn read_filter_page(State(app_state): State<AppState>, query: Query<Re
         Some(mut reader) => {
             match reader.read_filter(query.start_line, query.max_lines) {
                 Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
-                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Error reading filter: {}", e))).into_response()
+                Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, Json(format!("Error reading filter: {e}"))).into_response()
             }
         }
         None => (StatusCode::NOT_FOUND, Json("File not opened")).into_response()

--- a/logmancer-web/src/api/open_server_file.rs
+++ b/logmancer-web/src/api/open_server_file.rs
@@ -35,7 +35,7 @@ pub async fn open_server_file(
             error!("Error opening file path={} error={}", trimmed_path, e);
             (
                 StatusCode::BAD_REQUEST,
-                Json(format!("Could not open file '{}': {}", trimmed_path, e)),
+                Json(format!("Could not open file '{trimmed_path}': {e}")),
             )
                 .into_response()
         }

--- a/logmancer-web/src/api/read_page.rs
+++ b/logmancer-web/src/api/read_page.rs
@@ -17,7 +17,7 @@ pub async fn read_page(
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(format!("Error reading file: {}", e)),
+                Json(format!("Error reading file: {e}")),
             )
                 .into_response(),
         },
@@ -33,7 +33,7 @@ pub async fn tail(State(app_state): State<AppState>, query: Query<TailRequest>) 
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(format!("Error reading file: {}", e)),
+                Json(format!("Error reading file: {e}")),
             )
                 .into_response(),
         },

--- a/logmancer-web/src/api/upload_file.rs
+++ b/logmancer-web/src/api/upload_file.rs
@@ -4,6 +4,7 @@ use axum::extract::{Multipart, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{error, info, warn};
@@ -14,7 +15,20 @@ pub async fn upload_file(
 ) -> impl IntoResponse {
     let mut temp_path: Option<PathBuf> = None;
 
-    while let Ok(Some(field)) = multipart.next_field().await {
+    loop {
+        let field = match multipart.next_field().await {
+            Ok(Some(field)) => field,
+            Ok(None) => break,
+            Err(err) => {
+                error!("Error parsing multipart request: {}", err);
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json("Could not parse uploaded file.".to_string()),
+                )
+                    .into_response();
+            }
+        };
+
         if field.name() != Some("file") {
             continue;
         }
@@ -25,27 +39,6 @@ pub async fn upload_file(
             .filter(|name| !name.is_empty())
             .unwrap_or_else(|| "uploaded.log".to_string());
 
-        let bytes = match field.bytes().await {
-            Ok(bytes) => bytes,
-            Err(err) => {
-                error!("Error reading multipart bytes: {}", err);
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json("Could not read uploaded file.".to_string()),
-                )
-                    .into_response();
-            }
-        };
-
-        if bytes.is_empty() {
-            warn!("Rejected upload-file request with empty payload");
-            return (
-                StatusCode::BAD_REQUEST,
-                Json("Uploaded file cannot be empty.".to_string()),
-            )
-                .into_response();
-        }
-
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos())
@@ -53,11 +46,53 @@ pub async fn upload_file(
         let mut path = std::env::temp_dir();
         path.push(format!("logmancer-upload-{}-{}", timestamp, file_name));
 
-        if let Err(err) = std::fs::write(&path, &bytes) {
-            error!("Error writing temp uploaded file path={:?} error={}", path, err);
+        let mut temp_file = match std::fs::File::create(&path) {
+            Ok(file) => file,
+            Err(err) => {
+                error!("Error creating temp uploaded file path={:?} error={}", path, err);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json("Could not store temporary uploaded file.".to_string()),
+                )
+                    .into_response();
+            }
+        };
+
+        let mut field = field;
+        let mut uploaded_bytes = 0usize;
+        loop {
+            let chunk = match field.chunk().await {
+                Ok(Some(chunk)) => chunk,
+                Ok(None) => break,
+                Err(err) => {
+                    error!("Error reading multipart chunk: {}", err);
+                    let _ = std::fs::remove_file(&path);
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json("Could not read uploaded file.".to_string()),
+                    )
+                        .into_response();
+                }
+            };
+
+            uploaded_bytes += chunk.len();
+            if let Err(err) = temp_file.write_all(&chunk) {
+                error!("Error writing temp uploaded file path={:?} error={}", path, err);
+                let _ = std::fs::remove_file(&path);
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json("Could not store temporary uploaded file.".to_string()),
+                )
+                    .into_response();
+            }
+        }
+
+        if uploaded_bytes == 0 {
+            warn!("Rejected upload-file request with empty payload");
+            let _ = std::fs::remove_file(&path);
             return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json("Could not store temporary uploaded file.".to_string()),
+                StatusCode::BAD_REQUEST,
+                Json("Uploaded file cannot be empty.".to_string()),
             )
                 .into_response();
         }

--- a/logmancer-web/src/api/upload_file.rs
+++ b/logmancer-web/src/api/upload_file.rs
@@ -44,7 +44,7 @@ pub async fn upload_file(
             .map(|d| d.as_nanos())
             .unwrap_or_default();
         let mut path = std::env::temp_dir();
-        path.push(format!("logmancer-upload-{}-{}", timestamp, file_name));
+        path.push(format!("logmancer-upload-{timestamp}-{file_name}"));
 
         let mut temp_file = match std::fs::File::create(&path) {
             Ok(file) => file,
@@ -123,7 +123,7 @@ pub async fn upload_file(
             error!("Error opening uploaded file path={} error={}", path_string, err);
             (
                 StatusCode::BAD_REQUEST,
-                Json(format!("Could not open uploaded file: {}", err)),
+                Json(format!("Could not open uploaded file: {err}")),
             )
                 .into_response()
         }

--- a/logmancer-web/src/components/async_functions.rs
+++ b/logmancer-web/src/components/async_functions.rs
@@ -8,7 +8,7 @@ use web_sys::{FormData, RequestInit, Response};
 pub async fn fetch_page(file_id: String, start_line: usize, max_lines: usize, tail: bool, follow: bool) -> Result<PageResult, ServerFnError> {
     let base = window().location().origin().unwrap();
     let request = if tail {
-        let url = format!("{}/api/tail", base);
+        let url = format!("{base}/api/tail");
         reqwest::Client::new()
             .get(url)
             .query(&TailRequest {
@@ -17,7 +17,7 @@ pub async fn fetch_page(file_id: String, start_line: usize, max_lines: usize, ta
                 follow
             })
     } else {
-        let url = format!("{}/api/read-page", base);
+        let url = format!("{base}/api/read-page");
         reqwest::Client::new()
             .get(url)
             .query(&ReadPageRequest {
@@ -36,7 +36,7 @@ pub async fn fetch_page(file_id: String, start_line: usize, max_lines: usize, ta
 
 pub async fn apply_filter(file_id: String, filter: String) -> Result<String, ServerFnError> {
     let base = window().location().origin().unwrap();
-    let url = format!("{}/api/apply-filter", base);
+    let url = format!("{base}/api/apply-filter");
     let request = reqwest::Client::new()
         .post(url)
         .json(&ApplyFilterRequest {
@@ -53,7 +53,7 @@ pub async fn apply_filter(file_id: String, filter: String) -> Result<String, Ser
 
 pub async fn fetch_filter_page(file_id: String, start_line: usize, max_lines: usize) -> Result<PageResult, ServerFnError> {
     let base = window().location().origin().unwrap();
-    let url = format!("{}/api/read-filter-page", base);
+    let url = format!("{base}/api/read-filter-page");
     let request = reqwest::Client::new()
         .get(url)
         .query(&ReadFilterRequest {
@@ -74,7 +74,7 @@ pub async fn open_server_file(path: String) -> Result<String, String> {
         .location()
         .origin()
         .map_err(|_| "Could not detect application origin.".to_string())?;
-    let url = format!("{}/api/open-server-file", base);
+    let url = format!("{base}/api/open-server-file");
 
     let response = reqwest::Client::new()
         .post(url)
@@ -122,7 +122,7 @@ pub async fn upload_local_file(file: web_sys::File) -> Result<String, String> {
         .map_err(|_| "Could not detect application origin.".to_string())?;
 
     let fetch_promise = window().fetch_with_str_and_init(
-        &format!("{}/api/upload-file", base),
+        &format!("{base}/api/upload-file"),
         &request_init,
     );
 

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -142,7 +142,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         };
         set_wheel_lines.set(lines_to_jump * signum);
 
-        if let None = debounce.get() {
+        if debounce.get().is_none() {
             if let Some(page_result) = page_result.get() {
                 let handle = set_timeout_with_handle(
                     move || {
@@ -151,7 +151,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                             log!("Scrolling up {} lines", delta_lines);
                             page_result
                                 .start_line
-                                .saturating_sub(delta_lines.abs() as usize)
+                                .saturating_sub(delta_lines.unsigned_abs() as usize)
                         } else {
                             log!("Scrolling down {} lines", delta_lines);
                             page_result

--- a/logmancer-web/src/components/content_scroll.rs
+++ b/logmancer-web/src/components/content_scroll.rs
@@ -51,7 +51,7 @@ pub fn ContentScroll(context: LogViewContext) -> impl IntoView {
 
             if let Some(page_result) = page_result.get() {
                 log!("Scroll detected: {}", scroll.scroll_top());
-                if None == scroll_debounce.get() {
+                if scroll_debounce.get().is_none() {
                     let timeout_handle = set_timeout_with_handle(
                         move || {
                             let ratio = page_result.total_lines as f64 * scroll.scroll_top() as f64 / scroll.scroll_height() as f64;
@@ -103,7 +103,7 @@ pub fn ContentScroll(context: LogViewContext) -> impl IntoView {
     
     Effect::new(move || {
         if let Some(page_result) = page_result.get() {
-            if page_result.indexing_progress < 1.0 && None == index_debounce.get() {
+            if page_result.indexing_progress < 1.0 && index_debounce.get().is_none() {
                 let handle = set_timeout_with_handle(
                     move || {
                         set_start_line.notify();

--- a/logmancer-web/src/components/home.rs
+++ b/logmancer-web/src/components/home.rs
@@ -26,7 +26,7 @@ pub fn Home() -> impl IntoView {
         spawn_local(async move {
             match upload_local_file(file).await {
                 Ok(file_id) => {
-                    navigate(&format!("/log/{}", file_id), Default::default());
+                    navigate(&format!("/log/{file_id}"), Default::default());
                 }
                 Err(err) => {
                     log!("Error uploading file: {}", err);
@@ -53,7 +53,7 @@ pub fn Home() -> impl IntoView {
         spawn_local(async move {
             match open_server_file(trimmed_path).await {
                 Ok(file_id) => {
-                    navigate(&format!("/log/{}", file_id), Default::default());
+                    navigate(&format!("/log/{file_id}"), Default::default());
                 }
                 Err(err) => {
                     log!("Error opening server file: {}", err);

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -94,9 +94,7 @@ pub fn try_open_initial_file(
 ) -> Option<String> {
     use tracing::{error, info, warn};
 
-    let Some(path) = initial_path.map(str::trim).filter(|path| !path.is_empty()) else {
-        return None;
-    };
+    let path = initial_path.map(str::trim).filter(|path| !path.is_empty())?;
 
     info!("Attempting to open initial file path={}", path);
     match registry.open_file(path) {

--- a/logmancer-web/src/main.rs
+++ b/logmancer-web/src/main.rs
@@ -19,8 +19,8 @@ async fn main() {
         .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
     let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
     let startup_url = match initial_file_id.as_deref() {
-        Some(file_id) => format!("http://{}/log/{}", addr, file_id),
-        None => format!("http://{}", addr),
+        Some(file_id) => format!("http://{addr}/log/{file_id}"),
+        None => format!("http://{addr}"),
     };
 
     info!(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy"]


### PR DESCRIPTION
## Summary
- Ensures release binaries and packaged web assets agree on the Leptos WASM output name.
- Streams uploaded log files to temp storage instead of buffering the whole upload in memory.
- Raises the multipart body limit so multi-megabyte log uploads do not abort during parsing.

## Changes
| File | Change |
|------|--------|
| `.cargo/config.toml` | Sets `LEPTOS_OUTPUT_NAME=logmancer-web` for local Cargo compilation. |
| `.github/workflows/rust.yml` | Sets `LEPTOS_OUTPUT_NAME` for the full CI build, not only `cargo leptos build`. |
| `logmancer-web/build.rs` | Removes the incomplete crate-local env workaround. |
| `logmancer-web/src/api/config.rs` | Adds a 512 MiB body limit for upload-capable API routes. |
| `logmancer-web/src/api/upload_file.rs` | Streams multipart chunks to a temp file and cleans up on upload errors. |

## Test Plan
- [x] Manually verified local upload works with `debug.2026-04-23.1.log.txt` (~3 MiB).
- [x] Inspected latest GitHub artifact and confirmed the prior release mismatch: JS defaulted to `_bg.wasm` while the package contained `logmancer-web.wasm`.
- [ ] Not run: build/test commands, per project instruction not to build after changes.

## Notes
- No linked issue: repository currently has no open issue for this regression and no PR template requiring one.
- Unrelated local files are intentionally excluded from this PR.