### PR TITLE
chore: bump development version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,7 +2930,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logmancer-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossbeam-channel",
  "dashmap",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "logmancer-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "logmancer-core",
  "logmancer-web",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "logmancer-tui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "logmancer-web"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "console_error_panic_hook",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A lightweight, cross-platform log viewer written in Rust. Designed for efficiency and speed, Logmancer reads directly from disk and handles very large log files with ease.
 
-Current version: `0.1.0`.
+Current development version: `0.2.0`.
 
 ---
 

--- a/logmancer-core/Cargo.toml
+++ b/logmancer-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logmancer-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/logmancer-desktop/Cargo.toml
+++ b/logmancer-desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logmancer-desktop"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/logmancer-desktop/tauri.conf.json
+++ b/logmancer-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "tauri-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.tauri-app.app",
   "build": {
     "beforeDevCommand": "cargo leptos watch --project logmancer-web",

--- a/logmancer-tui/Cargo.toml
+++ b/logmancer-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logmancer-tui"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/logmancer-web/Cargo.toml
+++ b/logmancer-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logmancer-web"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
## Summary
- Bump workspace package versions to `0.2.0` after the `v0.1.0` release.
- Update the Tauri app version to `0.2.0`.
- Mark the README as the current development version.

## Notes
This maintenance PR intentionally does not link an issue.

## Test Plan
- [x] Version-only change; no runtime tests required.