### PR TITLE
fix(release): polish app titles

### DIFF
--- a/logmancer-desktop/tauri.conf.json
+++ b/logmancer-desktop/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "tauri-app",
+  "productName": "Logmancer",
   "version": "0.2.0",
-  "identifier": "com.tauri-app.app",
+  "identifier": "com.ignsabbag.logmancer",
   "build": {
     "beforeDevCommand": "cargo leptos watch --project logmancer-web",
     "devUrl": "http://localhost:3000",
@@ -13,7 +13,7 @@
     "withGlobalTauri": true,
     "windows": [
       {
-        "title": "tauri-app",
+        "title": "Logmancer",
         "width": 800,
         "height": 600
       }

--- a/logmancer-web/src/components/app.rs
+++ b/logmancer-web/src/components/app.rs
@@ -17,7 +17,7 @@ pub fn App() -> impl IntoView {
         <Stylesheet id="leptos" href="/pkg/logmancer-web.css"/>
 
         // sets the document title
-        <Title text="Welcome to Leptos"/>
+        <Title text="Logmancer"/>
 
         // content for this welcome page
         <Router>

--- a/packaging/portable/windows/run-desktop.cmd
+++ b/packaging/portable/windows/run-desktop.cmd
@@ -3,4 +3,4 @@ set LEPTOS_OUTPUT_NAME=logmancer-web
 set LEPTOS_SITE_ROOT=%~dp0site
 if not exist "%~dp0logs" mkdir "%~dp0logs"
 set LOGMANCER_LOG_FILE=%~dp0logs\logmancer-desktop.log
-"%~dp0logmancer-desktop.exe" %*
+start "" "%~dp0logmancer-desktop.exe" %*


### PR DESCRIPTION
Closes #47

## Summary
- Sets the desktop product/window title and web document title to `Logmancer`.
- Replaces the default Tauri identifier before the first tagged release.
- Uses `start ""` in the Windows desktop portable launcher so it does not keep the launcher console open.

## Changes
| File | Change |
|------|--------|
| `logmancer-desktop/tauri.conf.json` | Sets product name/window title to Logmancer and updates the app identifier. |
| `logmancer-web/src/components/app.rs` | Sets the Leptos document title to Logmancer. |
| `packaging/portable/windows/run-desktop.cmd` | Starts the desktop executable via `start ""` to detach from the launcher console. |

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] Ran `cargo fmt --check`.
- [x] Ran `cargo clippy --workspace -- -D warnings`.
- [x] Parsed `logmancer-desktop/tauri.conf.json` as JSON.
- [x] Ran `git diff --check`.
- [x] Ran fresh-context review on the release polish diff.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.