### PR TITLE
feat(web): sync filter selection with main viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ### Added
 
 - Project roadmap in `ROADMAP.md`.
+- Selected line highlighting in the web/desktop main viewer and filter panel (#15).
+- Filter result selection now synchronizes with the main viewer, selecting and revealing the matching original log line (#16).
 
 ## [0.1.0] - 2026-05-05
 

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -34,8 +34,15 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         log_page,
         selected_line,
         set_selected_line,
+        selection_source,
+        set_selected_line_source,
         ..
     } = context;
+
+    let select_line = move |line_number| {
+        set_selected_line_source.set(selection_source);
+        set_selected_line.set(Some(line_number));
+    };
 
     let div_ref: NodeRef<html::Div> = NodeRef::new();
     let (max_width, set_max_width) = signal(0);
@@ -215,7 +222,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                                 let line_number = line.number;
                                 view! {
                                     <div
-                                        on:click=move |_| set_selected_line.set(Some(line_number))
+                                        on:click=move |_| select_line(line_number)
                                     >
                                         <b>{line_number}</b>
                                     </div>
@@ -234,7 +241,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                                 view! {
                                     <div
                                         class:selected=move || selected_line.get() == Some(line_number)
-                                        on:click=move |_| set_selected_line.set(Some(line_number))
+                                        on:click=move |_| select_line(line_number)
                                     >
                                         {line_text}
                                     </div>

--- a/logmancer-web/src/components/context.rs
+++ b/logmancer-web/src/components/context.rs
@@ -14,6 +14,20 @@ pub struct LogFileContext {
 }
 
 #[derive(Clone)]
+pub struct SelectionContext {
+    pub selected_original_line: ReadSignal<Option<usize>>,
+    pub set_selected_original_line: WriteSignal<Option<usize>>,
+    pub selected_line_source: ReadSignal<SelectionSource>,
+    pub set_selected_line_source: WriteSignal<SelectionSource>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SelectionSource {
+    Main,
+    Filter,
+}
+
+#[derive(Clone)]
 pub struct LogViewContext {
     pub set_start_line: WriteSignal<usize>,
     pub page_size: ReadSignal<usize>,
@@ -23,4 +37,6 @@ pub struct LogViewContext {
     pub set_indexing_progress: WriteSignal<f64>,
     pub selected_line: ReadSignal<Option<usize>>,
     pub set_selected_line: WriteSignal<Option<usize>>,
+    pub selection_source: SelectionSource,
+    pub set_selected_line_source: WriteSignal<SelectionSource>,
 }

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -1,7 +1,7 @@
 use crate::components::async_functions::{apply_filter as apply_filter_fetch, fetch_filter_page};
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
-use crate::components::context::{LogFileContext, LogViewContext};
+use crate::components::context::{LogFileContext, LogViewContext, SelectionContext, SelectionSource};
 use crate::components::pane_index_progress::PaneIndexProgress;
 use leptos::context::use_context;
 use leptos::ev::KeyboardEvent;
@@ -26,7 +26,12 @@ pub fn FilterPane() -> impl IntoView {
     let (filter_text, set_filter_text) = signal(String::new());
     let (filter_applied, set_filter_applied) = signal(false);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
-    let (selected_line, set_selected_line) = signal(None::<usize>);
+    let SelectionContext {
+        selected_original_line,
+        set_selected_original_line,
+        set_selected_line_source,
+        ..
+    } = use_context().expect("SelectionContext not found");
     
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
@@ -53,8 +58,10 @@ pub fn FilterPane() -> impl IntoView {
         log_page: filter_page,
         indexing_progress,
         set_indexing_progress,
-        selected_line,
-        set_selected_line,
+        selected_line: selected_original_line,
+        set_selected_line: set_selected_original_line,
+        selection_source: SelectionSource::Filter,
+        set_selected_line_source,
     };
 
     let on_input = move |ev: leptos::ev::Event| {

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -1,4 +1,4 @@
-use crate::components::context::LogFileContext;
+use crate::components::context::{LogFileContext, SelectionContext, SelectionSource};
 use crate::components::filter_pane::FilterPane;
 use crate::components::main_pane::MainPane;
 use leptos::html;
@@ -11,6 +11,8 @@ pub fn LogView() -> impl IntoView {
     let file_id = Memo::new(move |_| use_params_map().get().get("id").unwrap_or_default());
     let (follow, set_follow) = signal(false);
     let (tail, set_tail) = signal(false);
+    let (selected_original_line, set_selected_original_line) = signal(None::<usize>);
+    let (selected_line_source, set_selected_line_source) = signal(SelectionSource::Main);
     let (filter_height_percent, set_filter_height_percent) = signal(30.0_f64);
     let (is_resizing, set_is_resizing) = signal(false);
     let log_view_ref: NodeRef<html::Div> = NodeRef::new();
@@ -42,6 +44,13 @@ pub fn LogView() -> impl IntoView {
         set_tail,
         follow,
         set_follow,
+    });
+
+    provide_context(SelectionContext {
+        selected_original_line,
+        set_selected_original_line,
+        selected_line_source,
+        set_selected_line_source,
     });
 
     view! {

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -1,7 +1,7 @@
 use crate::components::async_functions::fetch_page;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
-use crate::components::context::{LogFileContext, LogViewContext};
+use crate::components::context::{LogFileContext, LogViewContext, SelectionContext, SelectionSource};
 use crate::components::pane_index_progress::PaneIndexProgress;
 use leptos::context::use_context;
 use leptos::html::Div;
@@ -12,14 +12,33 @@ use leptos_use::use_resize_observer;
 
 const LINE_HEIGHT: f64 = 15.0;
 
+fn reveal_start_line_for_selected_line(selected_original_line: usize, page_size: usize) -> usize {
+    if selected_original_line == 0 {
+        return 0;
+    }
+
+    let selected_zero_based = selected_original_line.saturating_sub(1);
+    let center_offset = page_size / 2;
+    selected_zero_based.saturating_sub(center_offset)
+}
+
 #[component]
 pub fn MainPane() -> impl IntoView {
     let LogFileContext {
         file_id,
         tail,
+        set_tail,
         follow,
+        set_follow,
         ..
     } = use_context().expect("");
+
+    let SelectionContext {
+        selected_original_line,
+        set_selected_original_line,
+        selected_line_source,
+        set_selected_line_source,
+    } = use_context().expect("SelectionContext not found");
 
     let div_ref = NodeRef::<Div>::new();    
     let (content_width, set_content_width) = signal(2048_f64);
@@ -28,8 +47,6 @@ pub fn MainPane() -> impl IntoView {
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
-    let (selected_line, set_selected_line) = signal(None::<usize>);
-    
     let log_page = LocalResource::new(move ||
         fetch_page(file_id.get(), start_line.get(), page_size.get(), tail.get(), follow.get()));
     
@@ -40,9 +57,24 @@ pub fn MainPane() -> impl IntoView {
         log_page,
         indexing_progress,
         set_indexing_progress,
-        selected_line,
-        set_selected_line,
+        selected_line: selected_original_line,
+        set_selected_line: set_selected_original_line,
+        selection_source: SelectionSource::Main,
+        set_selected_line_source,
     };
+
+    Effect::new(move || {
+        if selected_line_source.get() != SelectionSource::Filter {
+            return;
+        }
+
+        if let Some(line_number) = selected_original_line.get() {
+            let reveal_start_line = reveal_start_line_for_selected_line(line_number, page_size.get());
+            set_tail.set(false);
+            set_follow.set(false);
+            set_start_line.set(reveal_start_line);
+        }
+    });
 
     Effect::new(move || {
         use_resize_observer(div_ref, move |entries, _observer| {
@@ -76,5 +108,26 @@ pub fn MainPane() -> impl IntoView {
                 <ContentScroll context=log_view_context.clone() />
             </div>
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::reveal_start_line_for_selected_line;
+
+    #[test]
+    fn reveal_line_at_top_clamps_to_zero() {
+        assert_eq!(reveal_start_line_for_selected_line(1, 50), 0);
+    }
+
+    #[test]
+    fn reveal_center_for_middle_line() {
+        assert_eq!(reveal_start_line_for_selected_line(101, 50), 75);
+    }
+
+    #[test]
+    fn reveal_handles_even_page_size_off_by_one() {
+        assert_eq!(reveal_start_line_for_selected_line(26, 50), 0);
+        assert_eq!(reveal_start_line_for_selected_line(27, 50), 1);
     }
 }


### PR DESCRIPTION
Closes #16

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Shares selected line state between the main viewer and filter panel.
- Reveals the matching original log line in the main viewer when selecting a filter result.
- Updates the changelog for issues #15 and #16.

## Changes

| File | Change |
|------|--------|
| `CHANGELOG.md` | Documents selected-line highlighting and filter selection sync in Unreleased. |
| `logmancer-web/src/components/context.rs` | Adds shared selection context and selection source tracking. |
| `logmancer-web/src/components/log_view.rs` | Provides shared selection state to both viewer panes. |
| `logmancer-web/src/components/filter_pane.rs` | Uses shared selection state and marks selections as filter-originated. |
| `logmancer-web/src/components/main_pane.rs` | Reveals filter-originated selections and keeps main-originated selections from changing scroll. |
| `logmancer-web/src/components/content_lines.rs` | Records selection source before updating the selected line. |

## Test Plan

- [x] `cargo test -p logmancer-web components::main_pane::tests`
- [x] Manually tested: selecting filter results reveals the original line in the main viewer.
- [x] Manually tested: selecting lines in the main viewer only changes highlight and does not change `start_line`.
- [x] No shell scripts changed; shellcheck not applicable.

## Contributor Checklist

- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran shellcheck on modified scripts, or marked not applicable.
- [x] Docs updated if behavior changed.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.