### PR TITLE
docs(release): update 0.2.0 changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 
 /tests/output/
 **/examples/**/output/
+
+/.atl/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,11 @@ cargo test -- --nocapture
 - Prefer temp files for file operation tests
 - Clean up test files in test body
 
+### Changelog
+- Update `CHANGELOG.md` before committing relevant user-facing, release, packaging, workflow, or behavior changes.
+- Keep changelog entries concise and grouped under `[Unreleased]` during development or the active release section when preparing a tag.
+- If a change is purely internal and not release-note-worthy, leave `CHANGELOG.md` unchanged and call that out in the commit/PR summary.
+
 ---
 
 ## Dependencies
@@ -156,3 +161,4 @@ cargo tauri dev
 ## Project Skills
 
 - `skills/rust-quality-gate/SKILL.md` — OpenCode-compatible skill for commit/PR preparation. It requires `cargo fmt` and `cargo clippy --workspace -- -D warnings` before creating a commit or PR.
+- The Rust quality gate skill also requires an explicit `CHANGELOG.md` decision before committing relevant user-facing, release, packaging, workflow, or behavior changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,34 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-05-15
+
 ### Added
 
 - Project roadmap in `ROADMAP.md`.
+- Local web file upload flow from the Home screen (#10).
 - Selected line highlighting in the web/desktop main viewer and filter panel (#15).
 - Filter result selection now synchronizes with the main viewer, selecting and revealing the matching original log line (#16).
+- Active log panel indication for the web/desktop viewer and filter panel (#17).
 - Added a visible auto-scroll/follow mode indicator in the web/desktop UI (#18).
+- Root-scoped server file browser for Logmancer Web, enabled by `LOGMANCER_SERVER_FILE_ROOT`, with Spotlight-style navigation, local filtering, root-bound backend validation, and text-file opening (#40).
+- Portable release packaging with versioned README/launchers, simplified Linux/Windows artifact names, and tag-triggered GitHub Release asset publishing (#43, #45).
+
+### Changed
+
+- Split CI testing and release-build packaging workflows, with non-blocking dependency caches and the `windows-2025-vs2026` Windows runner (#28, #31, #33).
+- Commit/PR guidance now requires an explicit `CHANGELOG.md` decision for release-relevant changes.
+- Desktop and web release branding now use the Logmancer app name and the desktop build uses the `com.ignsabbag.logmancer` application identifier (#47).
+- Windows desktop portable launcher now starts the GUI executable without keeping the launcher console open (#47).
 
 ### Fixes
 
+- Release web builds now hydrate correctly and initialize backend logging reliably.
 - Web keyboard navigation now supports repeated arrow/page movement plus `g`, `G`, and `f` shortcuts.
 - Web main viewer keeps auto-scroll status scoped to the main pane and avoids filter-panel scroll/follow coupling.
 - Web/desktop log scrolling now preserves accumulated mouse wheel and trackpad intent, avoiding stale debounced viewport updates that made fast scrolling feel like it moved backwards (#19).
 - Large-file indexing no longer blocks main log reads while scanning new line offsets, keeping the UI responsive when applying filters during indexing (#30).
+- Release builds now set a higher Leptos recursion limit so GitHub release packaging can compile the web UI reliably (#42).
 
 ## [0.1.0] - 2026-05-05
 
@@ -35,3 +50,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 - Web follow mode works, but does not yet expose a clear visual indicator.
 - Search, visual rules, structured parsing, and multi-file workspace improvements are planned but not part of `0.1.0`.
+
+[Unreleased]: https://github.com/ignsabbag/logmancer/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ignsabbag/logmancer/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/ignsabbag/logmancer/releases/tag/v0.1.0

--- a/skills/rust-quality-gate/SKILL.md
+++ b/skills/rust-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-quality-gate
-description: "Trigger: commit, PR, pull request, cargo fmt, clippy. Run Logmancer Rust quality gates before commit or PR."
+description: "Trigger: commit, PR, pull request, changelog, cargo fmt, clippy. Run Logmancer review gates before commit or PR."
 license: Apache-2.0
 metadata:
   version: "1.0"
@@ -17,6 +17,7 @@ Use this skill before creating a commit, opening a PR, or preparing changes for 
 - Do not create the commit or PR while either command fails.
 - If `cargo fmt` changes files, include those formatting changes in the same reviewable work unit.
 - Do not run `cargo build`; this project explicitly avoids builds during agent changes unless the user asks.
+- Update `CHANGELOG.md` before committing any relevant user-facing, release, packaging, workflow, or behavior change.
 - Keep Conventional Commit style and never add AI attribution trailers.
 
 ## Decision Gates
@@ -26,20 +27,25 @@ Use this skill before creating a commit, opening a PR, or preparing changes for 
 | `cargo fmt` succeeds with changes | Continue, then include changed files in commit/PR scope |
 | `cargo fmt` fails | Stop, report the formatter error, and do not commit or open a PR |
 | `cargo clippy --workspace -- -D warnings` fails | Fix warnings if in scope; otherwise stop and report blockers |
+| Change affects users, releases, packaging, CI behavior, or documented behavior | Update `CHANGELOG.md` in the same work unit before committing |
+| Change is purely internal and not notable for release notes | Leave `CHANGELOG.md` unchanged and mention why in the commit/PR summary |
 | User asks to skip gates | Push back and require explicit confirmation before bypassing |
 
 ## Execution Steps
 
-1. Run `cargo fmt` from the repository root.
-2. Run `cargo clippy --workspace -- -D warnings` from the repository root.
-3. Inspect the resulting working tree before committing or preparing a PR.
-4. Proceed only when both commands pass.
+1. Decide whether the change is changelog-worthy before staging the commit.
+2. If it is notable, update `CHANGELOG.md` under `[Unreleased]` or the active release section.
+3. Run `cargo fmt` from the repository root.
+4. Run `cargo clippy --workspace -- -D warnings` from the repository root.
+5. Inspect the resulting working tree before committing or preparing a PR.
+6. Proceed only when the changelog decision is explicit and both commands pass.
 
 ## Output Contract
 
 Report:
 - `cargo fmt`: pass/fail and whether files changed.
 - `cargo clippy --workspace -- -D warnings`: pass/fail.
+- `CHANGELOG.md`: updated or intentionally unchanged, with a short reason.
 - Any blockers that prevent commit or PR creation.
 
 ## References


### PR DESCRIPTION
Closes #49

## Summary
- Moves accumulated release notes into a dated `0.2.0` changelog section before tagging.
- Adds missing release notes for the server file browser, portable packaging, release polish, CI changes, and recent fixes.
- Updates project guidance and the Rust quality gate skill to require an explicit changelog decision before relevant commits.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | Adds the `0.2.0` section, missing release entries, and compare links. |
| `AGENTS.md` | Documents the changelog decision rule for future agent work. |
| `skills/rust-quality-gate/SKILL.md` | Adds changelog checks to commit/PR preparation. |
| `.gitignore` | Ignores local `.atl/` skill-registry cache output. |

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] Ran `git diff --check`.
- [x] Ran `cargo fmt --check`.
- [x] Ran `cargo clippy --workspace -- -D warnings`.
- [x] Ran fresh-context review on changelog/guidance changes.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Changelog updated.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.