### PR TITLE
feat(web): add slash search panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 - Shared core search engine with reusable `PageResult` search metadata (`PageSearchResult` + page-scoped match spans with multiple occurrences per line), less-style wrap navigation (`next`/`previous`), and stable match identity for frontend adapters.
 - Search API endpoints for web/desktop thin adapters (`apply-search`, `search-next`, `search-previous`, `search-status`, `clear-search`) backed directly by core semantics.
+- Web/desktop bottom search panel opened with `/` or `Ctrl+F`, backed by the shared search API and current-page match highlighting.
 - TUI search controls: `/` to apply/clear query and `n`/`N` for next/previous match navigation using core behavior.
 
 ### Changed

--- a/docs/feature/shared-search-engine.md
+++ b/docs/feature/shared-search-engine.md
@@ -6,6 +6,7 @@ Logmancer search is a **core-owned capability** shared by Web, Desktop, and TUI:
 
 - Search behavior lives in `logmancer-core`, not in each client.
 - `PageResult` remains the primary page response and may include optional search metadata.
+- Web/Desktop expose search through a bottom search panel opened with `/` or `Ctrl+F`.
 - Clients render page-scoped match spans and highlight the current match.
 - Navigation uses shared `next` / `previous` semantics with less-style wrapping.
 - Search matches support multiple occurrences per line.
@@ -20,6 +21,24 @@ Logmancer search is a **core-owned capability** shared by Web, Desktop, and TUI:
 | Press previous | Core moves to the previous match and returns a page positioned around it. |
 | Reach last/first match | Navigation wraps, matching less-style search behavior. |
 | Clear search | Core removes active search metadata and normal page reads continue. |
+
+## Web/Desktop search panel
+
+Issue #21 adds the Web/Desktop entry point for shared search. It should stay focused on starting a search, revealing the first match, and rendering matches already visible on the current page.
+
+| Interaction | Expected result |
+|---|---|
+| Press `/` | Open the bottom search panel and focus the input. |
+| Press `Ctrl+F` | Open the same search panel and focus the input. |
+| Type query | Update the input value without moving focus away from the search panel. |
+| Press `Enter` | Submit the query, run shared search, reveal or select the first returned match, keep the panel visible, then move focus back to the main log panel. |
+| Press `Esc` | Close the search panel cleanly without submitting a new search. |
+| Click `x` | Close the search panel cleanly. |
+| Submit an empty query | Reset search cleanly without stale highlights while keeping the panel visible. |
+
+The panel is hidden by default. When visible, it is a compact fixed panel pinned to the bottom of the whole viewport/window. It spans the full window width, with the search input and `x` close button aligned on the right. The input receives focus immediately when opened or reopened with `/` or `Ctrl+F` so keyboard search works without an extra click. `Esc` and `x` are the only close interactions for issue #21; submitting with `Enter` leaves the panel visible.
+
+Navigation between matches with `n` / `N` is intentionally out of scope for issue #21 and belongs to issue #23. Issue #21 may introduce state that makes #23 straightforward, but it should not implement next/previous navigation behavior.
 
 ## Response model
 
@@ -115,8 +134,12 @@ The worker may discover matches in circular scan order for responsiveness, but s
 - [ ] Search behavior is owned by `logmancer-core`.
 - [ ] `PageResult` remains the primary response contract.
 - [ ] Search metadata is optional and page-scoped.
+- [ ] Web/Desktop `/` opens a bottom search panel with focused input.
+- [ ] Web/Desktop `Ctrl+F` opens the same search panel with focused input.
+- [ ] Web/Desktop `Esc` and `x` close the search panel cleanly.
+- [ ] Web/Desktop `Enter` submits search, keeps the panel visible, and returns focus to the main log panel.
 - [ ] Multiple matches per line are represented with line + span + ordinal.
-- [ ] `next` / `previous` navigation wraps.
+- [ ] `next` / `previous` navigation wraps in core/API; Web/Desktop `n` / `N` controls are intentionally deferred to issue #23.
 - [ ] Scroll position does not change the selected current match.
 - [ ] Web/Desktop and TUI only render core-provided search metadata.
 - [ ] Large-file search work is batchable and does not require one long synchronous scan.

--- a/logmancer-web/src/components/async_functions.rs
+++ b/logmancer-web/src/components/async_functions.rs
@@ -1,7 +1,7 @@
 use crate::api::commons::{
-    ApiError, ApplyFilterRequest, OpenServerFileResponse, ReadFilterRequest, ReadPageRequest,
-    ServerBrowserListRequest, ServerBrowserListResponse, ServerBrowserOpenRequest,
-    ServerBrowserStatusResponse, TailRequest,
+    ApiError, ApplyFilterRequest, ApplySearchRequest, OpenServerFileResponse, ReadFilterRequest,
+    ReadPageRequest, SearchStatusRequest, ServerBrowserListRequest, ServerBrowserListResponse,
+    ServerBrowserOpenRequest, ServerBrowserStatusResponse, TailRequest,
 };
 use leptos::prelude::{window, ServerFnError};
 use leptos::wasm_bindgen::{JsCast, JsValue};
@@ -42,6 +42,32 @@ pub async fn apply_filter(file_id: String, filter: String) -> Result<String, Ser
     let request = reqwest::Client::new()
         .post(url)
         .json(&ApplyFilterRequest { file_id, filter });
+    let result = request.send().await?.json::<String>().await?;
+    Ok(result)
+}
+
+pub async fn apply_search(
+    file_id: String,
+    query: String,
+    max_lines: usize,
+) -> Result<PageResult, ServerFnError> {
+    let base = window().location().origin().unwrap();
+    let url = format!("{base}/api/apply-search");
+    let request = reqwest::Client::new().post(url).json(&ApplySearchRequest {
+        file_id,
+        query,
+        max_lines,
+    });
+    let result = request.send().await?.json::<PageResult>().await?;
+    Ok(result)
+}
+
+pub async fn clear_search(file_id: String) -> Result<String, ServerFnError> {
+    let base = window().location().origin().unwrap();
+    let url = format!("{base}/api/clear-search");
+    let request = reqwest::Client::new()
+        .get(url)
+        .query(&SearchStatusRequest { file_id });
     let result = request.send().await?.json::<String>().await?;
     Ok(result)
 }

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -65,26 +65,29 @@ fn wheel_lines_to_jump(delta: f64, is_precise_scroll: bool) -> i32 {
     }
 }
 
-fn split_with_match_spans<'a>(line: &'a str, spans: &[(usize, usize)]) -> Vec<(&'a str, bool)> {
+fn split_with_match_spans<'a>(
+    line: &'a str,
+    spans: &[(usize, usize, bool)],
+) -> Vec<(&'a str, bool, bool)> {
     if spans.is_empty() {
-        return vec![(line, false)];
+        return vec![(line, false, false)];
     }
 
     let mut parts = Vec::new();
     let mut cursor = 0usize;
-    for (start, end) in spans {
+    for (start, end, is_current) in spans {
         let start = (*start).min(line.len());
         let end = (*end).min(line.len());
         if cursor < start {
-            parts.push((&line[cursor..start], false));
+            parts.push((&line[cursor..start], false, false));
         }
         if start < end {
-            parts.push((&line[start..end], true));
+            parts.push((&line[start..end], true, *is_current));
         }
         cursor = end;
     }
     if cursor < line.len() {
-        parts.push((&line[cursor..], false));
+        parts.push((&line[cursor..], false, false));
     }
     parts
 }
@@ -109,6 +112,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         selection_source,
         set_selected_line_source,
         set_active_pane,
+        focus_request,
         ..
     } = context;
 
@@ -206,6 +210,9 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
     let on_key_down = move |ev: KeyboardEvent| {
         set_active_pane.set(selection_source);
         let key = ev.key();
+        if (ev.ctrl_key() || ev.meta_key()) && key.eq_ignore_ascii_case("f") {
+            return;
+        }
         if is_handled_key(&key) {
             ev.prevent_default();
             process_key(&key);
@@ -391,6 +398,17 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         }
     });
 
+    Effect::new(move || {
+        let request = focus_request.get();
+        if request == 0 || active_pane.get() != selection_source {
+            return;
+        }
+
+        if let Some(div) = div_ref.get() {
+            _ = div.focus();
+        }
+    });
+
     view! {
         <Transition>
             { move || Suspend::new(async move {
@@ -405,13 +423,17 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                         update_tail(page_result.start_line);
                     }
                     let lines = page_result.lines;
-                    let mut page_match_spans: HashMap<usize, Vec<(usize, usize)>> = HashMap::new();
+                    let mut page_match_spans: HashMap<usize, Vec<(usize, usize, bool)>> = HashMap::new();
                     if let Some(search) = page_result.search.as_ref() {
                         for search_match in &search.page_matches {
                             page_match_spans
                                 .entry(search_match.line_index + 1)
                                 .or_default()
-                                .push((search_match.start, search_match.end));
+                                .push((
+                                    search_match.start,
+                                    search_match.end,
+                                    search.current.as_ref() == Some(search_match),
+                                ));
                         }
                     }
                     view! {
@@ -444,9 +466,10 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                                         class:selected=move || selected_line.get() == Some(line_number)
                                         on:click=move |_| select_line(line_number)
                                     >
-                                        {chunks.into_iter().map(|(chunk, highlighted)| {
+                                        {chunks.into_iter().map(|(chunk, highlighted, is_current)| {
                                             if highlighted {
-                                                view! { <mark>{chunk.to_string()}</mark> }.into_any()
+                                                let class = if is_current { "search-match search-match-current" } else { "search-match" };
+                                                view! { <mark class=class>{chunk.to_string()}</mark> }.into_any()
                                             } else {
                                                 view! { <span>{chunk.to_string()}</span> }.into_any()
                                             }
@@ -514,8 +537,15 @@ mod tests {
 
     #[test]
     fn split_with_match_spans_marks_multiple_occurrences() {
-        let parts = split_with_match_spans("foo bar foo", &[(0, 3), (8, 11)]);
-        assert_eq!(parts, vec![("foo", true), (" bar ", false), ("foo", true)]);
+        let parts = split_with_match_spans("foo bar foo", &[(0, 3, false), (8, 11, true)]);
+        assert_eq!(
+            parts,
+            vec![
+                ("foo", true, false),
+                (" bar ", false, false),
+                ("foo", true, true)
+            ]
+        );
     }
 
     #[test]

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -1,5 +1,5 @@
 use crate::components::context::{
-    ActivePaneContext, LogFileContext, LogViewContext, SelectionSource,
+    ActivePaneContext, LogContentFocusContext, LogFileContext, LogViewContext, SelectionSource,
 };
 use crate::components::diagnostics::{scroll_trace, scroll_trace_enabled};
 use crate::components::layout::{
@@ -112,11 +112,12 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         selection_source,
         set_selected_line_source,
         set_active_pane,
-        focus_request,
         ..
     } = context;
 
     let ActivePaneContext { active_pane, .. } = use_context().expect("ActivePaneContext not found");
+    let LogContentFocusContext { focus_request, .. } =
+        use_context().expect("LogContentFocusContext not found");
 
     let select_line = move |line_number| {
         set_active_pane.set(selection_source);
@@ -400,12 +401,17 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
 
     Effect::new(move || {
         let request = focus_request.get();
-        if request == 0 || active_pane.get() != selection_source {
+        if request == 0
+            || active_pane.get() != selection_source
+            || selection_source != SelectionSource::Main
+        {
             return;
         }
 
         if let Some(div) = div_ref.get() {
-            _ = div.focus();
+            request_animation_frame(move || {
+                _ = div.focus();
+            });
         }
     });
 

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -132,6 +132,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
     let (debounce, set_debounce) = signal(None::<TimeoutHandle>);
     let (wheel_event_id, set_wheel_event_id) = signal(0_u64);
     let (page_result, set_page_result) = signal(None::<PageResult>);
+    let (last_handled_focus_request, set_last_handled_focus_request) = signal(0_u64);
     let scroll_trace = scroll_trace_enabled();
 
     let is_at_end = move |result: &PageResult| {
@@ -401,13 +402,17 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
 
     Effect::new(move || {
         let request = focus_request.get();
-        if request == 0
-            || active_pane.get() != selection_source
+        if request == 0 || request == last_handled_focus_request.get_untracked() {
+            return;
+        }
+
+        if active_pane.get_untracked() != selection_source
             || selection_source != SelectionSource::Main
         {
             return;
         }
 
+        set_last_handled_focus_request.set(request);
         if let Some(div) = div_ref.get() {
             request_animation_frame(move || {
                 _ = div.focus();

--- a/logmancer-web/src/components/context.rs
+++ b/logmancer-web/src/components/context.rs
@@ -28,9 +28,29 @@ pub struct ActivePaneContext {
 }
 
 #[derive(Clone)]
-pub struct SearchShortcutContext {
-    pub open_request: ReadSignal<u64>,
-    pub close_request: ReadSignal<u64>,
+pub struct SearchUiContext {
+    pub visible: ReadSignal<bool>,
+    pub query: ReadSignal<String>,
+    pub set_query: WriteSignal<String>,
+    pub status: ReadSignal<String>,
+    pub set_status: WriteSignal<String>,
+    pub focus_request: ReadSignal<u64>,
+    pub request_focus: WriteSignal<u64>,
+    pub request_close: WriteSignal<u64>,
+}
+
+#[derive(Clone)]
+pub struct SearchCommandContext {
+    pub submit_request: ReadSignal<u64>,
+    pub request_submit: WriteSignal<u64>,
+    pub clear_request: ReadSignal<u64>,
+    pub request_clear: WriteSignal<u64>,
+}
+
+#[derive(Clone)]
+pub struct LogContentFocusContext {
+    pub focus_request: ReadSignal<u64>,
+    pub request_focus: WriteSignal<u64>,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -52,5 +72,4 @@ pub struct LogViewContext {
     pub selection_source: SelectionSource,
     pub set_selected_line_source: WriteSignal<SelectionSource>,
     pub set_active_pane: WriteSignal<SelectionSource>,
-    pub focus_request: ReadSignal<u64>,
 }

--- a/logmancer-web/src/components/context.rs
+++ b/logmancer-web/src/components/context.rs
@@ -27,6 +27,12 @@ pub struct ActivePaneContext {
     pub set_active_pane: WriteSignal<SelectionSource>,
 }
 
+#[derive(Clone)]
+pub struct SearchShortcutContext {
+    pub open_request: ReadSignal<u64>,
+    pub close_request: ReadSignal<u64>,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SelectionSource {
     Main,
@@ -46,4 +52,5 @@ pub struct LogViewContext {
     pub selection_source: SelectionSource,
     pub set_selected_line_source: WriteSignal<SelectionSource>,
     pub set_active_pane: WriteSignal<SelectionSource>,
+    pub focus_request: ReadSignal<u64>,
 }

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -37,8 +37,6 @@ pub fn FilterPane() -> impl IntoView {
 
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
-    let (focus_request, _) = signal(0_u64);
-
     let filter_page = LocalResource::new(move || {
         let file_id = file_id.get();
         let start = start_line.get();
@@ -66,7 +64,6 @@ pub fn FilterPane() -> impl IntoView {
         selection_source: SelectionSource::Filter,
         set_selected_line_source,
         set_active_pane,
-        focus_request,
     };
 
     let on_input = move |ev: leptos::ev::Event| {

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -37,6 +37,7 @@ pub fn FilterPane() -> impl IntoView {
 
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
+    let (focus_request, _) = signal(0_u64);
 
     let filter_page = LocalResource::new(move || {
         let file_id = file_id.get();
@@ -65,6 +66,7 @@ pub fn FilterPane() -> impl IntoView {
         selection_source: SelectionSource::Filter,
         set_selected_line_source,
         set_active_pane,
+        focus_request,
     };
 
     let on_input = move |ev: leptos::ev::Event| {

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -1,14 +1,20 @@
 use crate::components::context::{
-    ActivePaneContext, LogFileContext, SearchShortcutContext, SelectionContext, SelectionSource,
+    ActivePaneContext, LogContentFocusContext, LogFileContext, SearchCommandContext,
+    SearchUiContext, SelectionContext, SelectionSource,
 };
 use crate::components::filter_pane::FilterPane;
 use crate::components::main_pane::MainPane;
-use leptos::ev::KeyboardEvent;
+use crate::components::search_panel::SearchPanel;
+#[cfg(target_arch = "wasm32")]
+use leptos::ev::{keydown, KeyboardEvent};
 use leptos::html;
 use leptos::prelude::*;
+#[cfg(target_arch = "wasm32")]
 use leptos::wasm_bindgen::JsCast;
 use leptos::{component, view, IntoView};
 use leptos_router::hooks::use_params_map;
+#[cfg(target_arch = "wasm32")]
+use leptos_use::use_event_listener;
 
 #[component]
 pub fn LogView() -> impl IntoView {
@@ -20,38 +26,73 @@ pub fn LogView() -> impl IntoView {
     let (active_pane, set_active_pane) = signal(SelectionSource::Main);
     let (filter_height_percent, set_filter_height_percent) = signal(30.0_f64);
     let (is_resizing, set_is_resizing) = signal(false);
-    let (search_open_request, set_search_open_request) = signal(0_u64);
-    let (search_close_request, set_search_close_request) = signal(0_u64);
+    let (search_panel_visible, set_search_panel_visible) = signal(false);
+    let (search_query, set_search_query) = signal(String::new());
+    let (search_status, set_search_status) = signal(String::new());
+    let (search_focus_request, request_search_focus) = signal(0_u64);
+    let (search_close_request, request_search_close) = signal(0_u64);
+    let (search_submit_request, request_search_submit) = signal(0_u64);
+    let (search_clear_request, request_search_clear) = signal(0_u64);
+    let (log_content_focus_request, request_log_content_focus) = signal(0_u64);
     let log_view_ref: NodeRef<html::Div> = NodeRef::new();
 
-    let on_key_down = move |ev: KeyboardEvent| {
-        let target = ev
-            .target()
-            .and_then(|target| target.dyn_into::<leptos::web_sys::HtmlElement>().ok());
-        let is_editable_target = target
-            .as_ref()
-            .map(|element| {
-                matches!(element.tag_name().as_str(), "INPUT" | "TEXTAREA" | "SELECT")
-                    || element
-                        .get_attribute("contenteditable")
-                        .map(|value| value.eq_ignore_ascii_case("true") || value.is_empty())
-                        .unwrap_or(false)
-            })
-            .unwrap_or(false);
-        let opens_with_slash = ev.key() == "/" && !ev.ctrl_key() && !ev.meta_key() && !ev.alt_key();
-        let opens_with_find =
-            (ev.ctrl_key() || ev.meta_key()) && ev.key().eq_ignore_ascii_case("f");
+    let focus_main_content = move || {
+        set_active_pane.set(SelectionSource::Main);
+        request_log_content_focus.update(|request| *request = request.saturating_add(1));
+    };
 
-        if ev.key() == "Escape" {
-            set_search_close_request.update(|request| *request = request.saturating_add(1));
-            return;
-        }
+    #[cfg(target_arch = "wasm32")]
+    let open_search_panel = move || {
+        set_search_panel_visible.set(true);
+        set_search_status.set(String::new());
+        request_search_focus.update(|request| *request = request.saturating_add(1));
+    };
 
-        if opens_with_find || (opens_with_slash && !is_editable_target) {
-            ev.prevent_default();
-            set_search_open_request.update(|request| *request = request.saturating_add(1));
+    let close_search_panel = move || {
+        set_search_panel_visible.set(false);
+        set_search_status.set(String::new());
+        focus_main_content();
+
+        if let Some(log_view) = log_view_ref.get() {
+            request_animation_frame(move || {
+                _ = log_view.focus();
+            });
         }
     };
+
+    #[cfg(target_arch = "wasm32")]
+    let _search_shortcut_cleanup =
+        use_event_listener(web_sys::window(), keydown, move |ev: KeyboardEvent| {
+            let target = ev
+                .target()
+                .and_then(|target| target.dyn_into::<leptos::web_sys::HtmlElement>().ok());
+            let is_editable_target = target
+                .as_ref()
+                .map(|element| {
+                    matches!(element.tag_name().as_str(), "INPUT" | "TEXTAREA" | "SELECT")
+                        || element
+                            .get_attribute("contenteditable")
+                            .map(|value| value.eq_ignore_ascii_case("true") || value.is_empty())
+                            .unwrap_or(false)
+                })
+                .unwrap_or(false);
+            let opens_with_slash =
+                ev.key() == "/" && !ev.ctrl_key() && !ev.meta_key() && !ev.alt_key();
+            let opens_with_find =
+                (ev.ctrl_key() || ev.meta_key()) && ev.key().eq_ignore_ascii_case("f");
+
+            if ev.key() == "Escape" {
+                if search_panel_visible.get_untracked() {
+                    request_search_close.update(|request| *request = request.saturating_add(1));
+                }
+                return;
+            }
+
+            if opens_with_find || (opens_with_slash && !is_editable_target) {
+                ev.prevent_default();
+                open_search_panel();
+            }
+        });
 
     let update_split = move |event: leptos::ev::PointerEvent| {
         if !is_resizing.get() {
@@ -94,9 +135,36 @@ pub fn LogView() -> impl IntoView {
         set_active_pane,
     });
 
-    provide_context(SearchShortcutContext {
-        open_request: search_open_request,
-        close_request: search_close_request,
+    provide_context(SearchUiContext {
+        visible: search_panel_visible,
+        query: search_query,
+        set_query: set_search_query,
+        status: search_status,
+        set_status: set_search_status,
+        focus_request: search_focus_request,
+        request_focus: request_search_focus,
+        request_close: request_search_close,
+    });
+
+    provide_context(SearchCommandContext {
+        submit_request: search_submit_request,
+        request_submit: request_search_submit,
+        clear_request: search_clear_request,
+        request_clear: request_search_clear,
+    });
+
+    provide_context(LogContentFocusContext {
+        focus_request: log_content_focus_request,
+        request_focus: request_log_content_focus,
+    });
+
+    Effect::new(move || {
+        let request = search_close_request.get();
+        if request == 0 || !search_panel_visible.get_untracked() {
+            return;
+        }
+
+        close_search_panel();
     });
 
     view! {
@@ -112,7 +180,7 @@ pub fn LogView() -> impl IntoView {
             on:pointermove=update_split
             on:pointerup=move |_| set_is_resizing.set(false)
             on:pointerleave=move |_| set_is_resizing.set(false)
-            on:keydown=on_key_down
+            tabindex="0"
         >
             <div
                 class=move || {
@@ -145,6 +213,7 @@ pub fn LogView() -> impl IntoView {
             >
                 <FilterPane />
             </div>
+            <SearchPanel />
         </div>
     }
 }

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -1,10 +1,12 @@
 use crate::components::context::{
-    ActivePaneContext, LogFileContext, SelectionContext, SelectionSource,
+    ActivePaneContext, LogFileContext, SearchShortcutContext, SelectionContext, SelectionSource,
 };
 use crate::components::filter_pane::FilterPane;
 use crate::components::main_pane::MainPane;
+use leptos::ev::KeyboardEvent;
 use leptos::html;
 use leptos::prelude::*;
+use leptos::wasm_bindgen::JsCast;
 use leptos::{component, view, IntoView};
 use leptos_router::hooks::use_params_map;
 
@@ -18,7 +20,38 @@ pub fn LogView() -> impl IntoView {
     let (active_pane, set_active_pane) = signal(SelectionSource::Main);
     let (filter_height_percent, set_filter_height_percent) = signal(30.0_f64);
     let (is_resizing, set_is_resizing) = signal(false);
+    let (search_open_request, set_search_open_request) = signal(0_u64);
+    let (search_close_request, set_search_close_request) = signal(0_u64);
     let log_view_ref: NodeRef<html::Div> = NodeRef::new();
+
+    let on_key_down = move |ev: KeyboardEvent| {
+        let target = ev
+            .target()
+            .and_then(|target| target.dyn_into::<leptos::web_sys::HtmlElement>().ok());
+        let is_editable_target = target
+            .as_ref()
+            .map(|element| {
+                matches!(element.tag_name().as_str(), "INPUT" | "TEXTAREA" | "SELECT")
+                    || element
+                        .get_attribute("contenteditable")
+                        .map(|value| value.eq_ignore_ascii_case("true") || value.is_empty())
+                        .unwrap_or(false)
+            })
+            .unwrap_or(false);
+        let opens_with_slash = ev.key() == "/" && !ev.ctrl_key() && !ev.meta_key() && !ev.alt_key();
+        let opens_with_find =
+            (ev.ctrl_key() || ev.meta_key()) && ev.key().eq_ignore_ascii_case("f");
+
+        if ev.key() == "Escape" {
+            set_search_close_request.update(|request| *request = request.saturating_add(1));
+            return;
+        }
+
+        if opens_with_find || (opens_with_slash && !is_editable_target) {
+            ev.prevent_default();
+            set_search_open_request.update(|request| *request = request.saturating_add(1));
+        }
+    };
 
     let update_split = move |event: leptos::ev::PointerEvent| {
         if !is_resizing.get() {
@@ -61,6 +94,11 @@ pub fn LogView() -> impl IntoView {
         set_active_pane,
     });
 
+    provide_context(SearchShortcutContext {
+        open_request: search_open_request,
+        close_request: search_close_request,
+    });
+
     view! {
         <div
             node_ref=log_view_ref
@@ -74,6 +112,7 @@ pub fn LogView() -> impl IntoView {
             on:pointermove=update_split
             on:pointerup=move |_| set_is_resizing.set(false)
             on:pointerleave=move |_| set_is_resizing.set(false)
+            on:keydown=on_key_down
         >
             <div
                 class=move || {

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -100,7 +100,7 @@ pub fn MainPane() -> impl IntoView {
     };
 
     let clear_current_search = move || {
-        let file_id = file_id.get();
+        let file_id = file_id.get_untracked();
 
         spawn_local(async move {
             clear_search(file_id).await.ok();
@@ -112,9 +112,9 @@ pub fn MainPane() -> impl IntoView {
     };
 
     let submit_search = move || {
-        let query = search_query.get().trim().to_string();
-        let file_id = file_id.get();
-        let max_lines = page_size.get();
+        let query = search_query.get_untracked().trim().to_string();
+        let file_id = file_id.get_untracked();
+        let max_lines = page_size.get_untracked();
 
         if query.is_empty() {
             clear_current_search();

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -3,12 +3,11 @@ use crate::components::auto_scroll_status::AutoScrollStatus;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
 use crate::components::context::{
-    ActivePaneContext, LogFileContext, LogViewContext, SearchShortcutContext, SelectionContext,
-    SelectionSource,
+    ActivePaneContext, LogContentFocusContext, LogFileContext, LogViewContext,
+    SearchCommandContext, SearchUiContext, SelectionContext, SelectionSource,
 };
 use crate::components::layout::LOG_LINE_HEIGHT_PX;
 use crate::components::pane_index_progress::PaneIndexProgress;
-use crate::components::search_panel::SearchPanel;
 use leptos::context::use_context;
 use leptos::html::Div;
 use leptos::leptos_dom::log;
@@ -49,10 +48,20 @@ pub fn MainPane() -> impl IntoView {
         active_pane,
         set_active_pane,
     } = use_context().expect("ActivePaneContext not found");
-    let SearchShortcutContext {
-        open_request: search_open_request,
-        close_request: search_close_request,
-    } = use_context().expect("SearchShortcutContext not found");
+    let SearchUiContext {
+        query: search_query,
+        set_status: set_search_status,
+        ..
+    } = use_context().expect("SearchUiContext not found");
+    let SearchCommandContext {
+        submit_request: search_submit_request,
+        clear_request: search_clear_request,
+        ..
+    } = use_context().expect("SearchCommandContext not found");
+    let LogContentFocusContext {
+        request_focus: request_log_content_focus,
+        ..
+    } = use_context().expect("LogContentFocusContext not found");
 
     let div_ref = NodeRef::<Div>::new();
     let (content_width, set_content_width) = signal(2048_f64);
@@ -61,11 +70,6 @@ pub fn MainPane() -> impl IntoView {
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
-    let (focus_request, set_focus_request) = signal(0_u64);
-    let (search_panel_visible, set_search_panel_visible) = signal(false);
-    let (search_text, set_search_text) = signal(String::new());
-    let (search_status, set_search_status) = signal(String::new());
-    let (search_focus_request, set_search_focus_request) = signal(0_u64);
     let log_page = LocalResource::new(move || {
         fetch_page(
             file_id.get(),
@@ -88,33 +92,32 @@ pub fn MainPane() -> impl IntoView {
         selection_source: SelectionSource::Main,
         set_selected_line_source,
         set_active_pane,
-        focus_request,
     };
 
     let return_focus_to_main = move || {
         set_active_pane.set(SelectionSource::Main);
-        set_focus_request.update(|request| *request = request.saturating_add(1));
+        request_log_content_focus.update(|request| *request = request.saturating_add(1));
     };
 
-    let close_search_panel = move || {
-        set_search_panel_visible.set(false);
-        set_search_status.set(String::new());
-        return_focus_to_main();
+    let clear_current_search = move || {
+        let file_id = file_id.get();
+
+        spawn_local(async move {
+            clear_search(file_id).await.ok();
+            set_selected_original_line.set(None);
+            set_start_line.notify();
+            set_search_status.set(String::new());
+            return_focus_to_main();
+        });
     };
 
     let submit_search = move || {
-        let query = search_text.get().trim().to_string();
+        let query = search_query.get().trim().to_string();
         let file_id = file_id.get();
         let max_lines = page_size.get();
 
         if query.is_empty() {
-            spawn_local(async move {
-                clear_search(file_id).await.ok();
-                set_selected_original_line.set(None);
-                set_start_line.notify();
-                set_search_status.set(String::new());
-                return_focus_to_main();
-            });
+            clear_current_search();
             return;
         }
 
@@ -163,23 +166,21 @@ pub fn MainPane() -> impl IntoView {
     });
 
     Effect::new(move || {
-        let request = search_open_request.get();
+        let request = search_submit_request.get();
         if request == 0 {
             return;
         }
 
-        set_search_panel_visible.set(true);
-        set_search_status.set(String::new());
-        set_search_focus_request.update(|request| *request = request.saturating_add(1));
+        submit_search();
     });
 
     Effect::new(move || {
-        let request = search_close_request.get();
-        if request == 0 || !search_panel_visible.get() {
+        let request = search_clear_request.get();
+        if request == 0 {
             return;
         }
 
-        close_search_panel();
+        clear_current_search();
     });
 
     Effect::new(move || {
@@ -217,16 +218,6 @@ pub fn MainPane() -> impl IntoView {
                 <ContentScroll context=log_view_context.clone() />
             </div>
             <AutoScrollStatus />
-            <SearchPanel
-                visible=search_panel_visible
-                text=search_text
-                set_text=set_search_text
-                status=search_status
-                set_status=set_search_status
-                focus_request=search_focus_request
-                on_submit=submit_search
-                on_close=close_search_panel
-            />
         </div>
     }
 }

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -1,16 +1,19 @@
-use crate::components::async_functions::fetch_page;
+use crate::components::async_functions::{apply_search, clear_search, fetch_page};
 use crate::components::auto_scroll_status::AutoScrollStatus;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
 use crate::components::context::{
-    ActivePaneContext, LogFileContext, LogViewContext, SelectionContext, SelectionSource,
+    ActivePaneContext, LogFileContext, LogViewContext, SearchShortcutContext, SelectionContext,
+    SelectionSource,
 };
 use crate::components::layout::LOG_LINE_HEIGHT_PX;
 use crate::components::pane_index_progress::PaneIndexProgress;
+use crate::components::search_panel::SearchPanel;
 use leptos::context::use_context;
 use leptos::html::Div;
 use leptos::leptos_dom::log;
 use leptos::prelude::*;
+use leptos::task::spawn_local;
 use leptos::{component, view, IntoView};
 use leptos_use::use_resize_observer;
 
@@ -46,6 +49,10 @@ pub fn MainPane() -> impl IntoView {
         active_pane,
         set_active_pane,
     } = use_context().expect("ActivePaneContext not found");
+    let SearchShortcutContext {
+        open_request: search_open_request,
+        close_request: search_close_request,
+    } = use_context().expect("SearchShortcutContext not found");
 
     let div_ref = NodeRef::<Div>::new();
     let (content_width, set_content_width) = signal(2048_f64);
@@ -54,6 +61,11 @@ pub fn MainPane() -> impl IntoView {
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
+    let (focus_request, set_focus_request) = signal(0_u64);
+    let (search_panel_visible, set_search_panel_visible) = signal(false);
+    let (search_text, set_search_text) = signal(String::new());
+    let (search_status, set_search_status) = signal(String::new());
+    let (search_focus_request, set_search_focus_request) = signal(0_u64);
     let log_page = LocalResource::new(move || {
         fetch_page(
             file_id.get(),
@@ -76,6 +88,64 @@ pub fn MainPane() -> impl IntoView {
         selection_source: SelectionSource::Main,
         set_selected_line_source,
         set_active_pane,
+        focus_request,
+    };
+
+    let return_focus_to_main = move || {
+        set_active_pane.set(SelectionSource::Main);
+        set_focus_request.update(|request| *request = request.saturating_add(1));
+    };
+
+    let close_search_panel = move || {
+        set_search_panel_visible.set(false);
+        set_search_status.set(String::new());
+        return_focus_to_main();
+    };
+
+    let submit_search = move || {
+        let query = search_text.get().trim().to_string();
+        let file_id = file_id.get();
+        let max_lines = page_size.get();
+
+        if query.is_empty() {
+            spawn_local(async move {
+                clear_search(file_id).await.ok();
+                set_selected_original_line.set(None);
+                set_start_line.notify();
+                set_search_status.set(String::new());
+                return_focus_to_main();
+            });
+            return;
+        }
+
+        set_search_status.set("Searching...".to_string());
+        spawn_local(async move {
+            match apply_search(file_id, query, max_lines).await {
+                Ok(page) => {
+                    set_tail.set(false);
+                    set_follow.set(false);
+                    set_start_line.set(page.start_line);
+                    set_start_line.notify();
+
+                    let selected_match = page
+                        .search
+                        .as_ref()
+                        .and_then(|search| search.current.as_ref().or(search.first.as_ref()))
+                        .cloned();
+                    if let Some(search_match) = selected_match {
+                        set_selected_line_source.set(SelectionSource::Main);
+                        set_selected_original_line.set(Some(search_match.line_index + 1));
+                    }
+
+                    set_search_status.set(String::new());
+                    return_focus_to_main();
+                }
+                Err(_) => {
+                    set_search_status.set("Search failed".to_string());
+                    return_focus_to_main();
+                }
+            }
+        });
     };
 
     Effect::new(move || {
@@ -90,6 +160,26 @@ pub fn MainPane() -> impl IntoView {
             set_follow.set(false);
             set_start_line.set(reveal_start_line);
         }
+    });
+
+    Effect::new(move || {
+        let request = search_open_request.get();
+        if request == 0 {
+            return;
+        }
+
+        set_search_panel_visible.set(true);
+        set_search_status.set(String::new());
+        set_search_focus_request.update(|request| *request = request.saturating_add(1));
+    });
+
+    Effect::new(move || {
+        let request = search_close_request.get();
+        if request == 0 || !search_panel_visible.get() {
+            return;
+        }
+
+        close_search_panel();
     });
 
     Effect::new(move || {
@@ -127,6 +217,16 @@ pub fn MainPane() -> impl IntoView {
                 <ContentScroll context=log_view_context.clone() />
             </div>
             <AutoScrollStatus />
+            <SearchPanel
+                visible=search_panel_visible
+                text=search_text
+                set_text=set_search_text
+                status=search_status
+                set_status=set_search_status
+                focus_request=search_focus_request
+                on_submit=submit_search
+                on_close=close_search_panel
+            />
         </div>
     }
 }

--- a/logmancer-web/src/components/mod.rs
+++ b/logmancer-web/src/components/mod.rs
@@ -12,6 +12,7 @@ mod log_view;
 mod main_pane;
 mod pane_index_progress;
 mod progress_bar;
+mod search_panel;
 mod server_file_spotlight;
 
 pub use app::App;

--- a/logmancer-web/src/components/search_panel.rs
+++ b/logmancer-web/src/components/search_panel.rs
@@ -1,35 +1,52 @@
+use crate::components::context::{SearchCommandContext, SearchUiContext};
 use leptos::ev::KeyboardEvent;
 use leptos::html::Input;
 use leptos::prelude::*;
 use leptos::{component, view, IntoView};
 
 #[component]
-pub fn SearchPanel(
-    visible: ReadSignal<bool>,
-    text: ReadSignal<String>,
-    set_text: WriteSignal<String>,
-    status: ReadSignal<String>,
-    set_status: WriteSignal<String>,
-    focus_request: ReadSignal<u64>,
-    on_submit: impl Fn() + Copy + Send + Sync + 'static,
-    on_close: impl Fn() + Copy + Send + Sync + 'static,
-) -> impl IntoView {
+pub fn SearchPanel() -> impl IntoView {
+    let SearchUiContext {
+        visible,
+        query,
+        set_query,
+        status,
+        set_status,
+        focus_request,
+        request_focus: request_search_focus,
+        request_close,
+        ..
+    } = use_context().expect("SearchUiContext not found");
+    let SearchCommandContext {
+        request_submit,
+        request_clear,
+        ..
+    } = use_context().expect("SearchCommandContext not found");
     let input_ref = NodeRef::<Input>::new();
+
+    let close_panel = move || request_close.update(|request| *request = request.saturating_add(1));
 
     let on_key_down = move |ev: KeyboardEvent| match ev.key().as_str() {
         "Enter" => {
             ev.prevent_default();
-            on_submit();
+            ev.stop_propagation();
+            // Empty submissions are explicit clear commands; MainPane owns backend state changes.
+            if query.get().trim().is_empty() {
+                request_clear.update(|request| *request = request.saturating_add(1));
+            } else {
+                request_submit.update(|request| *request = request.saturating_add(1));
+            }
         }
         "Escape" => {
             ev.prevent_default();
-            on_close();
+            ev.stop_propagation();
+            close_panel();
         }
         _ => (),
     };
 
     let on_input = move |ev| {
-        set_text.set(event_target_value(&ev));
+        set_query.set(event_target_value(&ev));
         set_status.set(String::new());
     };
 
@@ -48,26 +65,36 @@ pub fn SearchPanel(
     });
 
     view! {
-        <Show when=move || visible.get()>
-            <div class="search-panel" role="search">
-                <span class="search-panel__prefix">"/"</span>
-                <input
-                    node_ref=input_ref
-                    type="text"
-                    class="search-panel__input"
-                    placeholder="Search logs"
-                    value=text
-                    on:input=on_input
-                    on:keydown=on_key_down
-                />
-                <span class="search-panel__status" aria-live="polite">{move || status.get()}</span>
-                <button
-                    type="button"
-                    class="search-panel__close"
-                    aria-label="Close search"
-                    on:click=move |_| on_close()
-                >"x"</button>
-            </div>
-        </Show>
+        <div
+            class="search-panel"
+            class:search-panel--hidden=move || !visible.get()
+            role="search"
+            aria-hidden=move || (!visible.get()).to_string()
+        >
+            <span
+                class="search-panel__prefix"
+                on:click=move |_| {
+                    request_search_focus.update(|request| *request = request.saturating_add(1));
+                }
+            >"/"</span>
+            <input
+                node_ref=input_ref
+                type="text"
+                class="search-panel__input"
+                placeholder="Search logs"
+                value=query
+                tabindex=move || if visible.get() { "0" } else { "-1" }
+                on:input=on_input
+                on:keydown=on_key_down
+            />
+            <span class="search-panel__status" aria-live="polite">{move || status.get()}</span>
+            <button
+                type="button"
+                class="search-panel__close"
+                aria-label="Close search"
+                tabindex=move || if visible.get() { "0" } else { "-1" }
+                on:click=move |_| close_panel()
+            >"x"</button>
+        </div>
     }
 }

--- a/logmancer-web/src/components/search_panel.rs
+++ b/logmancer-web/src/components/search_panel.rs
@@ -1,0 +1,73 @@
+use leptos::ev::KeyboardEvent;
+use leptos::html::Input;
+use leptos::prelude::*;
+use leptos::{component, view, IntoView};
+
+#[component]
+pub fn SearchPanel(
+    visible: ReadSignal<bool>,
+    text: ReadSignal<String>,
+    set_text: WriteSignal<String>,
+    status: ReadSignal<String>,
+    set_status: WriteSignal<String>,
+    focus_request: ReadSignal<u64>,
+    on_submit: impl Fn() + Copy + Send + Sync + 'static,
+    on_close: impl Fn() + Copy + Send + Sync + 'static,
+) -> impl IntoView {
+    let input_ref = NodeRef::<Input>::new();
+
+    let on_key_down = move |ev: KeyboardEvent| match ev.key().as_str() {
+        "Enter" => {
+            ev.prevent_default();
+            on_submit();
+        }
+        "Escape" => {
+            ev.prevent_default();
+            on_close();
+        }
+        _ => (),
+    };
+
+    let on_input = move |ev| {
+        set_text.set(event_target_value(&ev));
+        set_status.set(String::new());
+    };
+
+    Effect::new(move || {
+        if !visible.get() {
+            return;
+        }
+        let _ = focus_request.get();
+
+        if let Some(input) = input_ref.get() {
+            request_animation_frame(move || {
+                _ = input.focus();
+                input.select();
+            });
+        }
+    });
+
+    view! {
+        <Show when=move || visible.get()>
+            <div class="search-panel" role="search">
+                <span class="search-panel__prefix">"/"</span>
+                <input
+                    node_ref=input_ref
+                    type="text"
+                    class="search-panel__input"
+                    placeholder="Search logs"
+                    value=text
+                    on:input=on_input
+                    on:keydown=on_key_down
+                />
+                <span class="search-panel__status" aria-live="polite">{move || status.get()}</span>
+                <button
+                    type="button"
+                    class="search-panel__close"
+                    aria-label="Close search"
+                    on:click=move |_| on_close()
+                >"x"</button>
+            </div>
+        </Show>
+    }
+}

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -375,6 +375,7 @@ body {
   font-size: var(--log-font-size);
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .content {
@@ -421,6 +422,77 @@ body {
 .text-lines div.selected {
   background: #dbeafe;
   box-shadow: inset 0 0 0 1px #93c5fd;
+}
+
+.search-match {
+  background: #fef08a;
+  color: inherit;
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.search-match-current {
+  background: #fb923c;
+  box-shadow: 0 0 0 1px rgba(194, 65, 12, 0.35);
+}
+
+.search-panel {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 9998;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  width: 100vw;
+  min-height: 34px;
+  padding: 4px 8px;
+  border-top: 1px solid #cbd5e1;
+  background: rgba(248, 250, 252, 0.97);
+  box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.12);
+}
+
+.search-panel__prefix {
+  color: #64748b;
+  font-weight: 700;
+}
+
+.search-panel__input {
+  flex: 0 1 min(460px, 55vw);
+  min-width: 0;
+  max-width: 460px;
+  border: 0;
+  outline: none;
+  background: transparent;
+  color: #111827;
+  font-family: var(--log-font-family);
+  font-size: var(--log-font-size);
+}
+
+.search-panel__status {
+  min-width: max-content;
+  color: #64748b;
+  font-size: 11px;
+}
+
+.search-panel__close {
+  width: 22px;
+  height: 22px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: #475569;
+  cursor: pointer;
+  font-family: var(--log-font-family);
+  line-height: 1;
+
+  &:hover,
+  &:focus-visible {
+    border-color: #cbd5e1;
+    background: #e2e8f0;
+  }
 }
 
 .scrollbar {

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -454,6 +454,11 @@ body {
   box-shadow: 0 -8px 24px rgba(15, 23, 42, 0.12);
 }
 
+.search-panel--hidden {
+  visibility: hidden;
+  pointer-events: none;
+}
+
 .search-panel__prefix {
   color: #64748b;
   font-weight: 700;


### PR DESCRIPTION
Closes #21

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds a fixed Web/Desktop search panel opened with `/` or `Ctrl+F`.
- Submits searches through the shared search API and highlights current-page matches.
- Keeps search UI state global in `LogView` with focused search/focus command contexts.

## Changes
| File | Change |
|------|--------|
| `logmancer-web/src/components/search_panel.rs` | Adds the search panel UI, input handling, close button, and focus behavior. |
| `logmancer-web/src/components/log_view.rs` | Owns global search UI state, shortcuts, and panel composition. |
| `logmancer-web/src/components/main_pane.rs` | Applies/clears global search and updates main log viewport/selection. |
| `logmancer-web/src/components/content_lines.rs` | Renders current-page search matches and stabilizes focus requests. |
| `logmancer-web/style/main.scss` | Styles the fixed bottom search panel and match highlights. |
| `docs/feature/shared-search-engine.md` | Documents issue #21 Web/Desktop search panel behavior. |
| `CHANGELOG.md` | Adds the user-facing search panel entry. |

## Review note
This PR is intentionally kept as one PR with maintainer-approved `size:exception` despite exceeding the 400-line review budget, because the feature behavior, context refactor, and focus fixes are tightly coupled and were validated together.

## Test Plan
- [x] `cargo fmt`
- [x] `cargo check -p logmancer-web`
- [x] `cargo test -p logmancer-web content_`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Manually tested search open/close/refocus behavior in Web/Desktop flow

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No scripts changed; shellcheck not applicable
- [x] Docs updated for behavior change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers