### PR TITLE
ci(release): simplify portable artifact names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build:
-    name: Package for ${{ matrix.package_suffix }}
+    name: Package for ${{ matrix.package_name }}
     if: github.event.workflow_run.event == 'push' && github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.os }}
     strategy:
@@ -29,10 +29,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            package_suffix: x86_64-unknown-linux-gnu
+            package_name: linux
           - os: windows-2025-vs2026
             target: x86_64-pc-windows-msvc
-            package_suffix: x86_64-pc-windows-msvc-windows-2025-vs2026
+            package_name: windows
 
     steps:
       - uses: actions/checkout@v6
@@ -73,7 +73,7 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: build-${{ runner.os }}-${{ matrix.package_suffix }}
+          shared-key: build-${{ runner.os }}-${{ matrix.package_name }}
 
       - name: Install cargo-leptos
         run: cargo install cargo-leptos --locked
@@ -92,8 +92,7 @@ jobs:
         run: |
           set -euo pipefail
           target_dir="target/${{ matrix.target }}/release"
-          package_root="dist/logmancer-${{ matrix.package_suffix }}"
-          archive_name="logmancer-main-${{ matrix.package_suffix }}-portable.zip"
+          package_root="dist/logmancer-${{ matrix.package_name }}"
 
           mkdir -p "$package_root"
           cp "$target_dir/logmancer-web" "$package_root/"
@@ -106,15 +105,12 @@ jobs:
 
           chmod +x "$package_root/run-web.sh" "$package_root/run-desktop.sh"
 
-          (cd "dist" && zip -r "$archive_name" "logmancer-${{ matrix.package_suffix }}")
-
       - name: Package Windows artifacts
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $targetDir = "target/${{ matrix.target }}/release"
-          $packageRoot = "dist/logmancer-${{ matrix.package_suffix }}"
-          $archiveName = "logmancer-main-${{ matrix.package_suffix }}-portable.zip"
+          $packageRoot = "dist/logmancer-${{ matrix.package_name }}"
 
           New-Item -ItemType Directory -Path $packageRoot -Force | Out-Null
           Copy-Item "$targetDir/logmancer-web.exe" "$packageRoot/"
@@ -125,13 +121,11 @@ jobs:
           Copy-Item "packaging/portable/windows/run-web.cmd" "$packageRoot/"
           Copy-Item "packaging/portable/windows/run-desktop.cmd" "$packageRoot/"
 
-          Compress-Archive -Path $packageRoot -DestinationPath "dist/$archiveName" -Force
-
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: logmancer-package-${{ matrix.package_suffix }}
-          path: dist/logmancer-main-${{ matrix.package_suffix }}-portable.zip
+          name: logmancer-package-${{ matrix.package_name }}
+          path: dist/logmancer-${{ matrix.package_name }}
           if-no-files-found: error
 
   cleanup-artifacts:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   package:
-    name: Package release for ${{ matrix.package_suffix }}
+    name: Package release for ${{ matrix.package_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -22,10 +22,10 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            package_suffix: x86_64-unknown-linux-gnu
+            package_name: linux
           - os: windows-2025-vs2026
             target: x86_64-pc-windows-msvc
-            package_suffix: x86_64-pc-windows-msvc-windows-2025-vs2026
+            package_name: windows
 
     steps:
       - uses: actions/checkout@v6
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: true
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: release-${{ runner.os }}-${{ matrix.package_suffix }}
+          shared-key: release-${{ runner.os }}-${{ matrix.package_name }}
 
       - name: Install cargo-leptos
         run: cargo install cargo-leptos --locked
@@ -87,8 +87,8 @@ jobs:
         run: |
           set -euo pipefail
           target_dir="target/${{ matrix.target }}/release"
-          package_root="dist/logmancer-${{ matrix.package_suffix }}"
-          archive_name="logmancer-${LOGMANCER_VERSION}-${{ matrix.package_suffix }}-portable.zip"
+          package_root="dist/logmancer-${{ matrix.package_name }}"
+          archive_name="logmancer-${LOGMANCER_VERSION}-${{ matrix.package_name }}-portable.zip"
 
           mkdir -p "$package_root"
           cp "$target_dir/logmancer-web" "$package_root/"
@@ -100,15 +100,15 @@ jobs:
           cp packaging/portable/linux/run-desktop.sh "$package_root/"
 
           chmod +x "$package_root/run-web.sh" "$package_root/run-desktop.sh"
-          (cd "dist" && zip -r "$archive_name" "logmancer-${{ matrix.package_suffix }}")
+          (cd "$package_root" && zip -r "../$archive_name" .)
 
       - name: Package Windows portable zip
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           $targetDir = "target/${{ matrix.target }}/release"
-          $packageRoot = "dist/logmancer-${{ matrix.package_suffix }}"
-          $archiveName = "logmancer-${env:LOGMANCER_VERSION}-${{ matrix.package_suffix }}-portable.zip"
+          $packageRoot = "dist/logmancer-${{ matrix.package_name }}"
+          $archiveName = "logmancer-${env:LOGMANCER_VERSION}-${{ matrix.package_name }}-portable.zip"
 
           New-Item -ItemType Directory -Path $packageRoot -Force | Out-Null
           Copy-Item "$targetDir/logmancer-web.exe" "$packageRoot/"
@@ -119,13 +119,13 @@ jobs:
           Copy-Item "packaging/portable/windows/run-web.cmd" "$packageRoot/"
           Copy-Item "packaging/portable/windows/run-desktop.cmd" "$packageRoot/"
 
-          Compress-Archive -Path $packageRoot -DestinationPath "dist/$archiveName" -Force
+          Compress-Archive -Path "$packageRoot/*" -DestinationPath "dist/$archiveName" -Force
 
       - name: Upload portable zip artifact
         uses: actions/upload-artifact@v7
         with:
-          name: logmancer-portable-${{ matrix.package_suffix }}
-          path: dist/logmancer-*-${{ matrix.package_suffix }}-portable.zip
+          name: logmancer-portable-${{ matrix.package_name }}
+          path: dist/logmancer-*-${{ matrix.package_name }}-portable.zip
           if-no-files-found: error
 
   publish:


### PR DESCRIPTION
Closes #45

## Summary
- Changes main-build artifacts to upload the portable package directory directly, avoiding the nested portable zip.
- Uses friendly platform names (`linux`, `windows`) instead of Rust target triples in artifact/package names.
- Keeps release assets as direct-content portable zip files.

## Changes
| File | Change |
|------|--------|
| `.github/workflows/build.yml` | Uploads platform package directories directly as GitHub artifacts and uses linux/windows names. |
| `.github/workflows/release.yml` | Uses linux/windows names and creates release zips from package contents directly. |

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] Parsed workflow YAML with Ruby.
- [x] Ran `git diff --check`.
- [x] Ran fresh-context review on the workflow diff.
- [ ] `actionlint` unavailable locally.
- [ ] `shellcheck` unavailable locally.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.