### PR TITLE
ci: make build cache non-blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,13 +71,14 @@ jobs:
         with:
           targets: ${{ matrix.target }},wasm32-unknown-unknown
 
-      - name: Install cargo-leptos
-        run: cargo install cargo-leptos --locked
-
       - name: Cache Rust dependencies
+        continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: build-${{ runner.os }}-${{ matrix.package_suffix }}
+
+      - name: Install cargo-leptos
+        run: cargo install cargo-leptos --locked
 
       - name: Build release binaries
         run: cargo build --release --target ${{ matrix.target }}


### PR DESCRIPTION
Closes #31

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Move Rust cache restore before installing cargo-leptos.
- Make the Rust cache step non-blocking so cache restore issues do not skip build/package steps.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/build.yml` | Restores cache before cargo-leptos install and adds `continue-on-error` to the cache step. |

## Test Plan
- [ ] GitHub Actions Build workflow passes on main
- [ ] windows-2025-vs2026 reaches build/package steps even if cache restore fails
- [x] No local build run; workflow-only change

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Ran shellcheck on modified scripts / N/A, no shell scripts changed
- [x] Skills tested in at least one agent / N/A, no skills changed
- [x] Docs updated if behavior changed / N/A
- [x] Conventional commit format
- [x] No Co-Authored-By trailers