### PR TITLE
fix(web): raise Leptos recursion limit

### DIFF
--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 pub mod api;
 pub mod app;
 pub mod components;


### PR DESCRIPTION
Fixes #40

## Type
- [x] Bug fix

## Summary
- Raises the `logmancer-web` crate recursion limit to satisfy the Leptos release build type expansion.
- Fixes the GitHub Linux/Windows build failure: `queries overflow the depth limit`.

## Changes
| File | Change |
|------|--------|
| `logmancer-web/src/lib.rs` | Adds `#![recursion_limit = \"256\"]`. |

## Test Plan
- [x] `cargo build --package=logmancer-web --bin=logmancer-web --no-default-features --features=ssr --release`
- [x] `cargo leptos build --release --project logmancer-web`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers