### PR TITLE
feat(web): indicate active log panel

### DIFF
--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -36,10 +36,12 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         set_selected_line,
         selection_source,
         set_selected_line_source,
+        set_active_pane,
         ..
     } = context;
 
     let select_line = move |line_number| {
+        set_active_pane.set(selection_source);
         set_selected_line_source.set(selection_source);
         set_selected_line.set(Some(line_number));
     };
@@ -102,6 +104,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
     };
 
     let on_key_down = move |ev: KeyboardEvent| {
+        set_active_pane.set(selection_source);
         let key = ev.key();
         if KEYS.contains(&key.as_str()) {
             if active_key.get() == Some(key.clone()) {
@@ -136,6 +139,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
     };
 
     let on_wheel = move |ev: WheelEvent| {
+        set_active_pane.set(selection_source);
         ev.prevent_default();
 
         let delta = ev.delta_y().abs();
@@ -232,6 +236,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                         <div
                             node_ref=div_ref
                             class="text-lines" tabindex="0"
+                            on:focus=move |_| set_active_pane.set(selection_source)
                             on:keydown=on_key_down on:keyup=on_key_up
                             on:wheel=on_wheel
                         >

--- a/logmancer-web/src/components/context.rs
+++ b/logmancer-web/src/components/context.rs
@@ -21,6 +21,12 @@ pub struct SelectionContext {
     pub set_selected_line_source: WriteSignal<SelectionSource>,
 }
 
+#[derive(Clone)]
+pub struct ActivePaneContext {
+    pub active_pane: ReadSignal<SelectionSource>,
+    pub set_active_pane: WriteSignal<SelectionSource>,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SelectionSource {
     Main,
@@ -39,4 +45,5 @@ pub struct LogViewContext {
     pub set_selected_line: WriteSignal<Option<usize>>,
     pub selection_source: SelectionSource,
     pub set_selected_line_source: WriteSignal<SelectionSource>,
+    pub set_active_pane: WriteSignal<SelectionSource>,
 }

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -1,7 +1,9 @@
 use crate::components::async_functions::{apply_filter as apply_filter_fetch, fetch_filter_page};
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
-use crate::components::context::{LogFileContext, LogViewContext, SelectionContext, SelectionSource};
+use crate::components::context::{
+    ActivePaneContext, LogFileContext, LogViewContext, SelectionContext, SelectionSource,
+};
 use crate::components::pane_index_progress::PaneIndexProgress;
 use leptos::context::use_context;
 use leptos::ev::KeyboardEvent;
@@ -32,6 +34,10 @@ pub fn FilterPane() -> impl IntoView {
         set_selected_line_source,
         ..
     } = use_context().expect("SelectionContext not found");
+    let ActivePaneContext {
+        active_pane,
+        set_active_pane,
+    } = use_context().expect("ActivePaneContext not found");
     
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
@@ -62,6 +68,7 @@ pub fn FilterPane() -> impl IntoView {
         set_selected_line: set_selected_original_line,
         selection_source: SelectionSource::Filter,
         set_selected_line_source,
+        set_active_pane,
     };
 
     let on_input = move |ev: leptos::ev::Event| {
@@ -70,6 +77,7 @@ pub fn FilterPane() -> impl IntoView {
     };
 
     let on_key_down = move |ev: KeyboardEvent| {
+        set_active_pane.set(SelectionSource::Filter);
         if ev.key() == "Enter" {
             let text = filter_text.get();
             if !text.is_empty() {
@@ -119,7 +127,10 @@ pub fn FilterPane() -> impl IntoView {
     });
     
     view! {
-        <div class="filter-pane">
+        <div
+            class="filter-pane"
+            class:active-pane=move || active_pane.get() == SelectionSource::Filter
+        >
             <div class="filter-input-container">
                 <input 
                     type="text" 
@@ -128,6 +139,7 @@ pub fn FilterPane() -> impl IntoView {
                     value=filter_text
                     on:input=on_input
                     on:keydown=on_key_down
+                    on:focus=move |_| set_active_pane.set(SelectionSource::Filter)
                 />
             </div>
             <PaneIndexProgress

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -1,4 +1,6 @@
-use crate::components::context::{LogFileContext, SelectionContext, SelectionSource};
+use crate::components::context::{
+    ActivePaneContext, LogFileContext, SelectionContext, SelectionSource,
+};
 use crate::components::filter_pane::FilterPane;
 use crate::components::main_pane::MainPane;
 use leptos::html;
@@ -13,6 +15,7 @@ pub fn LogView() -> impl IntoView {
     let (tail, set_tail) = signal(false);
     let (selected_original_line, set_selected_original_line) = signal(None::<usize>);
     let (selected_line_source, set_selected_line_source) = signal(SelectionSource::Main);
+    let (active_pane, set_active_pane) = signal(SelectionSource::Main);
     let (filter_height_percent, set_filter_height_percent) = signal(30.0_f64);
     let (is_resizing, set_is_resizing) = signal(false);
     let log_view_ref: NodeRef<html::Div> = NodeRef::new();
@@ -53,6 +56,11 @@ pub fn LogView() -> impl IntoView {
         set_selected_line_source,
     });
 
+    provide_context(ActivePaneContext {
+        active_pane,
+        set_active_pane,
+    });
+
     view! {
         <div
             node_ref=log_view_ref
@@ -68,7 +76,13 @@ pub fn LogView() -> impl IntoView {
             on:pointerleave=move |_| set_is_resizing.set(false)
         >
             <div
-                class="main-pane-container"
+                class=move || {
+                    if active_pane.get() == SelectionSource::Main {
+                        "main-pane-container pane-active"
+                    } else {
+                        "main-pane-container pane-inactive"
+                    }
+                }
                 style=move || {
                     let main_height_percent = 100.0 - filter_height_percent.get();
                     format!("flex: {main_height_percent} {main_height_percent} 0;")
@@ -78,7 +92,13 @@ pub fn LogView() -> impl IntoView {
             </div>
             <div class="divider" on:pointerdown=move |_| set_is_resizing.set(true)></div>
             <div
-                class="filter-pane-container"
+                class=move || {
+                    if active_pane.get() == SelectionSource::Filter {
+                        "filter-pane-container pane-active"
+                    } else {
+                        "filter-pane-container pane-inactive"
+                    }
+                }
                 style=move || {
                     let filter_height_percent = filter_height_percent.get();
                     format!("flex: {filter_height_percent} {filter_height_percent} 0;")

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -1,7 +1,9 @@
 use crate::components::async_functions::fetch_page;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
-use crate::components::context::{LogFileContext, LogViewContext, SelectionContext, SelectionSource};
+use crate::components::context::{
+    ActivePaneContext, LogFileContext, LogViewContext, SelectionContext, SelectionSource,
+};
 use crate::components::pane_index_progress::PaneIndexProgress;
 use leptos::context::use_context;
 use leptos::html::Div;
@@ -40,6 +42,11 @@ pub fn MainPane() -> impl IntoView {
         set_selected_line_source,
     } = use_context().expect("SelectionContext not found");
 
+    let ActivePaneContext {
+        active_pane,
+        set_active_pane,
+    } = use_context().expect("ActivePaneContext not found");
+
     let div_ref = NodeRef::<Div>::new();    
     let (content_width, set_content_width) = signal(2048_f64);
     let (content_height, set_content_height) = signal(1080_f64);
@@ -61,6 +68,7 @@ pub fn MainPane() -> impl IntoView {
         set_selected_line: set_selected_original_line,
         selection_source: SelectionSource::Main,
         set_selected_line_source,
+        set_active_pane,
     };
 
     Effect::new(move || {
@@ -97,7 +105,10 @@ pub fn MainPane() -> impl IntoView {
     });
     
     view! {
-        <div class="main-pane">
+        <div
+            class="main-pane"
+            class:active-pane=move || active_pane.get() == SelectionSource::Main
+        >
             <PaneIndexProgress
                 context=log_view_context.clone()
                 hidden=Signal::derive(move || indexing_progress.get() >= 1.0)

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -239,6 +239,8 @@ body {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
+  border: 1px solid transparent;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
 .divider {
@@ -264,6 +266,19 @@ body {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  border: 1px solid transparent;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+}
+
+.pane-active {
+  border-color: #3498db;
+  box-shadow: inset 0 0 0 1px rgba(52, 152, 219, 0.28);
+  background: rgba(219, 234, 254, 0.16);
+}
+
+.pane-inactive {
+  border-color: transparent;
+  box-shadow: none;
 }
 
 .filter-pane {
@@ -292,4 +307,14 @@ body {
   &:focus {
     border-color: #3498db;
   }
+}
+
+.pane-inactive .text-lines div.selected {
+  background: rgba(219, 234, 254, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(147, 197, 253, 0.55);
+}
+
+.pane-active .text-lines div.selected {
+  background: #dbeafe;
+  box-shadow: inset 0 0 0 1px #3498db;
 }


### PR DESCRIPTION
Closes #17

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds explicit active pane state so keyboard focus is visually separate from selected-line origin.
- Highlights the active main/filter panel and makes selected rows stronger only in the active pane.
- Wires focus, click, keyboard, and wheel interactions to keep active panel feedback current.

## Changes

| File | Change |
|------|--------|
| `logmancer-web/src/components/context.rs` | Adds active pane context and shares active pane setter with content views. |
| `logmancer-web/src/components/log_view.rs` | Provides active pane state and applies active/inactive pane classes. |
| `logmancer-web/src/components/main_pane.rs` | Connects main viewer content to active pane state. |
| `logmancer-web/src/components/filter_pane.rs` | Connects filter input and filter results to active pane state. |
| `logmancer-web/src/components/content_lines.rs` | Updates active pane on focus, line selection, keyboard, and wheel interactions. |
| `logmancer-web/style/main.scss` | Adds subtle active panel border/background and active/inactive selected-row styling. |

## Test Plan

- [x] `cargo check -p logmancer-web`
- [x] No shell scripts modified; shellcheck not applicable.
- [x] Verified this links an approved issue.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label: `type:feature`
- [x] Ran shellcheck on modified scripts, or confirmed no scripts changed
- [x] Docs updated if behavior changed, or not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers