### PR TITLE
feat(search): highlight visible matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Web/desktop bottom search panel opened with `/` or `Ctrl+F`, backed by the shared search API and current-page match highlighting.
 - Web/desktop search match navigation with `n` and `N`, matching core/TUI wrap behavior and keeping the selected match visible (#23).
 - TUI search prompt opened with `/`, including submit/cancel handling and `n`/`N` next/previous match navigation using core behavior.
+- Search match highlighting across Web/Desktop main and filtered views plus TUI visible lines, with a distinct current-match state (#24).
 
 ### Changed
 

--- a/docs/feature/shared-search-engine.md
+++ b/docs/feature/shared-search-engine.md
@@ -7,7 +7,7 @@ Logmancer search is a **core-owned capability** shared by Web, Desktop, and TUI:
 - Search behavior lives in `logmancer-core`, not in each client.
 - `PageResult` remains the primary page response and may include optional search metadata.
 - Web/Desktop expose search through a bottom search panel opened with `/` or `Ctrl+F`.
-- Clients render page-scoped match spans and highlight the current match.
+- Clients render view-scoped match spans and highlight the current match.
 - Navigation uses shared `next` / `previous` semantics with less-style wrapping.
 - Search matches support multiple occurrences per line.
 
@@ -17,6 +17,7 @@ Logmancer search is a **core-owned capability** shared by Web, Desktop, and TUI:
 |---|---|
 | Start a search | Core records the active query and begins searching from the current position. |
 | Read or scroll a page | The page response includes visible match spans when search is active. |
+| Read filtered results | The filtered page response includes search spans for the visible original log lines. |
 | Press next | Core moves to the next match and returns a page positioned around it. |
 | Press previous | Core moves to the previous match and returns a page positioned around it. |
 | Reach last/first match | Navigation wraps, matching less-style search behavior. |
@@ -61,7 +62,9 @@ PageResult {
 - total known matches,
 - current match index,
 - current match identity,
-- match spans for the visible page.
+- match spans for the visible page or filtered result set.
+
+For contiguous pages, core derives visible matches from the page range. For filtered views, visible rows can reference non-contiguous original log lines, so core projects the same search state onto the exact source line indexes returned by the filter page. Clients still receive a normal `PageSearchResult`; they do not need filter-specific search logic.
 
 ## Match identity
 
@@ -80,6 +83,7 @@ Clients are thin adapters:
 
 - Web/Desktop render all `page_matches` spans and emphasize the current one.
 - TUI renders visible matches and marks the current match.
+- Filtered views render core-provided search spans for the visible filtered rows.
 - Clients do not compute global search state or decide navigation order.
 
 This keeps UI rendering flexible while preventing each client from inventing different search semantics.
@@ -144,6 +148,7 @@ The worker may discover matches in circular scan order for responsiveness, but s
 - [ ] `next` / `previous` navigation wraps in core/API; Web/Desktop expose it through `n` / `N` controls.
 - [ ] Scroll position does not change the selected current match.
 - [ ] Web/Desktop and TUI only render core-provided search metadata.
+- [ ] Filtered pages include search metadata for visible non-contiguous source lines.
 - [ ] Large-file search work is batchable and does not require one long synchronous scan.
 - [ ] Search indexing starts from the current position and wraps to the beginning after EOF.
 - [ ] Clients show an indexing/searching state and poll until the first/current match is available.

--- a/logmancer-core/src/file_ops/read.rs
+++ b/logmancer-core/src/file_ops/read.rs
@@ -1,6 +1,7 @@
 use crate::models::log_file::LogFile;
 use crate::models::search::{PageSearchResult, SearchMatch, SearchStatus};
 use regex::Regex;
+use std::collections::HashSet;
 use std::io;
 use std::sync::RwLockReadGuard;
 
@@ -117,6 +118,27 @@ impl<'a> FileReadOps<'a> {
         })
     }
 
+    pub fn page_search_result_for_lines(&self, line_indexes: &[usize]) -> Option<PageSearchResult> {
+        let session = self.log_file.search.session.as_ref()?;
+        let visible_lines = line_indexes.iter().copied().collect::<HashSet<_>>();
+        let page_matches = session
+            .matches
+            .iter()
+            .filter(|m| visible_lines.contains(&m.line_index))
+            .cloned()
+            .collect::<Vec<SearchMatch>>();
+
+        Some(PageSearchResult {
+            query: session.query.clone(),
+            total_matches: session.matches.len(),
+            total_matches_final: session.total_matches_final,
+            is_indexing: !matches!(session.phase, crate::models::search::SearchPhase::Ready),
+            first: session.first_match.clone(),
+            current: session.current_match().cloned(),
+            page_matches,
+        })
+    }
+
     pub fn compute_search_batch(
         log_file: &LogFile,
         query: &str,
@@ -151,7 +173,17 @@ mod tests {
     use crate::models::log_file::LogFile;
     use std::fs::File;
     use std::io::Write;
+    use std::path::PathBuf;
     use std::sync::RwLock;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_file_path(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("logmancer-{prefix}-{unique}.log"))
+    }
 
     #[test]
     fn test_read_line() {
@@ -189,6 +221,52 @@ mod tests {
         assert_eq!(batch[0].line_index, 0);
         assert_eq!(batch[1].line_index, 0);
         assert_eq!(batch[2].line_index, 2);
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn page_search_result_for_lines_keeps_only_visible_matches() {
+        let path = temp_file_path("page-search-visible-lines");
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "foo").unwrap();
+        writeln!(file, "bar foo").unwrap();
+        writeln!(file, "baz").unwrap();
+
+        let log_file = RwLock::new(LogFile::new(path.to_string_lossy().into_owned()).unwrap());
+        let mut write_ops = FileWriteOps::new(std::sync::Arc::new(log_file));
+        while !write_ops.index_lines().unwrap() {}
+        write_ops.begin_search(1, "foo".to_string(), 0);
+        write_ops.merge_search_batch(
+            1,
+            vec![
+                SearchMatch {
+                    line_index: 0,
+                    start: 0,
+                    end: 3,
+                    ordinal: 0,
+                },
+                SearchMatch {
+                    line_index: 1,
+                    start: 4,
+                    end: 7,
+                    ordinal: 1,
+                },
+            ],
+            true,
+        );
+
+        let shared = write_ops.log_file();
+        let read_guard = shared.read().unwrap();
+        let read_ops = FileReadOps::new(read_guard);
+        let search = read_ops
+            .page_search_result_for_lines(&[1])
+            .expect("search metadata");
+
+        assert_eq!(search.page_matches.len(), 1);
+        assert_eq!(search.page_matches[0].line_index, 1);
+        assert_eq!(search.page_matches[0].start, 4);
+        assert_eq!(search.current.as_ref().map(|m| m.line_index), Some(0));
 
         std::fs::remove_file(path).unwrap();
     }

--- a/logmancer-core/src/reader.rs
+++ b/logmancer-core/src/reader.rs
@@ -94,10 +94,12 @@ impl LogReader {
         let mut matched_lines = 0;
         let mut current_line = 0;
         let mut lines = Vec::with_capacity(max_lines);
+        let mut visible_line_indexes = Vec::with_capacity(max_lines);
 
         while lines.len() < max_lines && current_line < processed_lines {
             if let Some(line) = read_ops.read_filter_line(current_line)? {
                 if matched_lines >= start_line {
+                    visible_line_indexes.push(current_line);
                     lines.push(PageLine {
                         number: current_line + 1,
                         text: line,
@@ -112,7 +114,7 @@ impl LogReader {
             start_line,
             total_lines,
             indexing_progress: read_ops.filter_indexing_progress()?,
-            search: None,
+            search: read_ops.page_search_result_for_lines(&visible_line_indexes),
         };
         self.current_view_start = page.start_line;
         Ok(page)
@@ -125,11 +127,13 @@ impl LogReader {
         }
         let read_ops = self.handler.read_ops();
         let mut lines = Vec::with_capacity(max_lines);
+        let mut visible_line_indexes = Vec::with_capacity(max_lines);
         let mut current_line = read_ops.total_lines()?;
 
         while lines.len() < max_lines && current_line > 0 {
             current_line -= 1;
             if let Some(line) = read_ops.read_filter_line(current_line)? {
+                visible_line_indexes.push(current_line);
                 lines.push(PageLine {
                     number: current_line + 1,
                     text: line,
@@ -137,12 +141,13 @@ impl LogReader {
             }
         }
         lines.reverse();
+        visible_line_indexes.reverse();
         let page = PageResult {
             lines,
             start_line: current_line,
             total_lines: read_ops.total_lines()?,
             indexing_progress: read_ops.filter_indexing_progress()?,
-            search: None,
+            search: read_ops.page_search_result_for_lines(&visible_line_indexes),
         };
         self.current_view_start = page.start_line;
         Ok(page)
@@ -246,6 +251,33 @@ mod tests {
                 text: "delta match".to_string(),
             }]
         );
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn read_filter_includes_search_matches_for_visible_filtered_lines() {
+        let path = temp_file_path("filter-search-highlights");
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "alpha foo").unwrap();
+        writeln!(file, "beta").unwrap();
+        writeln!(file, "gamma foo").unwrap();
+        writeln!(file, "delta").unwrap();
+        drop(file);
+
+        let mut reader = LogReader::new(path.to_string_lossy().into_owned()).unwrap();
+        reader.filter("foo".to_string());
+        reader.apply_search("foo".to_string(), 10).unwrap();
+        wait_search_ready(&reader);
+
+        let page = reader.read_filter(0, 10).unwrap();
+        let search = page.search.expect("filtered search metadata");
+
+        assert_eq!(page.lines.len(), 2);
+        assert_eq!(search.page_matches.len(), 2);
+        assert_eq!(search.page_matches[0].line_index, 0);
+        assert_eq!(search.page_matches[1].line_index, 2);
+        assert_eq!(search.current.as_ref().map(|m| m.line_index), Some(0));
 
         std::fs::remove_file(path).unwrap();
     }

--- a/logmancer-tui/src/main.rs
+++ b/logmancer-tui/src/main.rs
@@ -1,15 +1,16 @@
 #[macro_use]
 mod print_utils;
 
+use crate::print_utils::{HighlightKind, split_highlighted_segments};
 use crossterm::{
     cursor,
     event::{self, Event, KeyCode},
     execute,
-    style::Print,
+    style::{Attribute, Color, Print, PrintStyledContent, Stylize},
     terminal,
 };
 use log::{LevelFilter, debug, error};
-use logmancer_core::LogReader;
+use logmancer_core::{LogReader, PageSearchResult};
 use std::env;
 use std::fs::OpenOptions;
 use std::io::{Write, stdout};
@@ -121,20 +122,14 @@ fn main() -> std::io::Result<()> {
                 .unwrap_or(page_result.start_line + page_size);
             let left_offset = last_line.to_string().len() + 1;
             for (i, line) in page_result.lines.iter().enumerate() {
-                print_row!(
+                render_line_row(
                     i + 2,
-                    "{:<left_offset$}{} {}{}",
                     line.number,
-                    "|",
-                    trunc_str(line.text.trim_end(), columns as usize - left_offset - 2),
-                    page_result
-                        .search
-                        .as_ref()
-                        .and_then(|search| search.current.as_ref())
-                        .filter(|current| current.line_index + 1 == line.number)
-                        .map(|_| " <")
-                        .unwrap_or("")
-                );
+                    line.text.trim_end(),
+                    left_offset,
+                    columns as usize,
+                    page_result.search.as_ref(),
+                )?;
             }
 
             print_row!(
@@ -251,7 +246,88 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
+fn render_line_row(
+    row: usize,
+    line_number: usize,
+    line_text: &str,
+    left_offset: usize,
+    columns: usize,
+    search: Option<&PageSearchResult>,
+) -> std::io::Result<()> {
+    let is_current_line = search
+        .and_then(|state| state.current.as_ref())
+        .is_some_and(|current| current.line_index + 1 == line_number);
+    let current_marker = if is_current_line { " <" } else { "" };
+    let content_width = columns.saturating_sub(left_offset + 2 + current_marker.len());
+    let visible_text = trunc_str(line_text, content_width);
+    let spans = search
+        .map(|state| collect_line_spans(state, line_number, visible_text.len()))
+        .unwrap_or_default();
+    let segments = split_highlighted_segments(visible_text, &spans);
+
+    execute!(
+        stdout(),
+        cursor::MoveTo(0, row as u16),
+        terminal::Clear(terminal::ClearType::UntilNewLine),
+        Print(format!("{line_number:<left_offset$}| "))
+    )?;
+
+    for segment in segments {
+        match segment.kind {
+            HighlightKind::Plain => execute!(stdout(), Print(segment.text))?,
+            HighlightKind::Match => execute!(
+                stdout(),
+                PrintStyledContent(segment.text.black().on(Color::Yellow))
+            )?,
+            HighlightKind::CurrentMatch => execute!(
+                stdout(),
+                PrintStyledContent(
+                    segment
+                        .text
+                        .black()
+                        .on(Color::DarkYellow)
+                        .attribute(Attribute::Bold)
+                        .attribute(Attribute::Underlined)
+                )
+            )?,
+        }
+    }
+
+    if is_current_line {
+        execute!(
+            stdout(),
+            PrintStyledContent(current_marker.with(Color::Cyan).attribute(Attribute::Bold))
+        )?;
+    }
+
+    execute!(stdout(), cursor::MoveTo(0, row as u16))?;
+    Ok(())
+}
+
+fn collect_line_spans(
+    search: &PageSearchResult,
+    line_number: usize,
+    visible_len: usize,
+) -> Vec<(usize, usize, bool)> {
+    search
+        .page_matches
+        .iter()
+        .filter(|search_match| search_match.line_index + 1 == line_number)
+        .map(|search_match| {
+            (
+                search_match.start.min(visible_len),
+                search_match.end.min(visible_len),
+                search.current.as_ref() == Some(search_match),
+            )
+        })
+        .collect()
+}
+
 fn trunc_str(s: &str, max_len: usize) -> &str {
+    if max_len == 0 {
+        return "";
+    }
+
     if s.chars().count() > max_len {
         let mut end = 0;
         for (i, _) in s.char_indices().take(max_len) {
@@ -277,4 +353,47 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     debug!("Log initialized");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_line_spans, trunc_str};
+    use logmancer_core::{PageSearchResult, SearchMatch};
+
+    #[test]
+    fn trunc_str_returns_empty_when_width_is_zero() {
+        assert_eq!(trunc_str("foo", 0), "");
+    }
+
+    #[test]
+    fn collect_line_spans_marks_current_match_and_clamps_to_visible_text() {
+        let current = SearchMatch {
+            line_index: 4,
+            start: 6,
+            end: 20,
+            ordinal: 1,
+        };
+        let search = PageSearchResult {
+            query: "foo".to_string(),
+            total_matches: 2,
+            total_matches_final: true,
+            is_indexing: false,
+            first: None,
+            current: Some(current.clone()),
+            page_matches: vec![
+                SearchMatch {
+                    line_index: 4,
+                    start: 0,
+                    end: 3,
+                    ordinal: 0,
+                },
+                current,
+            ],
+        };
+
+        assert_eq!(
+            collect_line_spans(&search, 5, 8),
+            vec![(0, 3, false), (6, 8, true)]
+        );
+    }
 }

--- a/logmancer-tui/src/print_utils.rs
+++ b/logmancer-tui/src/print_utils.rs
@@ -10,3 +10,112 @@ macro_rules! print_row {
         )?;
     };
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HighlightKind {
+    Plain,
+    Match,
+    CurrentMatch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HighlightSegment<'a> {
+    pub text: &'a str,
+    pub kind: HighlightKind,
+}
+
+pub fn split_highlighted_segments<'a>(
+    line: &'a str,
+    spans: &[(usize, usize, bool)],
+) -> Vec<HighlightSegment<'a>> {
+    if spans.is_empty() {
+        return vec![HighlightSegment {
+            text: line,
+            kind: HighlightKind::Plain,
+        }];
+    }
+
+    let mut segments = Vec::new();
+    let mut cursor = 0usize;
+
+    for (start, end, is_current) in spans {
+        let start = (*start).min(line.len());
+        let end = (*end).min(line.len());
+
+        if cursor < start {
+            segments.push(HighlightSegment {
+                text: &line[cursor..start],
+                kind: HighlightKind::Plain,
+            });
+        }
+
+        if start < end {
+            segments.push(HighlightSegment {
+                text: &line[start..end],
+                kind: if *is_current {
+                    HighlightKind::CurrentMatch
+                } else {
+                    HighlightKind::Match
+                },
+            });
+        }
+
+        cursor = end;
+    }
+
+    if cursor < line.len() {
+        segments.push(HighlightSegment {
+            text: &line[cursor..],
+            kind: HighlightKind::Plain,
+        });
+    }
+
+    segments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HighlightKind, HighlightSegment, split_highlighted_segments};
+
+    #[test]
+    fn split_highlighted_segments_marks_current_and_secondary_matches() {
+        let segments = split_highlighted_segments("foo bar baz", &[(0, 3, false), (8, 11, true)]);
+
+        assert_eq!(
+            segments,
+            vec![
+                HighlightSegment {
+                    text: "foo",
+                    kind: HighlightKind::Match,
+                },
+                HighlightSegment {
+                    text: " bar ",
+                    kind: HighlightKind::Plain,
+                },
+                HighlightSegment {
+                    text: "baz",
+                    kind: HighlightKind::CurrentMatch,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn split_highlighted_segments_clamps_spans_to_visible_prefix() {
+        let segments = split_highlighted_segments("foobar", &[(3, 12, false)]);
+
+        assert_eq!(
+            segments,
+            vec![
+                HighlightSegment {
+                    text: "foo",
+                    kind: HighlightKind::Plain,
+                },
+                HighlightSegment {
+                    text: "bar",
+                    kind: HighlightKind::Match,
+                },
+            ]
+        );
+    }
+}

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -429,11 +429,23 @@ body {
   color: inherit;
   border-radius: 2px;
   padding: 0 1px;
+  box-shadow: inset 0 0 0 1px rgba(161, 98, 7, 0.18);
 }
 
 .search-match-current {
   background: #fb923c;
   box-shadow: 0 0 0 1px rgba(194, 65, 12, 0.35);
+  color: #111827;
+}
+
+.text-lines div.selected .search-match {
+  background: #fde68a;
+  box-shadow: inset 0 0 0 1px rgba(180, 83, 9, 0.28);
+}
+
+.text-lines div.selected .search-match-current {
+  background: #f97316;
+  box-shadow: 0 0 0 1px rgba(154, 52, 18, 0.5);
 }
 
 .search-panel {


### PR DESCRIPTION
Closes #24

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Highlights all visible search matches in the TUI with a distinct current-match style.
- Projects core search metadata onto filtered, non-contiguous visible lines so Web/Desktop filtered views can reuse the existing highlighter.
- Updates shared search documentation and changelog for the new highlighting behavior.

## Changes

| File | Change |
|------|--------|
| `logmancer-core/src/file_ops/read.rs` | Adds search metadata projection for arbitrary visible line indexes. |
| `logmancer-core/src/reader.rs` | Includes search metadata in filtered page responses. |
| `logmancer-tui/src/main.rs` | Renders styled search match spans and distinct current matches. |
| `logmancer-tui/src/print_utils.rs` | Adds highlight segment splitting helper and tests. |
| `logmancer-web/style/main.scss` | Improves selected-line search highlight contrast. |
| `docs/feature/shared-search-engine.md` | Documents view-scoped search spans, including filtered views. |
| `CHANGELOG.md` | Records issue #24 user-facing behavior. |

## Test Plan

- [x] `cargo fmt`
- [x] `cargo test -p logmancer-core read_filter_includes_search_matches_for_visible_filtered_lines`
- [x] `cargo test -p logmancer-core page_search_result_for_lines_keeps_only_visible_matches`
- [x] `cargo test -p logmancer-tui`
- [x] `cargo clippy --workspace -- -D warnings`

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable; no scripts changed)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
