### PR TITLE
feat(web): add server file browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,6 +2979,7 @@ dependencies = [
  "logmancer-core",
  "reqwest 0.12.28",
  "serde",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/docs/adr/0001-server-file-browser-root-scoped.md
+++ b/docs/adr/0001-server-file-browser-root-scoped.md
@@ -1,0 +1,43 @@
+# ADR 0001: Root-scoped server file browser
+
+## Status
+
+Accepted
+
+## Decision
+
+Server-side browsing is an explicit, root-scoped capability enabled by `LOGMANCER_SERVER_FILE_ROOT`.
+
+The browser lists and opens files only under that configured root. The UI uses a Spotlight-style modal, but filtering stays local to the currently loaded directory.
+
+## Context
+
+Logmancer Web needs a safer way to open server-side log files without requiring users to know exact paths. At the same time, exposing server files from a web process is sensitive: the feature must avoid arbitrary filesystem access and must not leak internal server paths through the UI or errors.
+
+## Decisions
+
+| Area | Decision |
+|---|---|
+| Enablement | Require `LOGMANCER_SERVER_FILE_ROOT`; if it is missing/invalid, server browsing is unavailable. |
+| Scope | Browse and open only paths that resolve under the configured root. |
+| Path validation | Canonicalize the configured root and each requested path before access. |
+| Symlinks | Reject symlinks that resolve outside the configured root. |
+| Search | Filter only the current directory entries; do not add recursive/global search. |
+| File opening | Re-validate the selected file and confirm it is text-readable before opening it. |
+| Errors | Return safe messages that avoid leaking absolute server paths or implementation details. |
+
+## Consequences
+
+- Deployments must opt in by setting `LOGMANCER_SERVER_FILE_ROOT`.
+- Users can navigate logs without typing full server paths.
+- Backend validation remains the source of truth; frontend state is only a convenience.
+- Recursive search can be considered later as a separate feature with its own security and performance review.
+
+## Verification checklist
+
+- [ ] Missing/invalid `LOGMANCER_SERVER_FILE_ROOT` keeps server browsing unavailable.
+- [ ] Valid `LOGMANCER_SERVER_FILE_ROOT` enables browsing from that root.
+- [ ] Traversal and absolute-path escape attempts are rejected.
+- [ ] Symlinks cannot escape the configured root.
+- [ ] Filtering does not search outside the current directory listing.
+- [ ] Opening a file revalidates scope and text-readability.

--- a/docs/adr/0001-server-file-browser-root-scoped.md
+++ b/docs/adr/0001-server-file-browser-root-scoped.md
@@ -24,6 +24,7 @@ Logmancer Web needs a safer way to open server-side log files without requiring 
 | Symlinks | Reject symlinks that resolve outside the configured root. |
 | Search | Filter only the current directory entries; do not add recursive/global search. |
 | File opening | Re-validate the selected file and confirm it is text-readable before opening it. |
+| Path display | The modal may display the current server path as read-only context; requests still use scoped relative tokens. |
 | Errors | Return safe messages that avoid leaking absolute server paths or implementation details. |
 
 ## Consequences

--- a/docs/feature/server-file-browser.md
+++ b/docs/feature/server-file-browser.md
@@ -39,7 +39,7 @@ Server browsing is exposed through `Explore Server` in both states.
 ## Spotlight behavior
 
 - Starts at configured root.
-- Shows current path as read-only.
+- Shows current server path as read-only.
 - Lists only current directory entries.
 - Sorts folders first, then alphabetical.
 - Supports enter folder, go up, single-select file, Enter/double-click/Open Selected.
@@ -51,7 +51,7 @@ Server browsing is exposed through `Explore Server` in both states.
 - All list/open requests are validated against configured root.
 - Traversal (`..`), absolute-path escape, and symlink-outside-root are rejected.
 - Open re-validates path and checks text-readability before opening.
-- Errors are safe (no internal absolute path leakage).
+- Errors are safe and do not include internal absolute paths.
 
 ## Review checklist
 

--- a/docs/feature/server-file-browser.md
+++ b/docs/feature/server-file-browser.md
@@ -1,0 +1,62 @@
+# Server File Browser
+
+## Quick answer
+
+`Explore Server` is now **config-driven and root-scoped**:
+
+- Set `LOGMANCER_SERVER_FILE_ROOT` to enable server browsing.
+- If missing or invalid, Home keeps `Explore Server` disabled with a safe explanation.
+- Manual server path entry is not part of the server browser experience.
+- Spotlight filter is **local to the current directory only** (no recursive/global search).
+
+## Configuration
+
+### Enable server browsing
+
+```bash
+LOGMANCER_SERVER_FILE_ROOT=/path/to/logs
+```
+
+The path must resolve to a readable directory for the running Logmancer process.
+
+### Disabled behavior
+
+If `LOGMANCER_SERVER_FILE_ROOT` is missing, invalid, or unreadable:
+
+- backend reports browser as unavailable,
+- Home renders `Explore Server` disabled,
+- UI shows a safe message explaining that server browsing requires configuration.
+
+## Home behavior (source of truth)
+
+| State | Home UI |
+|---|---|
+| Root configured + valid | `Explore Server` enabled |
+| Root missing/invalid | `Explore Server` disabled with safe message |
+
+Server browsing is exposed through `Explore Server` in both states.
+
+## Spotlight behavior
+
+- Starts at configured root.
+- Shows current path as read-only.
+- Lists only current directory entries.
+- Sorts folders first, then alphabetical.
+- Supports enter folder, go up, single-select file, Enter/double-click/Open Selected.
+- Filter applies only to currently loaded entries.
+
+## Security and scope
+
+- Read-only operations only.
+- All list/open requests are validated against configured root.
+- Traversal (`..`), absolute-path escape, and symlink-outside-root are rejected.
+- Open re-validates path and checks text-readability before opening.
+- Errors are safe (no internal absolute path leakage).
+
+## Review checklist
+
+- [ ] `LOGMANCER_SERVER_FILE_ROOT` valid → Explore Server enabled.
+- [ ] `LOGMANCER_SERVER_FILE_ROOT` missing/invalid → Explore Server disabled + safe explanation.
+- [ ] Server browsing is exposed through `Explore Server` only.
+- [ ] Filtering does not search recursively.
+- [ ] Open still routes to `/log/:id` only for valid text-readable files inside root.

--- a/logmancer-web/Cargo.toml
+++ b/logmancer-web/Cargo.toml
@@ -46,6 +46,9 @@ ssr = [
 ]
 external-server = []
 
+[dev-dependencies]
+tempfile = "3"
+
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name
 output-name = "logmancer-web"

--- a/logmancer-web/src/api/commons.rs
+++ b/logmancer-web/src/api/commons.rs
@@ -11,6 +11,44 @@ pub struct OpenServerFileResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct ApiError {
+    pub code: String,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ServerBrowserStatusResponse {
+    pub enabled: bool,
+    pub message: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ServerBrowserListRequest {
+    pub path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ServerBrowserListResponse {
+    pub current_path: String,
+    pub can_go_up: bool,
+    pub entries: Vec<ServerBrowserEntry>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ServerBrowserEntry {
+    pub name: String,
+    pub path: String,
+    pub entry_type: String,
+    pub size: Option<u64>,
+    pub modified: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ServerBrowserOpenRequest {
+    pub path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct FileInfoRequest {
     pub file_id: String,
 }

--- a/logmancer-web/src/api/commons.rs
+++ b/logmancer-web/src/api/commons.rs
@@ -34,7 +34,7 @@ pub struct ServerBrowserListResponse {
     pub entries: Vec<ServerBrowserEntry>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ServerBrowserEntry {
     pub name: String,
     pub path: String,

--- a/logmancer-web/src/api/commons.rs
+++ b/logmancer-web/src/api/commons.rs
@@ -30,6 +30,7 @@ pub struct ServerBrowserListRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ServerBrowserListResponse {
     pub current_path: String,
+    pub current_display_path: String,
     pub can_go_up: bool,
     pub entries: Vec<ServerBrowserEntry>,
 }

--- a/logmancer-web/src/api/config.rs
+++ b/logmancer-web/src/api/config.rs
@@ -1,7 +1,9 @@
 use crate::api::file_info::file_info;
 use crate::api::filter::{apply_filter, read_filter_page};
-use crate::api::open_server_file::open_server_file;
 use crate::api::read_page::{read_page, tail};
+use crate::api::server_browser::{
+    server_browser_list, server_browser_open, server_browser_status, ServerFileRoot,
+};
 use crate::api::upload_file::upload_file;
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
@@ -14,11 +16,16 @@ const LOG_UPLOAD_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 #[derive(Clone)]
 pub struct AppState {
     pub registry: Arc<LogRegistry>,
+    pub server_file_root: Option<ServerFileRoot>,
 }
 
 pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
+    let server_file_root = ServerFileRoot::from_env();
+
     Router::new()
-        .route("/open-server-file", post(open_server_file))
+        .route("/server-browser/status", get(server_browser_status))
+        .route("/server-browser/list", post(server_browser_list))
+        .route("/server-browser/open", post(server_browser_open))
         .route("/upload-file", post(upload_file))
         .route("/read-page", get(read_page))
         .route("/file_info", get(file_info))
@@ -26,7 +33,10 @@ pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
         .route("/apply-filter", post(apply_filter))
         .route("/read-filter-page", get(read_filter_page))
         .layer(DefaultBodyLimit::max(LOG_UPLOAD_BODY_LIMIT_BYTES))
-        .with_state(AppState { registry })
+        .with_state(AppState {
+            registry,
+            server_file_root,
+        })
 }
 
 pub fn api_routes<T>() -> Router<T> {

--- a/logmancer-web/src/api/mod.rs
+++ b/logmancer-web/src/api/mod.rs
@@ -4,9 +4,6 @@ pub mod commons;
 pub mod config;
 
 #[cfg(feature = "ssr")]
-pub mod open_server_file;
-
-#[cfg(feature = "ssr")]
 pub mod file_info;
 
 #[cfg(feature = "ssr")]
@@ -17,3 +14,6 @@ pub mod filter;
 
 #[cfg(feature = "ssr")]
 pub mod upload_file;
+
+#[cfg(feature = "ssr")]
+pub mod server_browser;

--- a/logmancer-web/src/api/server_browser.rs
+++ b/logmancer-web/src/api/server_browser.rs
@@ -7,6 +7,7 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
@@ -259,18 +260,21 @@ fn resolve_root_bound_path(
 }
 
 fn is_text_readable(path: &Path) -> bool {
-    let bytes = match std::fs::read(path) {
-        Ok(bytes) => bytes,
+    let mut file = match std::fs::File::open(path) {
+        Ok(file) => file,
         Err(_) => return false,
     };
 
-    let probe_len = bytes.len().min(8192);
-    let probe = &bytes[..probe_len];
+    let mut probe = Vec::with_capacity(8192);
+    if file.by_ref().take(8192).read_to_end(&mut probe).is_err() {
+        return false;
+    }
+
     if probe.contains(&0) {
         return false;
     }
 
-    std::str::from_utf8(probe).is_ok()
+    std::str::from_utf8(&probe).is_ok()
 }
 
 fn api_error(status: StatusCode, code: &str, message: &str) -> axum::response::Response {
@@ -374,6 +378,16 @@ mod tests {
         let path = root.canonical_path.join("bad.bin");
         let mut file = std::fs::File::create(&path).unwrap();
         file.write_all(&[0, 159, 146, 150]).unwrap();
+        assert!(!is_text_readable(&path));
+    }
+
+    #[test]
+    fn text_readable_probe_does_not_require_reading_entire_large_file() {
+        let (_dir, root) = mk_root();
+        let path = root.canonical_path.join("large.log");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(16 * 1024 * 1024).unwrap();
+
         assert!(!is_text_readable(&path));
     }
 }

--- a/logmancer-web/src/api/server_browser.rs
+++ b/logmancer-web/src/api/server_browser.rs
@@ -1,0 +1,374 @@
+use crate::api::commons::{
+    ApiError, OpenServerFileResponse, ServerBrowserEntry, ServerBrowserListRequest,
+    ServerBrowserListResponse, ServerBrowserOpenRequest, ServerBrowserStatusResponse,
+};
+use crate::api::config::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use std::path::{Component, Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+#[derive(Clone)]
+pub struct ServerFileRoot {
+    pub canonical_path: PathBuf,
+}
+
+impl ServerFileRoot {
+    pub fn from_env() -> Option<Self> {
+        let raw = std::env::var("LOGMANCER_SERVER_FILE_ROOT").ok()?;
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        let canonical_path = std::fs::canonicalize(trimmed).ok()?;
+        if !canonical_path.is_dir() {
+            return None;
+        }
+
+        Some(Self { canonical_path })
+    }
+}
+
+pub async fn server_browser_status(State(app_state): State<AppState>) -> impl IntoResponse {
+    let enabled = app_state.server_file_root.is_some();
+    let message = if enabled {
+        None
+    } else {
+        Some("Server browsing is not configured on this deployment.".to_string())
+    };
+
+    (
+        StatusCode::OK,
+        Json(ServerBrowserStatusResponse { enabled, message }),
+    )
+        .into_response()
+}
+
+pub async fn server_browser_list(
+    State(app_state): State<AppState>,
+    Json(payload): Json<ServerBrowserListRequest>,
+) -> impl IntoResponse {
+    let Some(root) = app_state.server_file_root.as_ref() else {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "server_browser_disabled",
+            "Server browser is unavailable.",
+        );
+    };
+
+    let resolved = match resolve_root_bound_path(root, &payload.path) {
+        Ok(path) => path,
+        Err((status, code, message)) => return api_error(status, code, message),
+    };
+
+    if !resolved.is_dir() {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "not_directory",
+            "Requested path is not a directory.",
+        );
+    }
+
+    match list_directory(root, &resolved) {
+        Ok(response) => (StatusCode::OK, Json(response)).into_response(),
+        Err(_) => api_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "open_failed",
+            "Could not list directory.",
+        ),
+    }
+}
+
+pub async fn server_browser_open(
+    State(app_state): State<AppState>,
+    Json(payload): Json<ServerBrowserOpenRequest>,
+) -> impl IntoResponse {
+    let Some(root) = app_state.server_file_root.as_ref() else {
+        return api_error(
+            StatusCode::FORBIDDEN,
+            "server_browser_disabled",
+            "Server browser is unavailable.",
+        );
+    };
+
+    let resolved = match resolve_root_bound_path(root, &payload.path) {
+        Ok(path) => path,
+        Err((status, code, message)) => return api_error(status, code, message),
+    };
+
+    if !resolved.is_file() {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "not_file",
+            "Requested path is not a file.",
+        );
+    }
+
+    if !is_text_readable(&resolved) {
+        return api_error(
+            StatusCode::BAD_REQUEST,
+            "not_text_readable",
+            "Requested file is not a readable text file.",
+        );
+    }
+
+    let open_target = resolved.to_string_lossy().to_string();
+    match app_state.registry.clone().open_file(&open_target) {
+        Ok(file_id) => (
+            StatusCode::CREATED,
+            Json(OpenServerFileResponse { file_id }),
+        )
+            .into_response(),
+        Err(_) => api_error(
+            StatusCode::BAD_REQUEST,
+            "open_failed",
+            "Could not open file.",
+        ),
+    }
+}
+
+fn list_directory(root: &ServerFileRoot, dir_path: &Path) -> Result<ServerBrowserListResponse, ()> {
+    let mut entries = Vec::new();
+
+    for entry in std::fs::read_dir(dir_path).map_err(|_| ())? {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+
+        let canonical = match std::fs::canonicalize(entry.path()) {
+            Ok(path) => path,
+            Err(_) => continue,
+        };
+
+        if !canonical.starts_with(&root.canonical_path) {
+            continue;
+        }
+
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+
+        let rel = match canonical.strip_prefix(&root.canonical_path) {
+            Ok(rel) => rel,
+            Err(_) => continue,
+        };
+
+        entries.push(ServerBrowserEntry {
+            name: entry.file_name().to_string_lossy().to_string(),
+            path: rel.to_string_lossy().replace('\\', "/"),
+            entry_type: if metadata.is_dir() {
+                "directory"
+            } else {
+                "file"
+            }
+            .to_string(),
+            size: if metadata.is_file() {
+                Some(metadata.len())
+            } else {
+                None
+            },
+            modified: metadata
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_secs().to_string()),
+        });
+    }
+
+    entries.sort_by(|a, b| {
+        let type_order = match (a.entry_type.as_str(), b.entry_type.as_str()) {
+            ("directory", "file") => std::cmp::Ordering::Less,
+            ("file", "directory") => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal,
+        };
+        if type_order != std::cmp::Ordering::Equal {
+            return type_order;
+        }
+        a.name.to_lowercase().cmp(&b.name.to_lowercase())
+    });
+
+    let current = dir_path
+        .strip_prefix(&root.canonical_path)
+        .map_err(|_| ())?
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Ok(ServerBrowserListResponse {
+        can_go_up: !current.is_empty(),
+        current_path: current,
+        entries,
+    })
+}
+
+fn resolve_root_bound_path(
+    root: &ServerFileRoot,
+    token: &str,
+) -> Result<PathBuf, (StatusCode, &'static str, &'static str)> {
+    let trimmed = token.trim();
+    let requested = if trimmed.is_empty() {
+        PathBuf::new()
+    } else {
+        PathBuf::from(trimmed)
+    };
+
+    if requested.is_absolute() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "invalid_path",
+            "Invalid path token.",
+        ));
+    }
+
+    for component in requested.components() {
+        match component {
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "invalid_path",
+                    "Invalid path token.",
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let joined = root.canonical_path.join(&requested);
+    let canonical = joined.canonicalize().map_err(|_| {
+        (
+            StatusCode::NOT_FOUND,
+            "not_found",
+            "Requested path was not found.",
+        )
+    })?;
+
+    if !canonical.starts_with(&root.canonical_path) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "invalid_path",
+            "Invalid path token.",
+        ));
+    }
+
+    Ok(canonical)
+}
+
+fn is_text_readable(path: &Path) -> bool {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+
+    let probe_len = bytes.len().min(8192);
+    let probe = &bytes[..probe_len];
+    if probe.contains(&0) {
+        return false;
+    }
+
+    std::str::from_utf8(probe).is_ok()
+}
+
+fn api_error(status: StatusCode, code: &str, message: &str) -> axum::response::Response {
+    (
+        status,
+        Json(ApiError {
+            code: code.to_string(),
+            message: message.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn mk_root() -> (tempfile::TempDir, ServerFileRoot) {
+        let dir = tempfile::tempdir().unwrap();
+        let root = ServerFileRoot {
+            canonical_path: std::fs::canonicalize(dir.path()).unwrap(),
+        };
+        (dir, root)
+    }
+
+    #[test]
+    fn rejects_parent_traversal() {
+        let (_dir, root) = mk_root();
+        let result = resolve_root_bound_path(&root, "../etc/passwd");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_absolute_path() {
+        let (_dir, root) = mk_root();
+        let result = resolve_root_bound_path(&root, "/etc/passwd");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_symlink_escape() {
+        let (_dir, root) = mk_root();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("outside.log"), "hello").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            outside.path().join("outside.log"),
+            root.canonical_path.join("link.log"),
+        )
+        .unwrap();
+
+        let result = resolve_root_bound_path(&root, "link.log");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn list_sorts_directories_first_then_alpha() {
+        let (_dir, root) = mk_root();
+        std::fs::create_dir_all(root.canonical_path.join("zdir")).unwrap();
+        std::fs::create_dir_all(root.canonical_path.join("adir")).unwrap();
+        std::fs::write(root.canonical_path.join("z.log"), "z").unwrap();
+        std::fs::write(root.canonical_path.join("a.log"), "a").unwrap();
+
+        let response = list_directory(&root, &root.canonical_path).unwrap();
+        let names: Vec<String> = response.entries.into_iter().map(|e| e.name).collect();
+        assert_eq!(names, vec!["adir", "zdir", "a.log", "z.log"]);
+    }
+
+    #[test]
+    fn list_populates_metadata_and_can_go_up() {
+        let (_dir, root) = mk_root();
+        std::fs::create_dir_all(root.canonical_path.join("child")).unwrap();
+        let file_path = root.canonical_path.join("child").join("app.log");
+        std::fs::write(&file_path, "abc").unwrap();
+
+        let response = list_directory(&root, &root.canonical_path.join("child")).unwrap();
+        assert!(response.can_go_up);
+        assert_eq!(response.current_path, "child");
+        assert_eq!(response.entries.len(), 1);
+        assert_eq!(response.entries[0].entry_type, "file");
+        assert_eq!(response.entries[0].size, Some(3));
+        assert!(response.entries[0].modified.is_some());
+    }
+
+    #[test]
+    fn text_readable_accepts_utf8_text() {
+        let (_dir, root) = mk_root();
+        let path = root.canonical_path.join("ok.log");
+        std::fs::write(&path, "hola").unwrap();
+        assert!(is_text_readable(&path));
+    }
+
+    #[test]
+    fn text_readable_rejects_binary_with_nul() {
+        let (_dir, root) = mk_root();
+        let path = root.canonical_path.join("bad.bin");
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(&[0, 159, 146, 150]).unwrap();
+        assert!(!is_text_readable(&path));
+    }
+}

--- a/logmancer-web/src/api/server_browser.rs
+++ b/logmancer-web/src/api/server_browser.rs
@@ -201,6 +201,7 @@ fn list_directory(root: &ServerFileRoot, dir_path: &Path) -> Result<ServerBrowse
     Ok(ServerBrowserListResponse {
         can_go_up: !current.is_empty(),
         current_path: current,
+        current_display_path: dir_path.to_string_lossy().to_string(),
         entries,
     })
 }
@@ -349,6 +350,10 @@ mod tests {
         let response = list_directory(&root, &root.canonical_path.join("child")).unwrap();
         assert!(response.can_go_up);
         assert_eq!(response.current_path, "child");
+        assert_eq!(
+            response.current_display_path,
+            file_path.parent().unwrap().to_string_lossy()
+        );
         assert_eq!(response.entries.len(), 1);
         assert_eq!(response.entries[0].entry_type, "file");
         assert_eq!(response.entries[0].size, Some(3));

--- a/logmancer-web/src/components/async_functions.rs
+++ b/logmancer-web/src/components/async_functions.rs
@@ -1,4 +1,8 @@
-use crate::api::commons::{ApplyFilterRequest, ReadFilterRequest, ReadPageRequest, TailRequest};
+use crate::api::commons::{
+    ApiError, ApplyFilterRequest, OpenServerFileResponse, ReadFilterRequest, ReadPageRequest,
+    ServerBrowserListRequest, ServerBrowserListResponse, ServerBrowserOpenRequest,
+    ServerBrowserStatusResponse, TailRequest,
+};
 use leptos::prelude::{window, ServerFnError};
 use leptos::wasm_bindgen::{JsCast, JsValue};
 use logmancer_core::PageResult;
@@ -58,39 +62,86 @@ pub async fn fetch_filter_page(
     Ok(result)
 }
 
-pub async fn open_server_file(path: String) -> Result<String, String> {
+pub async fn fetch_server_browser_status() -> Result<ServerBrowserStatusResponse, String> {
     let base = window()
         .location()
         .origin()
         .map_err(|_| "Could not detect application origin.".to_string())?;
-    let url = format!("{base}/api/open-server-file");
+    let url = format!("{base}/api/server-browser/status");
+
+    let response = reqwest::Client::new()
+        .get(url)
+        .send()
+        .await
+        .map_err(|_| "Could not connect to the server.".to_string())?;
+
+    if response.status().is_success() {
+        response
+            .json::<ServerBrowserStatusResponse>()
+            .await
+            .map_err(|_| "Could not parse server browser status.".to_string())
+    } else {
+        Err(parse_api_error_message(response, "Could not fetch server browser status.").await)
+    }
+}
+
+pub async fn fetch_server_browser_list(path: String) -> Result<ServerBrowserListResponse, String> {
+    let base = window()
+        .location()
+        .origin()
+        .map_err(|_| "Could not detect application origin.".to_string())?;
+    let url = format!("{base}/api/server-browser/list");
 
     let response = reqwest::Client::new()
         .post(url)
-        .json(&crate::api::commons::OpenServerFileRequest { path })
+        .json(&ServerBrowserListRequest { path })
+        .send()
+        .await
+        .map_err(|_| "Could not connect to the server.".to_string())?;
+
+    if response.status().is_success() {
+        response
+            .json::<ServerBrowserListResponse>()
+            .await
+            .map_err(|_| "Could not parse server browser listing.".to_string())
+    } else {
+        Err(parse_api_error_message(response, "Could not list directory.").await)
+    }
+}
+
+pub async fn open_server_browser_file(path: String) -> Result<String, String> {
+    let base = window()
+        .location()
+        .origin()
+        .map_err(|_| "Could not detect application origin.".to_string())?;
+    let url = format!("{base}/api/server-browser/open");
+
+    let response = reqwest::Client::new()
+        .post(url)
+        .json(&ServerBrowserOpenRequest { path })
         .send()
         .await
         .map_err(|_| "Could not connect to the server.".to_string())?;
 
     if response.status().is_success() {
         let payload = response
-            .json::<crate::api::commons::OpenServerFileResponse>()
+            .json::<OpenServerFileResponse>()
             .await
             .map_err(|_| "Could not parse server response.".to_string())?;
         Ok(payload.file_id)
     } else {
-        response
-            .json::<String>()
-            .await
-            .map_err(|_| "Could not open the requested file.".to_string())
-            .and_then(|message| {
-                if message.trim().is_empty() {
-                    Err("Could not open the requested file.".to_string())
-                } else {
-                    Err(message)
-                }
-            })
+        Err(parse_api_error_message(response, "Could not open the requested server file.").await)
     }
+}
+
+async fn parse_api_error_message(response: reqwest::Response, fallback: &str) -> String {
+    if let Ok(payload) = response.json::<ApiError>().await {
+        if !payload.message.trim().is_empty() {
+            return payload.message;
+        }
+    }
+
+    fallback.to_string()
 }
 
 pub async fn upload_local_file(file: web_sys::File) -> Result<String, String> {
@@ -141,5 +192,42 @@ pub async fn upload_local_file(file: web_sys::File) -> Result<String, String> {
         } else {
             Err(message)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApiError;
+
+    #[test]
+    fn api_error_prefers_non_empty_message() {
+        let payload = ApiError {
+            code: "invalid_path".to_string(),
+            message: "Invalid path token.".to_string(),
+        };
+
+        let message = if payload.message.trim().is_empty() {
+            "fallback".to_string()
+        } else {
+            payload.message
+        };
+
+        assert_eq!(message, "Invalid path token.");
+    }
+
+    #[test]
+    fn api_error_uses_fallback_for_blank_message() {
+        let payload = ApiError {
+            code: "open_failed".to_string(),
+            message: " ".to_string(),
+        };
+
+        let message = if payload.message.trim().is_empty() {
+            "fallback".to_string()
+        } else {
+            payload.message
+        };
+
+        assert_eq!(message, "fallback");
     }
 }

--- a/logmancer-web/src/components/home.rs
+++ b/logmancer-web/src/components/home.rs
@@ -1,4 +1,5 @@
-use crate::components::async_functions::{open_server_file, upload_local_file};
+use crate::components::async_functions::{fetch_server_browser_status, upload_local_file};
+use crate::components::ServerFileSpotlight;
 use leptos::logging::log;
 use leptos::prelude::*;
 use leptos::*;
@@ -9,14 +10,34 @@ use web_sys::{DragEvent, Event, File, HtmlInputElement};
 
 #[component]
 pub fn Home() -> impl IntoView {
-    let (server_path, set_server_path) = signal(String::new());
-    let (open_error, set_open_error) = signal(String::new());
     let (upload_error, set_upload_error) = signal(String::new());
-    let (is_loading_server, set_is_loading_server) = signal(false);
     let (is_uploading, set_is_uploading) = signal(false);
     let (is_dragging, set_is_dragging) = signal(false);
+    let (is_spotlight_open, set_is_spotlight_open) = signal(false);
+    let (is_server_browser_enabled, set_is_server_browser_enabled) = signal(false);
+    let (server_browser_message, set_server_browser_message) =
+        signal("Verificando disponibilidad del servidor...".to_string());
+    let (is_loading_server_browser_status, set_is_loading_server_browser_status) = signal(true);
     let navigate = use_navigate();
     let navigate_for_upload = navigate.clone();
+
+    Effect::new(move |_| {
+        spawn_local(async move {
+            match fetch_server_browser_status().await {
+                Ok(status) => {
+                    set_is_server_browser_enabled.set(status.enabled);
+                    set_server_browser_message.set(status.message.unwrap_or_else(|| {
+                        "Explorá y abrí archivos dentro del directorio configurado.".to_string()
+                    }));
+                }
+                Err(error) => {
+                    set_is_server_browser_enabled.set(false);
+                    set_server_browser_message.set(error);
+                }
+            }
+            set_is_loading_server_browser_status.set(false);
+        });
+    });
 
     let upload_file = Callback::new(move |file: File| {
         set_upload_error.set(String::new());
@@ -37,32 +58,6 @@ pub fn Home() -> impl IntoView {
             set_is_uploading.set(false);
         });
     });
-
-    let on_submit = move |ev: web_sys::SubmitEvent| {
-        ev.prevent_default();
-        let path_value = server_path.get();
-        let trimmed_path = path_value.trim().to_string();
-        if trimmed_path.is_empty() {
-            set_open_error.set("Please enter a valid path.".to_string());
-            return;
-        }
-
-        set_open_error.set(String::new());
-        set_is_loading_server.set(true);
-        let navigate = navigate.clone();
-        spawn_local(async move {
-            match open_server_file(trimmed_path).await {
-                Ok(file_id) => {
-                    navigate(&format!("/log/{file_id}"), Default::default());
-                }
-                Err(err) => {
-                    log!("Error opening server file: {}", err);
-                    set_open_error.set(err);
-                }
-            }
-            set_is_loading_server.set(false);
-        });
-    };
 
     let on_file_change = move |ev: Event| {
         if is_uploading.get_untracked() {
@@ -156,21 +151,27 @@ pub fn Home() -> impl IntoView {
                     <span>"o abrir desde el servidor"</span>
                 </div>
 
-                <form class="home-server-form" on:submit=on_submit>
-                    <input
-                        type="text"
-                        placeholder="Ruta en el servidor"
-                        bind:value=(server_path, set_server_path)
-                    />
-                    <button type="submit" disabled=move || is_loading_server.get()>
-                        {move || if is_loading_server.get() { "Abriendo..." } else { "Abrir archivo" }}
+                <div class="home-server-form">
+                    <button
+                        type="button"
+                        disabled=move || {
+                            is_loading_server_browser_status.get() || !is_server_browser_enabled.get()
+                        }
+                        on:click=move |_| set_is_spotlight_open.set(true)
+                    >
+                        {move || {
+                            if is_loading_server_browser_status.get() {
+                                "Verificando..."
+                            } else {
+                                "Explorar servidor"
+                            }
+                        }}
                     </button>
-                </form>
-
-                <Show when=move || !open_error.get().is_empty()>
-                    <p class="home-error">{move || open_error.get()}</p>
-                </Show>
+                    <p class="home-server-help">{move || server_browser_message.get()}</p>
+                </div>
             </section>
+
+            <ServerFileSpotlight is_open=is_spotlight_open set_is_open=set_is_spotlight_open />
         </main>
     }
 }

--- a/logmancer-web/src/components/home.rs
+++ b/logmancer-web/src/components/home.rs
@@ -16,7 +16,7 @@ pub fn Home() -> impl IntoView {
     let (is_spotlight_open, set_is_spotlight_open) = signal(false);
     let (is_server_browser_enabled, set_is_server_browser_enabled) = signal(false);
     let (server_browser_message, set_server_browser_message) =
-        signal("Verificando disponibilidad del servidor...".to_string());
+        signal("Checking server browser availability...".to_string());
     let (is_loading_server_browser_status, set_is_loading_server_browser_status) = signal(true);
     let navigate = use_navigate();
     let navigate_for_upload = navigate.clone();
@@ -27,7 +27,7 @@ pub fn Home() -> impl IntoView {
                 Ok(status) => {
                     set_is_server_browser_enabled.set(status.enabled);
                     set_server_browser_message.set(status.message.unwrap_or_else(|| {
-                        "Explorá y abrí archivos dentro del directorio configurado.".to_string()
+                        "Browse and open files inside the configured server root.".to_string()
                     }));
                 }
                 Err(error) => {
@@ -105,7 +105,7 @@ pub fn Home() -> impl IntoView {
         <main class="home-landing">
             <section class="home-card">
                 <h1>"Logmancer"</h1>
-                <p class="home-subtitle">"Explorá logs grandes desde el navegador, sin vueltas."</p>
+                <p class="home-subtitle">"Explore large logs from your browser without the friction."</p>
 
                 <div
                     class=move || {
@@ -119,8 +119,8 @@ pub fn Home() -> impl IntoView {
                     on:dragleave=on_drag_leave
                     on:drop=on_drop
                 >
-                    <p class="home-dropzone-title">"Arrastrá y soltá un archivo local"</p>
-                    <p class="home-dropzone-subtitle">"o elegilo manualmente para subirlo"</p>
+                    <p class="home-dropzone-title">"Drag and drop a local file"</p>
+                    <p class="home-dropzone-subtitle">"or choose one manually to upload it"</p>
 
                     <input
                         id="home-local-file-input"
@@ -139,7 +139,7 @@ pub fn Home() -> impl IntoView {
                             }
                         }
                     >
-                        {move || if is_uploading.get() { "Subiendo..." } else { "Elegir archivo local" }}
+                        {move || if is_uploading.get() { "Uploading..." } else { "Choose local file" }}
                     </label>
                 </div>
 
@@ -148,7 +148,7 @@ pub fn Home() -> impl IntoView {
                 </Show>
 
                 <div class="home-divider">
-                    <span>"o abrir desde el servidor"</span>
+                    <span>"or open from the server"</span>
                 </div>
 
                 <div class="home-server-form">
@@ -161,9 +161,9 @@ pub fn Home() -> impl IntoView {
                     >
                         {move || {
                             if is_loading_server_browser_status.get() {
-                                "Verificando..."
+                                "Checking..."
                             } else {
-                                "Explorar servidor"
+                                "Explore Server"
                             }
                         }}
                     </button>

--- a/logmancer-web/src/components/mod.rs
+++ b/logmancer-web/src/components/mod.rs
@@ -12,9 +12,11 @@ mod log_view;
 mod main_pane;
 mod pane_index_progress;
 mod progress_bar;
+mod server_file_spotlight;
 
 pub use app::App;
 pub use context::Port;
 pub use filter_pane::FilterPane;
 pub use home::Home;
 pub use log_view::LogView;
+pub use server_file_spotlight::ServerFileSpotlight;

--- a/logmancer-web/src/components/server_file_spotlight.rs
+++ b/logmancer-web/src/components/server_file_spotlight.rs
@@ -1,9 +1,12 @@
 use crate::api::commons::ServerBrowserEntry;
 use crate::components::async_functions::{fetch_server_browser_list, open_server_browser_file};
+use leptos::html;
 use leptos::logging::log;
 use leptos::prelude::*;
+use leptos::wasm_bindgen::JsCast;
 use leptos_router::hooks::use_navigate;
 use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlElement;
 
 #[component]
 pub fn ServerFileSpotlight(
@@ -13,24 +16,48 @@ pub fn ServerFileSpotlight(
     let (is_loading, set_is_loading) = signal(false);
     let (entries, set_entries) = signal(Vec::<ServerBrowserEntry>::new());
     let (current_path, set_current_path) = signal(String::new());
+    let (current_display_path, set_current_display_path) = signal(String::new());
     let (can_go_up, set_can_go_up) = signal(false);
     let (filter, set_filter) = signal(String::new());
     let (selected_path, set_selected_path) = signal(None::<String>);
     let (selected_is_file, set_selected_is_file) = signal(false);
     let (error_message, set_error_message) = signal(String::new());
     let navigate = use_navigate();
+    let spotlight_ref: NodeRef<html::Section> = NodeRef::new();
+    let filter_input_ref: NodeRef<html::Input> = NodeRef::new();
+
+    let focus_filter = move || {
+        if let Some(input) = filter_input_ref.get() {
+            let _ = input.focus();
+        }
+    };
+
+    let focus_first_entry = move || {
+        let Some(spotlight) = spotlight_ref.get() else {
+            return;
+        };
+        let Ok(Some(element)) = spotlight.query_selector(".server-spotlight-entry") else {
+            return;
+        };
+        if let Ok(element) = element.dyn_into::<HtmlElement>() {
+            let _ = element.focus();
+        }
+    };
 
     let load_directory = Callback::new(move |path: String| {
         set_error_message.set(String::new());
         set_is_loading.set(true);
+        set_filter.set(String::new());
         set_selected_path.set(None);
         set_selected_is_file.set(false);
+        focus_filter();
         let navigate_path = path.clone();
         spawn_local(async move {
             match fetch_server_browser_list(navigate_path).await {
                 Ok(response) => {
                     set_entries.set(response.entries);
                     set_current_path.set(response.current_path);
+                    set_current_display_path.set(response.current_display_path);
                     set_can_go_up.set(response.can_go_up);
                 }
                 Err(error) => {
@@ -52,17 +79,7 @@ pub fn ServerFileSpotlight(
         }
     });
 
-    let open_selected = Callback::new(move |_| {
-        let Some(path) = selected_path.get() else {
-            set_error_message.set("Seleccioná un archivo primero.".to_string());
-            return;
-        };
-
-        if !selected_is_file.get() {
-            set_error_message.set("Solo podés abrir archivos.".to_string());
-            return;
-        }
-
+    let open_file = Callback::new(move |path: String| {
         set_error_message.set(String::new());
         let navigate = navigate.clone();
         spawn_local(async move {
@@ -79,6 +96,20 @@ pub fn ServerFileSpotlight(
         });
     });
 
+    let open_selected = Callback::new(move |_| {
+        let Some(path) = selected_path.get() else {
+            set_error_message.set("Select a file first.".to_string());
+            return;
+        };
+
+        if !selected_is_file.get() {
+            set_error_message.set("Only files can be opened.".to_string());
+            return;
+        }
+
+        open_file.run(path);
+    });
+
     let go_up = move |_| {
         if !can_go_up.get() {
             return;
@@ -91,45 +122,49 @@ pub fn ServerFileSpotlight(
     };
 
     let filtered_entries = Memo::new(move |_| filter_entries(&entries.get(), &filter.get()));
+    let move_focus_from_filter = move |ev: leptos::ev::KeyboardEvent| {
+        if !matches!(ev.key().as_str(), "ArrowDown" | "Enter") {
+            return;
+        }
+        let entries = filtered_entries.get();
+        let Some((path, is_file)) = first_focus_target(&entries) else {
+            return;
+        };
+        ev.prevent_default();
+        set_selected_path.set(Some(path));
+        set_selected_is_file.set(is_file);
+        focus_first_entry();
+    };
 
     view! {
         <Show when=move || is_open.get()>
             <div class="server-spotlight-backdrop" on:click=close_modal>
-                <section class="server-spotlight" on:click=move |ev| ev.stop_propagation()>
+                <section node_ref=spotlight_ref class="server-spotlight" on:click=move |ev| ev.stop_propagation()>
                     <header class="server-spotlight-header">
-                        <h2>"Explorar servidor"</h2>
+                        <h2>"Explore Server"</h2>
                         <button type="button" on:click=close_modal>
-                            "Cerrar"
+                            "Close"
                         </button>
                     </header>
 
                     <div class="server-spotlight-controls">
                         <button type="button" disabled=move || !can_go_up.get() on:click=go_up>
-                            "Subir"
+                            "Up"
                         </button>
-                        <code>{move || {
-                            let path = current_path.get();
-                            if path.is_empty() {
-                                "/".to_string()
-                            } else {
-                                format!("/{path}")
-                            }
-                        }}</code>
+                        <code>{move || current_display_path.get()}</code>
                     </div>
 
                     <input
+                        node_ref=filter_input_ref
                         type="text"
-                        placeholder="Filtrar entradas del directorio actual"
+                        placeholder="Filter current folder entries"
                         bind:value=(filter, set_filter)
+                        on:keydown=move_focus_from_filter
                     />
 
-                    <div class="server-spotlight-results" on:keydown=move |ev: leptos::ev::KeyboardEvent| {
-                        if ev.key() == "Enter" {
-                            open_selected.run(());
-                        }
-                    }>
+                    <div class="server-spotlight-results">
                         <Show when=move || is_loading.get()>
-                            <p>"Cargando..."</p>
+                            <p>"Loading..."</p>
                         </Show>
 
                         <For
@@ -147,6 +182,8 @@ pub fn ServerFileSpotlight(
                                 let click_type = row_type.clone();
                                 let dblclick_path = row_path.clone();
                                 let dblclick_type = row_type.clone();
+                                let key_path = row_path.clone();
+                                let key_type = row_type.clone();
 
                                 view! {
                             <button
@@ -172,9 +209,24 @@ pub fn ServerFileSpotlight(
                                         set_selected_path.set(Some(dblclick_path.clone()));
                                         set_selected_is_file.set(dblclick_type == "file");
                                         if dblclick_type == "file" {
-                                            open_selected.run(());
+                                            open_file.run(dblclick_path.clone());
                                         } else {
                                             load_directory.run(dblclick_path.clone());
+                                        }
+                                    }
+                                }
+                                on:keydown={
+                                    move |ev: leptos::ev::KeyboardEvent| {
+                                        if ev.key() != "Enter" {
+                                            return;
+                                        }
+                                        ev.prevent_default();
+                                        set_selected_path.set(Some(key_path.clone()));
+                                        set_selected_is_file.set(key_type == "file");
+                                        if key_type == "file" {
+                                            open_file.run(key_path.clone());
+                                        } else {
+                                            load_directory.run(key_path.clone());
                                         }
                                     }
                                 }
@@ -188,7 +240,7 @@ pub fn ServerFileSpotlight(
                     </div>
 
                     <Show when=move || !error_message.get().is_empty()>
-                        <p class="home-error">{move || error_message.get()}</p>
+                        <p class="server-spotlight-error">{move || error_message.get()}</p>
                     </Show>
 
                     <footer class="server-spotlight-footer">
@@ -197,7 +249,7 @@ pub fn ServerFileSpotlight(
                             disabled=move || !selected_is_file.get()
                             on:click=move |_| open_selected.run(())
                         >
-                            "Abrir seleccionado"
+                            "Open Selected"
                         </button>
                     </footer>
                 </section>
@@ -233,9 +285,15 @@ pub(crate) fn parent_path(path: &str) -> String {
     parts.join("/")
 }
 
+pub(crate) fn first_focus_target(entries: &[ServerBrowserEntry]) -> Option<(String, bool)> {
+    entries
+        .first()
+        .map(|entry| (entry.path.clone(), entry.entry_type == "file"))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{filter_entries, parent_path};
+    use super::{filter_entries, first_focus_target, parent_path};
     use crate::api::commons::ServerBrowserEntry;
 
     fn mk_entry(name: &str, path: &str, entry_type: &str) -> ServerBrowserEntry {
@@ -282,5 +340,19 @@ mod tests {
         assert_eq!(parent_path(""), "");
         assert_eq!(parent_path("service"), "");
         assert_eq!(parent_path("service/api"), "service");
+    }
+
+    #[test]
+    fn first_focus_target_selects_first_entry_with_file_flag() {
+        let entries = vec![
+            mk_entry("app.log", "logs/app.log", "file"),
+            mk_entry("archive", "logs/archive", "directory"),
+        ];
+
+        assert_eq!(
+            first_focus_target(&entries),
+            Some(("logs/app.log".to_string(), true))
+        );
+        assert_eq!(first_focus_target(&[]), None);
     }
 }

--- a/logmancer-web/src/components/server_file_spotlight.rs
+++ b/logmancer-web/src/components/server_file_spotlight.rs
@@ -1,0 +1,286 @@
+use crate::api::commons::ServerBrowserEntry;
+use crate::components::async_functions::{fetch_server_browser_list, open_server_browser_file};
+use leptos::logging::log;
+use leptos::prelude::*;
+use leptos_router::hooks::use_navigate;
+use wasm_bindgen_futures::spawn_local;
+
+#[component]
+pub fn ServerFileSpotlight(
+    is_open: ReadSignal<bool>,
+    set_is_open: WriteSignal<bool>,
+) -> impl IntoView {
+    let (is_loading, set_is_loading) = signal(false);
+    let (entries, set_entries) = signal(Vec::<ServerBrowserEntry>::new());
+    let (current_path, set_current_path) = signal(String::new());
+    let (can_go_up, set_can_go_up) = signal(false);
+    let (filter, set_filter) = signal(String::new());
+    let (selected_path, set_selected_path) = signal(None::<String>);
+    let (selected_is_file, set_selected_is_file) = signal(false);
+    let (error_message, set_error_message) = signal(String::new());
+    let navigate = use_navigate();
+
+    let load_directory = Callback::new(move |path: String| {
+        set_error_message.set(String::new());
+        set_is_loading.set(true);
+        set_selected_path.set(None);
+        set_selected_is_file.set(false);
+        let navigate_path = path.clone();
+        spawn_local(async move {
+            match fetch_server_browser_list(navigate_path).await {
+                Ok(response) => {
+                    set_entries.set(response.entries);
+                    set_current_path.set(response.current_path);
+                    set_can_go_up.set(response.can_go_up);
+                }
+                Err(error) => {
+                    set_error_message.set(error);
+                }
+            }
+            set_is_loading.set(false);
+        });
+    });
+
+    Effect::new(move |_| {
+        if is_open.get() {
+            load_directory.run(String::new());
+        } else {
+            set_filter.set(String::new());
+            set_error_message.set(String::new());
+            set_selected_path.set(None);
+            set_selected_is_file.set(false);
+        }
+    });
+
+    let open_selected = Callback::new(move |_| {
+        let Some(path) = selected_path.get() else {
+            set_error_message.set("Seleccioná un archivo primero.".to_string());
+            return;
+        };
+
+        if !selected_is_file.get() {
+            set_error_message.set("Solo podés abrir archivos.".to_string());
+            return;
+        }
+
+        set_error_message.set(String::new());
+        let navigate = navigate.clone();
+        spawn_local(async move {
+            match open_server_browser_file(path).await {
+                Ok(file_id) => {
+                    set_is_open.set(false);
+                    navigate(&format!("/log/{file_id}"), Default::default());
+                }
+                Err(error) => {
+                    log!("Error opening server file from spotlight: {}", error);
+                    set_error_message.set(error);
+                }
+            }
+        });
+    });
+
+    let go_up = move |_| {
+        if !can_go_up.get() {
+            return;
+        }
+        load_directory.run(parent_path(&current_path.get()));
+    };
+
+    let close_modal = move |_| {
+        set_is_open.set(false);
+    };
+
+    let filtered_entries = Memo::new(move |_| filter_entries(&entries.get(), &filter.get()));
+
+    view! {
+        <Show when=move || is_open.get()>
+            <div class="server-spotlight-backdrop" on:click=close_modal>
+                <section class="server-spotlight" on:click=move |ev| ev.stop_propagation()>
+                    <header class="server-spotlight-header">
+                        <h2>"Explorar servidor"</h2>
+                        <button type="button" on:click=close_modal>
+                            "Cerrar"
+                        </button>
+                    </header>
+
+                    <div class="server-spotlight-controls">
+                        <button type="button" disabled=move || !can_go_up.get() on:click=go_up>
+                            "Subir"
+                        </button>
+                        <code>{move || {
+                            let path = current_path.get();
+                            if path.is_empty() {
+                                "/".to_string()
+                            } else {
+                                format!("/{path}")
+                            }
+                        }}</code>
+                    </div>
+
+                    <input
+                        type="text"
+                        placeholder="Filtrar entradas del directorio actual"
+                        bind:value=(filter, set_filter)
+                    />
+
+                    <div class="server-spotlight-results" on:keydown=move |ev: leptos::ev::KeyboardEvent| {
+                        if ev.key() == "Enter" {
+                            open_selected.run(());
+                        }
+                    }>
+                        <Show when=move || is_loading.get()>
+                            <p>"Cargando..."</p>
+                        </Show>
+
+                        <For
+                            each=move || filtered_entries.get()
+                            key=|entry| entry.path.clone()
+                            let:entry
+                        >
+                            {move || {
+                                let row_path = entry.path.clone();
+                                let row_type = entry.entry_type.clone();
+                                let row_name = entry.name.clone();
+                                let icon_type = row_type.clone();
+                                let class_path = row_path.clone();
+                                let click_path = row_path.clone();
+                                let click_type = row_type.clone();
+                                let dblclick_path = row_path.clone();
+                                let dblclick_type = row_type.clone();
+
+                                view! {
+                            <button
+                                type="button"
+                                class=move || {
+                                    if selected_path.get().as_ref() == Some(&class_path) {
+                                        "server-spotlight-entry is-selected"
+                                    } else {
+                                        "server-spotlight-entry"
+                                    }
+                                }
+                                on:click={
+                                    move |_| {
+                                        set_selected_path.set(Some(click_path.clone()));
+                                        set_selected_is_file.set(click_type == "file");
+                                        if click_type == "directory" {
+                                            load_directory.run(click_path.clone());
+                                        }
+                                    }
+                                }
+                                on:dblclick={
+                                    move |_| {
+                                        set_selected_path.set(Some(dblclick_path.clone()));
+                                        set_selected_is_file.set(dblclick_type == "file");
+                                        if dblclick_type == "file" {
+                                            open_selected.run(());
+                                        } else {
+                                            load_directory.run(dblclick_path.clone());
+                                        }
+                                    }
+                                }
+                            >
+                                <span>{move || if icon_type == "directory" { "📁" } else { "📄" }}</span>
+                                <span>{row_name.clone()}</span>
+                            </button>
+                                }
+                            }}
+                        </For>
+                    </div>
+
+                    <Show when=move || !error_message.get().is_empty()>
+                        <p class="home-error">{move || error_message.get()}</p>
+                    </Show>
+
+                    <footer class="server-spotlight-footer">
+                        <button
+                            type="button"
+                            disabled=move || !selected_is_file.get()
+                            on:click=move |_| open_selected.run(())
+                        >
+                            "Abrir seleccionado"
+                        </button>
+                    </footer>
+                </section>
+            </div>
+        </Show>
+    }
+}
+
+pub(crate) fn filter_entries(
+    entries: &[ServerBrowserEntry],
+    query: &str,
+) -> Vec<ServerBrowserEntry> {
+    let trimmed = query.trim().to_lowercase();
+    if trimmed.is_empty() {
+        return entries.to_vec();
+    }
+
+    entries
+        .iter()
+        .filter(|entry| entry.name.to_lowercase().contains(&trimmed))
+        .cloned()
+        .collect()
+}
+
+pub(crate) fn parent_path(path: &str) -> String {
+    let trimmed = path.trim_matches('/');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let mut parts: Vec<&str> = trimmed.split('/').collect();
+    parts.pop();
+    parts.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_entries, parent_path};
+    use crate::api::commons::ServerBrowserEntry;
+
+    fn mk_entry(name: &str, path: &str, entry_type: &str) -> ServerBrowserEntry {
+        ServerBrowserEntry {
+            name: name.to_string(),
+            path: path.to_string(),
+            entry_type: entry_type.to_string(),
+            size: None,
+            modified: None,
+        }
+    }
+
+    #[test]
+    fn filter_entries_only_applies_to_loaded_current_directory_entries() {
+        let entries = vec![
+            mk_entry("app.log", "app.log", "file"),
+            mk_entry("infra", "infra", "directory"),
+            mk_entry("error.log", "error.log", "file"),
+        ];
+
+        let filtered = filter_entries(&entries, "log");
+        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered[0].name, "app.log");
+        assert_eq!(filtered[1].name, "error.log");
+    }
+
+    #[test]
+    fn filter_entries_is_case_insensitive_and_returns_all_for_empty_query() {
+        let entries = vec![
+            mk_entry("API.LOG", "API.LOG", "file"),
+            mk_entry("docs", "docs", "directory"),
+        ];
+
+        let filtered = filter_entries(&entries, "api");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].name, "API.LOG");
+
+        let unfiltered = filter_entries(&entries, "   ");
+        assert_eq!(unfiltered.len(), 2);
+    }
+
+    #[test]
+    fn parent_path_stays_at_root_and_moves_up_one_level() {
+        assert_eq!(parent_path(""), "");
+        assert_eq!(parent_path("service"), "");
+        assert_eq!(parent_path("service/api"), "service");
+    }
+}

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -114,6 +114,8 @@ body {
 
 .home-server-form {
   display: flex;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 8px;
 
   input {
@@ -122,6 +124,200 @@ body {
     border-radius: 10px;
     padding: 10px 12px;
     font-size: 0.95rem;
+  }
+}
+
+.home-server-help {
+  color: #4b5563;
+  font-size: 0.9rem;
+  line-height: 1.35;
+}
+
+.server-spotlight-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.62);
+  z-index: 50;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 10vh 16px 16px;
+  backdrop-filter: blur(2px);
+}
+
+.server-spotlight {
+  width: min(760px, 96vw);
+  max-height: 74vh;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border: 1px solid #dbe2ef;
+  border-radius: 14px;
+  box-shadow: 0 26px 70px rgba(15, 23, 42, 0.25);
+  overflow: hidden;
+}
+
+.server-spotlight-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border-bottom: 1px solid #e5e7eb;
+
+  h2 {
+    color: #111827;
+    font-size: 1.05rem;
+    font-weight: 650;
+  }
+
+  button {
+    border: 1px solid #d1d5db;
+    background: #fff;
+    color: #374151;
+    border-radius: 8px;
+    padding: 7px 10px;
+    font-size: 0.86rem;
+    cursor: pointer;
+
+    &:hover {
+      background: #f9fafb;
+    }
+  }
+}
+
+.server-spotlight-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid #eef2f7;
+  background: #f8fafc;
+
+  button {
+    border: 1px solid #d1d5db;
+    background: #fff;
+    color: #1f2937;
+    border-radius: 8px;
+    padding: 6px 10px;
+    font-size: 0.86rem;
+    cursor: pointer;
+
+    &:hover {
+      background: #f1f5f9;
+    }
+
+    &:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+  }
+
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    background: #fff;
+    border: 1px solid #dbe2ef;
+    border-radius: 8px;
+    color: #334155;
+    font-size: 0.8rem;
+    padding: 5px 8px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.server-spotlight > input[type='text'] {
+  margin: 12px 14px;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 0.92rem;
+  outline: none;
+
+  &:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.14);
+  }
+}
+
+.server-spotlight-results {
+  margin: 0 14px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  min-height: 220px;
+  max-height: 46vh;
+  overflow-y: auto;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+
+  p {
+    padding: 10px 12px;
+    color: #64748b;
+    font-size: 0.88rem;
+  }
+}
+
+.server-spotlight-entry {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid #f1f5f9;
+  background: #fff;
+  color: #111827;
+  text-align: left;
+  padding: 9px 12px;
+  font-size: 0.9rem;
+  cursor: pointer;
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  &:hover {
+    background: #f8fafc;
+  }
+
+  &.is-selected {
+    background: #eff6ff;
+    box-shadow: inset 0 0 0 1px #bfdbfe;
+  }
+
+  span:last-child {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.server-spotlight-footer {
+  padding: 12px 14px 14px;
+  border-top: 1px solid #eef2f7;
+  display: flex;
+  justify-content: flex-end;
+
+  button {
+    border: 0;
+    border-radius: 10px;
+    padding: 10px 14px;
+    background: #2563eb;
+    color: #fff;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover {
+      background: #1d4ed8;
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
   }
 }
 

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -147,7 +147,7 @@ body {
 
 .server-spotlight {
   width: min(760px, 96vw);
-  max-height: 74vh;
+  height: min(760px, 82vh);
   display: flex;
   flex-direction: column;
   background: #ffffff;
@@ -214,6 +214,8 @@ body {
   }
 
   code {
+    flex: 1;
+    min-width: 0;
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     background: #fff;
     border: 1px solid #dbe2ef;
@@ -242,11 +244,12 @@ body {
 }
 
 .server-spotlight-results {
+  flex: 1;
   margin: 0 14px 12px;
   border: 1px solid #e5e7eb;
   border-radius: 10px;
   min-height: 220px;
-  max-height: 46vh;
+  max-height: none;
   overflow-y: auto;
   background: #fff;
   display: flex;
@@ -257,6 +260,18 @@ body {
     color: #64748b;
     font-size: 0.88rem;
   }
+}
+
+.server-spotlight-error {
+  margin: 0 14px 12px;
+  border: 1px solid #fecaca;
+  border-radius: 10px;
+  background: #fef2f2;
+  color: #b91c1c;
+  font-size: 0.9rem;
+  line-height: 1.35;
+  padding: 10px 12px;
+  flex-shrink: 0;
 }
 
 .server-spotlight-entry {


### PR DESCRIPTION
Closes #40

## Type
- [x] New feature

## Summary
- Adds an opt-in, root-scoped server file browser enabled by `LOGMANCER_SERVER_FILE_ROOT`.
- Adds backend status/list/open APIs with traversal, symlink escape, and text-readability validation.
- Replaces server file opening UX with an English Spotlight-style modal, local filtering, keyboard navigation, docs, and ADR.

## Changes
| File | Change |
|------|--------|
| `logmancer-web/src/api/server_browser.rs` | Adds root-scoped browser handlers, path validation, listing/open logic, and tests. |
| `logmancer-web/src/api/config.rs` | Wires server browser routes and optional root state. |
| `logmancer-web/src/api/commons.rs` | Adds server browser request/response DTOs and safe API error shape. |
| `logmancer-web/src/components/async_functions.rs` | Adds typed browser client helpers and safe error parsing. |
| `logmancer-web/src/components/home.rs` | Adds `Explore Server` entry point and removes manual server path flow from Home. |
| `logmancer-web/src/components/server_file_spotlight.rs` | Adds Spotlight-style browser modal with local filtering and keyboard behavior. |
| `logmancer-web/style/main.scss` | Adds modal, results, disabled/help, and error layout styles. |
| `docs/feature/server-file-browser.md` | Documents configuration, behavior, security, and review checklist. |
| `docs/adr/0001-server-file-browser-root-scoped.md` | Records root-scoped server browser architecture decisions. |

## Test Plan
- [x] `cargo test -p logmancer-web --features ssr`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Manually tested server file browsing flow before final UX polish.
- [x] Fresh PR-readiness review found and verified fix for bounded text probe.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers