### PR TITLE
ci: use VS2026 Windows runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             package_suffix: x86_64-unknown-linux-gnu
-          - os: windows-2025
-            target: x86_64-pc-windows-msvc
-            package_suffix: x86_64-pc-windows-msvc-windows-2025
           - os: windows-2025-vs2026
             target: x86_64-pc-windows-msvc
             package_suffix: x86_64-pc-windows-msvc-windows-2025-vs2026

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,6 @@ jobs:
             cache_key: ubuntu-workspace
             test_command: cargo test --workspace --verbose
             clippy: true
-          - name: windows 2025 core
-            os: windows-2025
-            cache_key: windows-2025-core
-            test_command: cargo test -p logmancer-core --verbose
-            clippy: false
           - name: windows 2025 vs2026 core
             os: windows-2025-vs2026
             cache_key: windows-2025-vs2026-core


### PR DESCRIPTION
Closes #33

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Remove temporary `windows-2025` CI matrix entries after validating `windows-2025-vs2026`.
- Keep the Windows Rust target as `x86_64-pc-windows-msvc` while using the explicit VS2026 runner image.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/test.yml` | Removes the temporary Windows 2025 core test job. |
| `.github/workflows/build.yml` | Removes the temporary Windows 2025 package job. |

## Test Plan
- [x] Previous run passed with both `windows-2025` and `windows-2025-vs2026`
- [ ] GitHub Actions Test workflow passes with only `windows-2025-vs2026`
- [x] No local build run; workflow-only change

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one type:* label
- [x] Ran shellcheck on modified scripts / N/A, no shell scripts changed
- [x] Skills tested in at least one agent / N/A, no skills changed
- [x] Docs updated if behavior changed / N/A
- [x] Conventional commit format
- [x] No Co-Authored-By trailers