### PR TITLE
feat(web): add auto-scroll indicator

### DIFF
--- a/logmancer-web/src/components/auto_scroll_status.rs
+++ b/logmancer-web/src/components/auto_scroll_status.rs
@@ -1,0 +1,15 @@
+use crate::components::context::LogFileContext;
+use leptos::context::use_context;
+use leptos::prelude::*;
+use leptos::{component, view, IntoView};
+
+#[component]
+pub fn AutoScrollStatus() -> impl IntoView {
+    let LogFileContext { follow, .. } = use_context().expect("LogFileContext not found");
+
+    view! {
+        <div class="auto-scroll-status">
+            {move || if follow.get() { "AUTO-SCROLL ON" } else { "AUTO-SCROLL OFF" }}
+        </div>
+    }
+}

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -51,17 +51,19 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
 
     let (wheel_lines, set_wheel_lines) = signal(0_i32);
     let (debounce, set_debounce) = signal(None::<TimeoutHandle>);
-    let (interval, set_interval) = signal(None::<IntervalHandle>);
-    let (active_key, set_active_key) = signal(None::<String>);
-
     let (page_result, set_page_result) = signal(None::<PageResult>);
+
+    let is_at_end = move |result: &PageResult| {
+        result.start_line.saturating_add(page_size.get()) >= result.total_lines
+    };
 
     let update_tail = move |new_line: usize| {
         set_tail.update_untracked(move |current| {
             let page_result = page_result.get().unwrap();
             if page_result.start_line > new_line {
                 log!("Updating tail to false");
-                *current = false
+                *current = false;
+                set_follow.set(false);
             } else if new_line.saturating_add(page_size.get()) >= page_result.total_lines {
                 log!("Updating tail to true");
                 *current = true
@@ -79,6 +81,11 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                 set_start_line.set(new_line);
             }
             ARROW_DOWN => {
+                if is_at_end(&page_result) {
+                    set_tail.set(true);
+                    set_follow.set(true);
+                    return;
+                }
                 let new_line = page_result.start_line.saturating_add(MIN_JUMP as usize);
                 update_tail(new_line);
                 set_start_line.set(new_line);
@@ -89,6 +96,11 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                 set_start_line.set(new_line);
             }
             PAGE_DOWN => {
+                if is_at_end(&page_result) {
+                    set_tail.set(true);
+                    set_follow.set(true);
+                    return;
+                }
                 let new_line = page_result.start_line.saturating_add(page_size.get());
                 update_tail(new_line);
                 set_start_line.set(new_line);
@@ -107,34 +119,15 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         set_active_pane.set(selection_source);
         let key = ev.key();
         if KEYS.contains(&key.as_str()) {
-            if active_key.get() == Some(key.clone()) {
-                return;
-            }
-            set_active_key.set(Some(key.clone()));
-
-            let result = set_interval_with_handle(
-                move || {
-                    if let Some(key) = active_key.get() {
-                        process_key(&key)
-                    }
-                },
-                Duration::from_millis(DEBOUNCE_MS),
-            );
-
-            if let Ok(handle) = result {
-                set_interval.set(Some(handle));
-            }
+            ev.prevent_default();
+            process_key(&key);
         }
     };
 
     let on_key_up = move |ev: KeyboardEvent| {
         let key = ev.key();
-        process_key(&key);
         if KEYS.contains(&key.as_str()) {
-            if let Some(handle) = interval.get() {
-                handle.clear();
-            }
-            set_active_key.set(None);
+            ev.prevent_default();
         }
     };
 
@@ -167,6 +160,12 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                                 .saturating_sub(delta_lines.unsigned_abs() as usize)
                         } else {
                             log!("Scrolling down {} lines", delta_lines);
+                            if is_at_end(&page_result) {
+                                set_tail.set(true);
+                                set_follow.set(true);
+                                set_debounce.set(None);
+                                return;
+                            }
                             page_result
                                 .start_line
                                 .saturating_add(delta_lines as usize)
@@ -176,7 +175,8 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                             log!("Updating start_line by wheel to: {}", new_line);
                             set_tail.update_untracked(move |current| {
                                 if page_result.start_line > new_line {
-                                    *current = false
+                                    *current = false;
+                                    set_follow.set(false);
                                 } else if new_line + page_size.get() > page_result.total_lines {
                                     *current = true
                                 }

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -1,4 +1,5 @@
 use crate::components::async_functions::{apply_filter as apply_filter_fetch, fetch_filter_page};
+use crate::components::auto_scroll_status::AutoScrollStatus;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
 use crate::components::context::{
@@ -16,12 +17,9 @@ const LINE_HEIGHT: f64 = 15.0;
 
 #[component]
 pub fn FilterPane() -> impl IntoView {
-    let LogFileContext {
-        file_id,
-        ..
-    } = use_context().expect("LogFileContext not found");
+    let LogFileContext { file_id, .. } = use_context().expect("LogFileContext not found");
 
-    let div_ref = NodeRef::<Div>::new();    
+    let div_ref = NodeRef::<Div>::new();
     let (content_width, set_content_width) = signal(2048_f64);
     let (content_height, set_content_height) = signal(1080_f64);
 
@@ -38,16 +36,16 @@ pub fn FilterPane() -> impl IntoView {
         active_pane,
         set_active_pane,
     } = use_context().expect("ActivePaneContext not found");
-    
+
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
-    
+
     let filter_page = LocalResource::new(move || {
         let file_id = file_id.get();
         let start = start_line.get();
         let size = page_size.get();
         let applied = filter_applied.get();
-        
+
         async move {
             if applied {
                 fetch_filter_page(file_id, start, size).await
@@ -56,7 +54,7 @@ pub fn FilterPane() -> impl IntoView {
             }
         }
     });
-    
+
     let log_view_context = LogViewContext {
         set_start_line,
         page_size,
@@ -83,7 +81,7 @@ pub fn FilterPane() -> impl IntoView {
             if !text.is_empty() {
                 let file_id = file_id.get();
                 let text_clone = text.clone();
-                
+
                 spawn_local(async move {
                     apply_filter_fetch(file_id, text_clone).await.ok();
                     set_filter_applied.set(true);
@@ -101,19 +99,19 @@ pub fn FilterPane() -> impl IntoView {
     Effect::new(move || {
         use leptos_use::use_resize_observer;
         use_resize_observer(div_ref, move |entries, _observer| {
-                let rect = entries[0].content_rect();
-                if content_width.get() != rect.width() {
-                    set_content_width.set(rect.width());
-                }
-                if content_height.get() != rect.height() {
-                    set_content_height.set(rect.height());
+            let rect = entries[0].content_rect();
+            if content_width.get() != rect.width() {
+                set_content_width.set(rect.width());
+            }
+            if content_height.get() != rect.height() {
+                set_content_height.set(rect.height());
 
-                    let lines = (rect.height() / LINE_HEIGHT) as usize;
-                    if lines != page_size.get() && lines > 0 {
-                        set_page_size.set(lines);
-                    }
+                let lines = (rect.height() / LINE_HEIGHT) as usize;
+                if lines != page_size.get() && lines > 0 {
+                    set_page_size.set(lines);
                 }
-            });
+            }
+        });
     });
 
     // Re-fetch when filter changes
@@ -122,18 +120,17 @@ pub fn FilterPane() -> impl IntoView {
         set_start_line.notify();
     });
 
-    let filter_progress_hidden = Signal::derive(move || {
-        !filter_applied.get() || indexing_progress.get() >= 1.0
-    });
-    
+    let filter_progress_hidden =
+        Signal::derive(move || !filter_applied.get() || indexing_progress.get() >= 1.0);
+
     view! {
         <div
             class="filter-pane"
             class:active-pane=move || active_pane.get() == SelectionSource::Filter
         >
             <div class="filter-input-container">
-                <input 
-                    type="text" 
+                <input
+                    type="text"
                     class="filter-input"
                     placeholder="Filter (press Enter)"
                     value=filter_text
@@ -151,6 +148,7 @@ pub fn FilterPane() -> impl IntoView {
                 <ContentLines context=log_view_context.clone() />
                 <ContentScroll context=log_view_context.clone() />
             </div>
+            <AutoScrollStatus />
         </div>
     }
 }

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -1,4 +1,5 @@
 use crate::components::async_functions::fetch_page;
+use crate::components::auto_scroll_status::AutoScrollStatus;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
 use crate::components::context::{
@@ -47,16 +48,23 @@ pub fn MainPane() -> impl IntoView {
         set_active_pane,
     } = use_context().expect("ActivePaneContext not found");
 
-    let div_ref = NodeRef::<Div>::new();    
+    let div_ref = NodeRef::<Div>::new();
     let (content_width, set_content_width) = signal(2048_f64);
     let (content_height, set_content_height) = signal(1080_f64);
 
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
-    let log_page = LocalResource::new(move ||
-        fetch_page(file_id.get(), start_line.get(), page_size.get(), tail.get(), follow.get()));
-    
+    let log_page = LocalResource::new(move || {
+        fetch_page(
+            file_id.get(),
+            start_line.get(),
+            page_size.get(),
+            tail.get(),
+            follow.get(),
+        )
+    });
+
     let log_view_context = LogViewContext {
         set_start_line,
         page_size,
@@ -77,7 +85,8 @@ pub fn MainPane() -> impl IntoView {
         }
 
         if let Some(line_number) = selected_original_line.get() {
-            let reveal_start_line = reveal_start_line_for_selected_line(line_number, page_size.get());
+            let reveal_start_line =
+                reveal_start_line_for_selected_line(line_number, page_size.get());
             set_tail.set(false);
             set_follow.set(false);
             set_start_line.set(reveal_start_line);
@@ -86,24 +95,24 @@ pub fn MainPane() -> impl IntoView {
 
     Effect::new(move || {
         use_resize_observer(div_ref, move |entries, _observer| {
-                let rect = entries[0].content_rect();
-                if content_width.get() != rect.width() {
-                    log!("Updating content width to {}", rect.width());
-                    set_content_width.set(rect.width());
-                }
-                if content_height.get() != rect.height() {
-                    log!("Updating content height to {}", rect.height());
-                    set_content_height.set(rect.height());
+            let rect = entries[0].content_rect();
+            if content_width.get() != rect.width() {
+                log!("Updating content width to {}", rect.width());
+                set_content_width.set(rect.width());
+            }
+            if content_height.get() != rect.height() {
+                log!("Updating content height to {}", rect.height());
+                set_content_height.set(rect.height());
 
-                    let lines = (rect.height() / LINE_HEIGHT) as usize;
-                    if lines != page_size.get() {
-                        log!("Updating page_size to {}", lines);
-                        set_page_size.set(lines);
-                    }
+                let lines = (rect.height() / LINE_HEIGHT) as usize;
+                if lines != page_size.get() {
+                    log!("Updating page_size to {}", lines);
+                    set_page_size.set(lines);
                 }
-            });
+            }
+        });
     });
-    
+
     view! {
         <div
             class="main-pane"
@@ -118,6 +127,7 @@ pub fn MainPane() -> impl IntoView {
                 <ContentLines context=log_view_context.clone() />
                 <ContentScroll context=log_view_context.clone() />
             </div>
+            <AutoScrollStatus />
         </div>
     }
 }

--- a/logmancer-web/src/components/mod.rs
+++ b/logmancer-web/src/components/mod.rs
@@ -1,17 +1,18 @@
-mod home;
-mod log_view;
-mod context;
-mod main_pane;
+mod app;
+mod async_functions;
+mod auto_scroll_status;
 mod content_lines;
 mod content_scroll;
-mod progress_bar;
-mod pane_index_progress;
-mod async_functions;
-mod app;
+mod context;
 mod filter_pane;
+mod home;
+mod log_view;
+mod main_pane;
+mod pane_index_progress;
+mod progress_bar;
 
-pub use context::Port;
 pub use app::App;
+pub use context::Port;
+pub use filter_pane::FilterPane;
 pub use home::Home;
 pub use log_view::LogView;
-pub use filter_pane::FilterPane;

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -156,6 +156,7 @@ body {
   overflow: hidden;
   font-family: monospace;
   display: flex;
+  flex-direction: column;
 }
 
 .content {
@@ -165,6 +166,8 @@ body {
   overflow-x: auto;
   overflow-y: hidden;
   position: relative;
+  flex: 1;
+  min-height: 0;
 }
 
 .line-numbers {
@@ -286,6 +289,19 @@ body {
   display: flex;
   flex-direction: column;
   font-family: monospace;
+}
+
+.auto-scroll-status {
+  border-top: 1px solid #ddd;
+  background: #f8f8f8;
+  color: #555;
+  font-size: 11px;
+  line-height: 1;
+  padding: 2px 6px;
+  min-height: 15px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .filter-input-container {


### PR DESCRIPTION
Closes #18

## PR Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a compact `AUTO-SCROLL ON/OFF` status row to both main and filter log panels.
- Activates auto-scroll when the user attempts to scroll down while already at the end.
- Keeps the indicator outside log content so it does not interfere with viewing or filtering.

## Changes
| File | Change |
|------|--------|
| `logmancer-web/src/components/auto_scroll_status.rs` | Adds reusable auto-scroll status component. |
| `logmancer-web/src/components/main_pane.rs` | Renders the status row in the main panel. |
| `logmancer-web/src/components/filter_pane.rs` | Renders the status row in the filter panel. |
| `logmancer-web/src/components/content_lines.rs` | Updates follow/tail behavior for scroll-down-at-end and scroll-up indicator sync. |
| `logmancer-web/src/components/mod.rs` | Wires the new component module. |
| `logmancer-web/style/main.scss` | Adds compact status row layout and pane flex stacking. |

## Test Plan
- [x] Ran `cargo fmt`
- [x] Ran `cargo test -p logmancer-web main_pane::tests`
- [ ] Manually tested the affected functionality in browser/desktop

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / not applicable: no scripts modified
- [x] Skills tested in at least one agent / not applicable
- [x] Docs updated if behavior changed / not applicable
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers