### PR TITLE
feat(web): add search match navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Shared core search engine with reusable `PageResult` search metadata (`PageSearchResult` + page-scoped match spans with multiple occurrences per line), less-style wrap navigation (`next`/`previous`), and stable match identity for frontend adapters.
 - Search API endpoints for web/desktop thin adapters (`apply-search`, `search-next`, `search-previous`, `search-status`, `clear-search`) backed directly by core semantics.
 - Web/desktop bottom search panel opened with `/` or `Ctrl+F`, backed by the shared search API and current-page match highlighting.
+- Web/desktop search match navigation with `n` and `N`, matching core/TUI wrap behavior and keeping the selected match visible (#23).
 - TUI search prompt opened with `/`, including submit/cancel handling and `n`/`N` next/previous match navigation using core behavior.
 
 ### Changed

--- a/docs/feature/shared-search-engine.md
+++ b/docs/feature/shared-search-engine.md
@@ -32,13 +32,15 @@ Issue #21 adds the Web/Desktop entry point for shared search. It should stay foc
 | Press `Ctrl+F` | Open the same search panel and focus the input. |
 | Type query | Update the input value without moving focus away from the search panel. |
 | Press `Enter` | Submit the query, run shared search, reveal or select the first returned match, keep the panel visible, then move focus back to the main log panel. |
+| Press `n` | Move to the next search match, keep the selected match visible, and return focus to the main log panel. |
+| Press `N` | Move to the previous search match, keep the selected match visible, and return focus to the main log panel. |
 | Press `Esc` | Close the search panel cleanly without submitting a new search. |
 | Click `x` | Close the search panel cleanly. |
 | Submit an empty query | Reset search cleanly without stale highlights while keeping the panel visible. |
 
 The panel is hidden by default. When visible, it is a compact fixed panel pinned to the bottom of the whole viewport/window. It spans the full window width, with the search input and `x` close button aligned on the right. The input receives focus immediately when opened or reopened with `/` or `Ctrl+F` so keyboard search works without an extra click. `Esc` and `x` are the only close interactions for issue #21; submitting with `Enter` leaves the panel visible.
 
-Navigation between matches with `n` / `N` is intentionally out of scope for issue #21 and belongs to issue #23. Issue #21 may introduce state that makes #23 straightforward, but it should not implement next/previous navigation behavior.
+Navigation between matches with `n` / `N` is implemented by issue #23. Web/Desktop should treat these shortcuts as main-view commands, not search-input commands: editable targets keep normal text entry behavior, while the main log view delegates next/previous movement to the shared search API.
 
 ## Response model
 
@@ -139,7 +141,7 @@ The worker may discover matches in circular scan order for responsiveness, but s
 - [ ] Web/Desktop `Esc` and `x` close the search panel cleanly.
 - [ ] Web/Desktop `Enter` submits search, keeps the panel visible, and returns focus to the main log panel.
 - [ ] Multiple matches per line are represented with line + span + ordinal.
-- [ ] `next` / `previous` navigation wraps in core/API; Web/Desktop `n` / `N` controls are intentionally deferred to issue #23.
+- [ ] `next` / `previous` navigation wraps in core/API; Web/Desktop expose it through `n` / `N` controls.
 - [ ] Scroll position does not change the selected current match.
 - [ ] Web/Desktop and TUI only render core-provided search metadata.
 - [ ] Large-file search work is batchable and does not require one long synchronous scan.

--- a/logmancer-web/src/components/async_functions.rs
+++ b/logmancer-web/src/components/async_functions.rs
@@ -1,7 +1,7 @@
 use crate::api::commons::{
     ApiError, ApplyFilterRequest, ApplySearchRequest, OpenServerFileResponse, ReadFilterRequest,
-    ReadPageRequest, SearchStatusRequest, ServerBrowserListRequest, ServerBrowserListResponse,
-    ServerBrowserOpenRequest, ServerBrowserStatusResponse, TailRequest,
+    ReadPageRequest, SearchNavigateRequest, SearchStatusRequest, ServerBrowserListRequest,
+    ServerBrowserListResponse, ServerBrowserOpenRequest, ServerBrowserStatusResponse, TailRequest,
 };
 use leptos::prelude::{window, ServerFnError};
 use leptos::wasm_bindgen::{JsCast, JsValue};
@@ -69,6 +69,29 @@ pub async fn clear_search(file_id: String) -> Result<String, ServerFnError> {
         .get(url)
         .query(&SearchStatusRequest { file_id });
     let result = request.send().await?.json::<String>().await?;
+    Ok(result)
+}
+
+pub async fn search_next(file_id: String, max_lines: usize) -> Result<PageResult, ServerFnError> {
+    let base = window().location().origin().unwrap();
+    let url = format!("{base}/api/search-next");
+    let request = reqwest::Client::new()
+        .get(url)
+        .query(&SearchNavigateRequest { file_id, max_lines });
+    let result = request.send().await?.json::<PageResult>().await?;
+    Ok(result)
+}
+
+pub async fn search_previous(
+    file_id: String,
+    max_lines: usize,
+) -> Result<PageResult, ServerFnError> {
+    let base = window().location().origin().unwrap();
+    let url = format!("{base}/api/search-previous");
+    let request = reqwest::Client::new()
+        .get(url)
+        .query(&SearchNavigateRequest { file_id, max_lines });
+    let result = request.send().await?.json::<PageResult>().await?;
     Ok(result)
 }
 

--- a/logmancer-web/src/components/context.rs
+++ b/logmancer-web/src/components/context.rs
@@ -45,6 +45,10 @@ pub struct SearchCommandContext {
     pub request_submit: WriteSignal<u64>,
     pub clear_request: ReadSignal<u64>,
     pub request_clear: WriteSignal<u64>,
+    pub next_request: ReadSignal<u64>,
+    pub previous_request: ReadSignal<u64>,
+    pub navigation_in_flight: ReadSignal<bool>,
+    pub set_navigation_in_flight: WriteSignal<bool>,
 }
 
 #[derive(Clone)]

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -16,6 +16,26 @@ use leptos_router::hooks::use_params_map;
 #[cfg(target_arch = "wasm32")]
 use leptos_use::use_event_listener;
 
+#[cfg(any(target_arch = "wasm32", test))]
+fn is_editable_element(tag_name: &str, content_editable: Option<&str>) -> bool {
+    matches!(tag_name, "INPUT" | "TEXTAREA" | "SELECT")
+        || content_editable
+            .map(|value| value.eq_ignore_ascii_case("true") || value.is_empty())
+            .unwrap_or(false)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_editable_target(target: Option<&leptos::web_sys::HtmlElement>) -> bool {
+    target
+        .map(|element| {
+            is_editable_element(
+                &element.tag_name(),
+                element.get_attribute("contenteditable").as_deref(),
+            ) || element.is_content_editable()
+        })
+        .unwrap_or(false)
+}
+
 #[component]
 pub fn LogView() -> impl IntoView {
     let file_id = Memo::new(move |_| use_params_map().get().get("id").unwrap_or_default());
@@ -33,6 +53,11 @@ pub fn LogView() -> impl IntoView {
     let (search_close_request, request_search_close) = signal(0_u64);
     let (search_submit_request, request_search_submit) = signal(0_u64);
     let (search_clear_request, request_search_clear) = signal(0_u64);
+    let (search_next_request, request_search_next) = signal(0_u64);
+    let (search_previous_request, request_search_previous) = signal(0_u64);
+    let (search_navigation_in_flight, set_search_navigation_in_flight) = signal(false);
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = (&request_search_next, &request_search_previous);
     let (log_content_focus_request, request_log_content_focus) = signal(0_u64);
     let log_view_ref: NodeRef<html::Div> = NodeRef::new();
 
@@ -66,20 +91,21 @@ pub fn LogView() -> impl IntoView {
             let target = ev
                 .target()
                 .and_then(|target| target.dyn_into::<leptos::web_sys::HtmlElement>().ok());
-            let is_editable_target = target
-                .as_ref()
-                .map(|element| {
-                    matches!(element.tag_name().as_str(), "INPUT" | "TEXTAREA" | "SELECT")
-                        || element
-                            .get_attribute("contenteditable")
-                            .map(|value| value.eq_ignore_ascii_case("true") || value.is_empty())
-                            .unwrap_or(false)
-                })
-                .unwrap_or(false);
+            let is_editable_target = is_editable_target(target.as_ref());
             let opens_with_slash =
                 ev.key() == "/" && !ev.ctrl_key() && !ev.meta_key() && !ev.alt_key();
             let opens_with_find =
                 (ev.ctrl_key() || ev.meta_key()) && ev.key().eq_ignore_ascii_case("f");
+            let search_next = ev.key() == "n"
+                && !is_editable_target
+                && !ev.ctrl_key()
+                && !ev.meta_key()
+                && !ev.alt_key();
+            let search_previous = ev.key() == "N"
+                && !is_editable_target
+                && !ev.ctrl_key()
+                && !ev.meta_key()
+                && !ev.alt_key();
 
             if ev.key() == "Escape" {
                 if search_panel_visible.get_untracked() {
@@ -91,6 +117,18 @@ pub fn LogView() -> impl IntoView {
             if opens_with_find || (opens_with_slash && !is_editable_target) {
                 ev.prevent_default();
                 open_search_panel();
+                return;
+            }
+
+            if search_next {
+                ev.prevent_default();
+                request_search_next.update(|request| *request = request.saturating_add(1));
+                return;
+            }
+
+            if search_previous {
+                ev.prevent_default();
+                request_search_previous.update(|request| *request = request.saturating_add(1));
             }
         });
 
@@ -151,6 +189,10 @@ pub fn LogView() -> impl IntoView {
         request_submit: request_search_submit,
         clear_request: search_clear_request,
         request_clear: request_search_clear,
+        next_request: search_next_request,
+        previous_request: search_previous_request,
+        navigation_in_flight: search_navigation_in_flight,
+        set_navigation_in_flight: set_search_navigation_in_flight,
     });
 
     provide_context(LogContentFocusContext {
@@ -215,5 +257,18 @@ pub fn LogView() -> impl IntoView {
             </div>
             <SearchPanel />
         </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_editable_element;
+
+    #[test]
+    fn editable_detection_matches_form_controls_and_contenteditable() {
+        assert!(is_editable_element("INPUT", None));
+        assert!(is_editable_element("TEXTAREA", None));
+        assert!(is_editable_element("DIV", Some("true")));
+        assert!(!is_editable_element("DIV", None));
     }
 }

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -1,4 +1,6 @@
-use crate::components::async_functions::{apply_search, clear_search, fetch_page};
+use crate::components::async_functions::{
+    apply_search, clear_search, fetch_page, search_next, search_previous,
+};
 use crate::components::auto_scroll_status::AutoScrollStatus;
 use crate::components::content_lines::ContentLines;
 use crate::components::content_scroll::ContentScroll;
@@ -15,6 +17,7 @@ use leptos::prelude::*;
 use leptos::task::spawn_local;
 use leptos::{component, view, IntoView};
 use leptos_use::use_resize_observer;
+use logmancer_core::PageResult;
 
 fn reveal_start_line_for_selected_line(selected_original_line: usize, page_size: usize) -> usize {
     if selected_original_line == 0 {
@@ -24,6 +27,29 @@ fn reveal_start_line_for_selected_line(selected_original_line: usize, page_size:
     let selected_zero_based = selected_original_line.saturating_sub(1);
     let center_offset = page_size / 2;
     selected_zero_based.saturating_sub(center_offset)
+}
+
+fn apply_search_page_result(
+    page: PageResult,
+    set_tail: WriteSignal<bool>,
+    set_follow: WriteSignal<bool>,
+    set_start_line: WriteSignal<usize>,
+    set_selected_original_line: WriteSignal<Option<usize>>,
+    set_selected_line_source: WriteSignal<SelectionSource>,
+) {
+    set_tail.set(false);
+    set_follow.set(false);
+    set_start_line.set(page.start_line);
+    set_start_line.notify();
+
+    let selected_match = page
+        .search
+        .as_ref()
+        .and_then(|search| search.current.as_ref().or(search.first.as_ref()))
+        .cloned();
+
+    set_selected_line_source.set(SelectionSource::Main);
+    set_selected_original_line.set(selected_match.map(|search_match| search_match.line_index + 1));
 }
 
 #[component]
@@ -56,6 +82,10 @@ pub fn MainPane() -> impl IntoView {
     let SearchCommandContext {
         submit_request: search_submit_request,
         clear_request: search_clear_request,
+        next_request: search_next_request,
+        previous_request: search_previous_request,
+        navigation_in_flight: search_navigation_in_flight,
+        set_navigation_in_flight: set_search_navigation_in_flight,
         ..
     } = use_context().expect("SearchCommandContext not found");
     let LogContentFocusContext {
@@ -70,6 +100,8 @@ pub fn MainPane() -> impl IntoView {
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let (indexing_progress, set_indexing_progress) = signal(0_f64);
+    let (handled_next_request, set_handled_next_request) = signal(0_u64);
+    let (handled_previous_request, set_handled_previous_request) = signal(0_u64);
     let log_page = LocalResource::new(move || {
         fetch_page(
             file_id.get(),
@@ -125,21 +157,14 @@ pub fn MainPane() -> impl IntoView {
         spawn_local(async move {
             match apply_search(file_id, query, max_lines).await {
                 Ok(page) => {
-                    set_tail.set(false);
-                    set_follow.set(false);
-                    set_start_line.set(page.start_line);
-                    set_start_line.notify();
-
-                    let selected_match = page
-                        .search
-                        .as_ref()
-                        .and_then(|search| search.current.as_ref().or(search.first.as_ref()))
-                        .cloned();
-                    if let Some(search_match) = selected_match {
-                        set_selected_line_source.set(SelectionSource::Main);
-                        set_selected_original_line.set(Some(search_match.line_index + 1));
-                    }
-
+                    apply_search_page_result(
+                        page,
+                        set_tail,
+                        set_follow,
+                        set_start_line,
+                        set_selected_original_line,
+                        set_selected_line_source,
+                    );
                     set_search_status.set(String::new());
                     return_focus_to_main();
                 }
@@ -148,6 +173,51 @@ pub fn MainPane() -> impl IntoView {
                     return_focus_to_main();
                 }
             }
+        });
+    };
+
+    let navigate_search = move |navigate_previous: bool| {
+        let file_id = file_id.get_untracked();
+        let max_lines = page_size.get_untracked();
+
+        set_search_navigation_in_flight.set(true);
+
+        set_search_status.set(if navigate_previous {
+            "Going to previous match...".to_string()
+        } else {
+            "Going to next match...".to_string()
+        });
+
+        spawn_local(async move {
+            let result = if navigate_previous {
+                search_previous(file_id, max_lines).await
+            } else {
+                search_next(file_id, max_lines).await
+            };
+
+            match result {
+                Ok(page) => {
+                    apply_search_page_result(
+                        page,
+                        set_tail,
+                        set_follow,
+                        set_start_line,
+                        set_selected_original_line,
+                        set_selected_line_source,
+                    );
+                    set_search_status.set(String::new());
+                }
+                Err(_) => {
+                    set_search_status.set(if navigate_previous {
+                        "Previous match unavailable".to_string()
+                    } else {
+                        "Next match unavailable".to_string()
+                    });
+                }
+            }
+
+            set_search_navigation_in_flight.set(false);
+            return_focus_to_main();
         });
     };
 
@@ -181,6 +251,38 @@ pub fn MainPane() -> impl IntoView {
         }
 
         clear_current_search();
+    });
+
+    Effect::new(move || {
+        let request = search_next_request.get();
+        let handled_request = handled_next_request.get();
+
+        if request == 0 || handled_request >= request {
+            return;
+        }
+
+        if search_navigation_in_flight.get() {
+            return;
+        }
+
+        set_handled_next_request.update(|handled| *handled = handled.saturating_add(1));
+        navigate_search(false);
+    });
+
+    Effect::new(move || {
+        let request = search_previous_request.get();
+        let handled_request = handled_previous_request.get();
+
+        if request == 0 || handled_request >= request {
+            return;
+        }
+
+        if search_navigation_in_flight.get() {
+            return;
+        }
+
+        set_handled_previous_request.update(|handled| *handled = handled.saturating_add(1));
+        navigate_search(true);
     });
 
     Effect::new(move || {


### PR DESCRIPTION
Closes #23

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Adds Web/Desktop `n` and `N` search match navigation backed by the shared search API.
- Keeps the selected match visible by updating viewport, search metadata, and selection together.
- Serializes repeated navigation requests to avoid concurrent backend search-state mutations.

## Changes
| File | Change |
|------|--------|
| `logmancer-web/src/components/async_functions.rs` | Adds client helpers for `search-next` and `search-previous`. |
| `logmancer-web/src/components/context.rs` | Extends search command context with navigation request and in-flight signals. |
| `logmancer-web/src/components/log_view.rs` | Adds `n` / `N` shortcuts outside editable targets. |
| `logmancer-web/src/components/main_pane.rs` | Executes navigation, updates visible page/selection, and serializes repeated requests. |
| `docs/feature/shared-search-engine.md` | Updates shared search docs now that issue #23 is implemented. |
| `CHANGELOG.md` | Adds the user-facing search navigation entry. |

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p logmancer-web`
- [x] `cargo clippy --workspace -- -D warnings`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts / not applicable: no scripts modified
- [x] Skills tested in at least one agent / not applicable: no skill changes
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
