### PR TITLE
feat(web): highlight selected viewer lines

### DIFF
--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -32,6 +32,8 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         page_size,
         set_page_size,
         log_page,
+        selected_line,
+        set_selected_line,
         ..
     } = context;
 
@@ -206,15 +208,18 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                     } else {
                         update_tail(page_result.start_line);
                     }
-                    let (line_numbers, line_texts): (Vec<_>, Vec<_>) = page_result
-                        .lines
-                        .into_iter()
-                        .map(|line| (line.number, line.text))
-                        .unzip();
+                    let lines = page_result.lines;
                     view! {
                         <div class="line-numbers">
-                            { line_numbers.into_iter().map(|line_number| view! {
-                                <div><b>{line_number}</b></div>
+                            { lines.iter().map(|line| {
+                                let line_number = line.number;
+                                view! {
+                                    <div
+                                        on:click=move |_| set_selected_line.set(Some(line_number))
+                                    >
+                                        <b>{line_number}</b>
+                                    </div>
+                                }
                             }).collect::<Vec<_>>() }
                         </div>
                         <div
@@ -223,8 +228,17 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                             on:keydown=on_key_down on:keyup=on_key_up
                             on:wheel=on_wheel
                         >
-                            { line_texts.into_iter().map(|line_text| view! {
-                                <div>{line_text}</div>
+                            { lines.into_iter().map(|line| {
+                                let line_number = line.number;
+                                let line_text = line.text;
+                                view! {
+                                    <div
+                                        class:selected=move || selected_line.get() == Some(line_number)
+                                        on:click=move |_| set_selected_line.set(Some(line_number))
+                                    >
+                                        {line_text}
+                                    </div>
+                                }
                             }).collect::<Vec<_>>() }
                         </div>
                     }

--- a/logmancer-web/src/components/context.rs
+++ b/logmancer-web/src/components/context.rs
@@ -21,4 +21,6 @@ pub struct LogViewContext {
     pub log_page: LocalResource<Result<PageResult,ServerFnError>>,
     pub indexing_progress: ReadSignal<f64>,
     pub set_indexing_progress: WriteSignal<f64>,
+    pub selected_line: ReadSignal<Option<usize>>,
+    pub set_selected_line: WriteSignal<Option<usize>>,
 }

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -26,6 +26,7 @@ pub fn FilterPane() -> impl IntoView {
     let (filter_text, set_filter_text) = signal(String::new());
     let (filter_applied, set_filter_applied) = signal(false);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
+    let (selected_line, set_selected_line) = signal(None::<usize>);
     
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
@@ -52,6 +53,8 @@ pub fn FilterPane() -> impl IntoView {
         log_page: filter_page,
         indexing_progress,
         set_indexing_progress,
+        selected_line,
+        set_selected_line,
     };
 
     let on_input = move |ev: leptos::ev::Event| {

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -28,6 +28,7 @@ pub fn MainPane() -> impl IntoView {
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
+    let (selected_line, set_selected_line) = signal(None::<usize>);
     
     let log_page = LocalResource::new(move ||
         fetch_page(file_id.get(), start_line.get(), page_size.get(), tail.get(), follow.get()));
@@ -39,6 +40,8 @@ pub fn MainPane() -> impl IntoView {
         log_page,
         indexing_progress,
         set_indexing_progress,
+        selected_line,
+        set_selected_line,
     };
 
     Effect::new(move || {

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -193,7 +193,13 @@ body {
 .line-numbers div,
 .text-lines div {
   height: 15px;
+  cursor: default;
   //line-height: 20px;
+}
+
+.text-lines div.selected {
+  background: #dbeafe;
+  box-shadow: inset 0 0 0 1px #93c5fd;
 }
 
 .scrollbar {


### PR DESCRIPTION
Closes #15

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds independent selected-line state for the main viewer and filter panel.
- Highlights the selected text row consistently across web and desktop through the shared web UI.
- Keeps filter-to-main synchronization out of scope for #16.

## Changes
| File | Change |
|------|--------|
| `logmancer-web/src/components/context.rs` | Adds selected-line signals to the log view context. |
| `logmancer-web/src/components/main_pane.rs` | Creates independent main viewer selection state. |
| `logmancer-web/src/components/filter_pane.rs` | Creates independent filter panel selection state. |
| `logmancer-web/src/components/content_lines.rs` | Sets selection on line click and applies selected styling to text rows. |
| `logmancer-web/style/main.scss` | Adds default cursor behavior and selected-row text highlight styling. |

## Test Plan
- [x] Manually tested with `cargo leptos watch --project logmancer-web`
- [x] Verified selected lines are visually distinguishable in the main viewer
- [x] Verified selected lines are visually distinguishable in the filter panel
- [x] Verified filter-to-main synchronization was not added
- [x] Shellcheck not applicable; no shell scripts changed

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts, or marked not applicable
- [x] Docs updated if behavior changed, or not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers