### PR TITLE
feat(search): show search status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Web/desktop search match navigation with `n` and `N`, matching core/TUI wrap behavior and keeping the selected match visible (#23).
 - TUI search prompt opened with `/`, including submit/cancel handling and `n`/`N` next/previous match navigation using core behavior.
 - Search match highlighting across Web/Desktop main and filtered views plus TUI visible lines, with a distinct current-match state (#24).
+- Search status display across TUI and Web/Desktop now shows the active query, current match position, total matches, and no-match feedback (#25).
 
 ### Changed
 

--- a/logmancer-core/src/lib.rs
+++ b/logmancer-core/src/lib.rs
@@ -8,6 +8,6 @@ mod workers;
 
 pub use models::file_info::FileInfo;
 pub use models::page_result::{PageLine, PageResult};
-pub use models::search::{PageSearchResult, SearchMatch, SearchStatus};
+pub use models::search::{PageSearchResult, SearchDisplayStatus, SearchMatch, SearchStatus};
 pub use reader::LogReader;
 pub use registry::LogRegistry;

--- a/logmancer-core/src/models/page_result.rs
+++ b/logmancer-core/src/models/page_result.rs
@@ -19,7 +19,11 @@ pub struct PageResult {
 
 impl PartialEq for PageResult {
     fn eq(&self, other: &Self) -> bool {
-        self.start_line == other.start_line && self.total_lines == other.total_lines
+        self.lines == other.lines
+            && self.start_line == other.start_line
+            && self.total_lines == other.total_lines
+            && self.indexing_progress == other.indexing_progress
+            && self.search == other.search
     }
 }
 

--- a/logmancer-core/src/models/search.rs
+++ b/logmancer-core/src/models/search.rs
@@ -19,6 +19,15 @@ pub struct PageSearchResult {
     pub page_matches: Vec<SearchMatch>,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SearchDisplayStatus {
+    pub query: String,
+    pub current_match_index: Option<usize>,
+    pub total_matches: usize,
+    pub total_matches_final: bool,
+    pub is_indexing: bool,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct SearchState {
     pub session: Option<SearchSession>,
@@ -54,6 +63,30 @@ pub struct SearchStatus {
     pub total_matches_final: bool,
     pub first: Option<SearchMatch>,
     pub current: Option<SearchMatch>,
+}
+
+impl PageSearchResult {
+    pub fn display_status(&self) -> SearchDisplayStatus {
+        SearchDisplayStatus {
+            query: self.query.clone(),
+            current_match_index: self.current.as_ref().map(|current| current.ordinal + 1),
+            total_matches: self.total_matches,
+            total_matches_final: self.total_matches_final,
+            is_indexing: self.is_indexing,
+        }
+    }
+}
+
+impl SearchStatus {
+    pub fn display_status(&self) -> Option<SearchDisplayStatus> {
+        self.query.as_ref().map(|query| SearchDisplayStatus {
+            query: query.clone(),
+            current_match_index: self.current.as_ref().map(|current| current.ordinal + 1),
+            total_matches: self.total_matches,
+            total_matches_final: self.total_matches_final,
+            is_indexing: !self.is_ready,
+        })
+    }
 }
 
 impl SearchState {
@@ -123,5 +156,82 @@ impl SearchSession {
         }
         let current = self.current_ordinal.unwrap_or(0);
         self.current_ordinal = Some((current + self.matches.len() - 1) % self.matches.len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PageSearchResult, SearchDisplayStatus, SearchMatch, SearchPhase, SearchStatus};
+
+    #[test]
+    fn page_search_display_status_uses_one_based_current_match_index() {
+        let search = PageSearchResult {
+            query: "error".to_string(),
+            total_matches: 27,
+            total_matches_final: false,
+            is_indexing: true,
+            first: None,
+            current: Some(SearchMatch {
+                line_index: 12,
+                start: 0,
+                end: 5,
+                ordinal: 2,
+            }),
+            page_matches: Vec::new(),
+        };
+
+        assert_eq!(
+            search.display_status(),
+            SearchDisplayStatus {
+                query: "error".to_string(),
+                current_match_index: Some(3),
+                total_matches: 27,
+                total_matches_final: false,
+                is_indexing: true,
+            }
+        );
+    }
+
+    #[test]
+    fn search_status_display_status_is_absent_without_query() {
+        let status = SearchStatus {
+            query: None,
+            generation: 0,
+            origin_line: None,
+            phase: SearchPhase::Ready,
+            is_ready: true,
+            total_matches: 0,
+            total_matches_final: true,
+            first: None,
+            current: None,
+        };
+
+        assert_eq!(status.display_status(), None);
+    }
+
+    #[test]
+    fn search_status_display_status_maps_readiness_to_indexing() {
+        let status = SearchStatus {
+            query: Some("error".to_string()),
+            generation: 1,
+            origin_line: Some(0),
+            phase: SearchPhase::Indexing,
+            is_ready: false,
+            total_matches: 0,
+            total_matches_final: false,
+            first: None,
+            current: None,
+        };
+
+        assert_eq!(
+            status.display_status(),
+            Some(SearchDisplayStatus {
+                query: "error".to_string(),
+                current_match_index: None,
+                total_matches: 0,
+                total_matches_final: false,
+                is_indexing: true,
+            })
+        );
     }
 }

--- a/logmancer-tui/src/main.rs
+++ b/logmancer-tui/src/main.rs
@@ -10,7 +10,7 @@ use crossterm::{
     terminal,
 };
 use log::{LevelFilter, debug, error};
-use logmancer_core::{LogReader, PageSearchResult};
+use logmancer_core::{LogReader, PageSearchResult, SearchDisplayStatus};
 use std::env;
 use std::fs::OpenOptions;
 use std::io::{Write, stdout};
@@ -100,17 +100,11 @@ fn main() -> std::io::Result<()> {
                 if follow_mode { "ON" } else { "OFF" },
                 page_result.total_lines,
                 indexed,
-                page_result.search.as_ref().map_or_else(
-                    || "OFF".to_string(),
-                    |search| {
-                        let phase = if search.is_indexing {
-                            " (searching...)"
-                        } else {
-                            ""
-                        };
-                        format!("{}{}", search.query, phase)
-                    },
-                )
+                page_result
+                    .search
+                    .as_ref()
+                    .map(|search| format_search_status(&search.display_status()))
+                    .unwrap_or_else(|| "OFF".to_string())
             );
             print_row!(1, "{}", "-".repeat(columns as usize));
 
@@ -323,6 +317,29 @@ fn collect_line_spans(
         .collect()
 }
 
+fn format_search_status(status: &SearchDisplayStatus) -> String {
+    let mut text = if status.total_matches == 0 {
+        if status.is_indexing {
+            format!("{} no matches yet", status.query)
+        } else {
+            format!("{} no matches", status.query)
+        }
+    } else if let Some(current_match_index) = status.current_match_index {
+        format!(
+            "{} {}/{}",
+            status.query, current_match_index, status.total_matches
+        )
+    } else {
+        format!("{} {} matches", status.query, status.total_matches)
+    };
+
+    if status.is_indexing {
+        text.push_str(" searching...");
+    }
+
+    text
+}
+
 fn trunc_str(s: &str, max_len: usize) -> &str {
     if max_len == 0 {
         return "";
@@ -357,8 +374,8 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_line_spans, trunc_str};
-    use logmancer_core::{PageSearchResult, SearchMatch};
+    use super::{collect_line_spans, format_search_status, trunc_str};
+    use logmancer_core::{PageSearchResult, SearchDisplayStatus, SearchMatch};
 
     #[test]
     fn trunc_str_returns_empty_when_width_is_zero() {
@@ -394,6 +411,34 @@ mod tests {
         assert_eq!(
             collect_line_spans(&search, 5, 8),
             vec![(0, 3, false), (6, 8, true)]
+        );
+    }
+
+    #[test]
+    fn format_search_status_shows_current_and_total_matches() {
+        assert_eq!(
+            format_search_status(&SearchDisplayStatus {
+                query: "error".to_string(),
+                current_match_index: Some(3),
+                total_matches: 27,
+                total_matches_final: true,
+                is_indexing: false,
+            }),
+            "error 3/27"
+        );
+    }
+
+    #[test]
+    fn format_search_status_shows_no_matches_while_indexing() {
+        assert_eq!(
+            format_search_status(&SearchDisplayStatus {
+                query: "error".to_string(),
+                current_match_index: None,
+                total_matches: 0,
+                total_matches_final: false,
+                is_indexing: true,
+            }),
+            "error no matches yet searching..."
         );
     }
 }

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -1,10 +1,12 @@
 use crate::components::context::{
-    ActivePaneContext, LogContentFocusContext, LogFileContext, LogViewContext, SelectionSource,
+    ActivePaneContext, LogContentFocusContext, LogFileContext, LogViewContext, SearchUiContext,
+    SelectionSource,
 };
 use crate::components::diagnostics::{scroll_trace, scroll_trace_enabled};
 use crate::components::layout::{
     SCROLL_LINE_JUMP, WHEEL_SCROLL_MAX_LINE_JUMP, WHEEL_SCROLL_PIXELS_PER_LINE_STEP,
 };
+use crate::components::search_status::format_page_search_status;
 use leptos::context::use_context;
 use leptos::ev::{KeyboardEvent, WheelEvent};
 use leptos::logging::log;
@@ -118,6 +120,10 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
     let ActivePaneContext { active_pane, .. } = use_context().expect("ActivePaneContext not found");
     let LogContentFocusContext { focus_request, .. } =
         use_context().expect("LogContentFocusContext not found");
+    let SearchUiContext {
+        set_status: set_search_status,
+        ..
+    } = use_context().expect("SearchUiContext not found");
 
     let select_line = move |line_number| {
         set_active_pane.set(selection_source);
@@ -424,6 +430,7 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
         <Transition>
             { move || Suspend::new(async move {
                 log_page.await.map(|page_result| {
+                    set_search_status.set(format_page_search_status(&page_result));
                     set_page_result.set(Some(page_result.clone()));
                     if debounce.get_untracked().is_none() {
                         set_wheel_target_line.set(Some(page_result.start_line));

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -69,13 +69,11 @@ pub fn LogView() -> impl IntoView {
     #[cfg(target_arch = "wasm32")]
     let open_search_panel = move || {
         set_search_panel_visible.set(true);
-        set_search_status.set(String::new());
         request_search_focus.update(|request| *request = request.saturating_add(1));
     };
 
     let close_search_panel = move || {
         set_search_panel_visible.set(false);
-        set_search_status.set(String::new());
         focus_main_content();
 
         if let Some(log_view) = log_view_ref.get() {

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -10,6 +10,7 @@ use crate::components::context::{
 };
 use crate::components::layout::LOG_LINE_HEIGHT_PX;
 use crate::components::pane_index_progress::PaneIndexProgress;
+use crate::components::search_status::format_page_search_status;
 use leptos::context::use_context;
 use leptos::html::Div;
 use leptos::leptos_dom::log;
@@ -157,6 +158,7 @@ pub fn MainPane() -> impl IntoView {
         spawn_local(async move {
             match apply_search(file_id, query, max_lines).await {
                 Ok(page) => {
+                    set_search_status.set(format_page_search_status(&page));
                     apply_search_page_result(
                         page,
                         set_tail,
@@ -165,7 +167,6 @@ pub fn MainPane() -> impl IntoView {
                         set_selected_original_line,
                         set_selected_line_source,
                     );
-                    set_search_status.set(String::new());
                     return_focus_to_main();
                 }
                 Err(_) => {
@@ -197,6 +198,7 @@ pub fn MainPane() -> impl IntoView {
 
             match result {
                 Ok(page) => {
+                    set_search_status.set(format_page_search_status(&page));
                     apply_search_page_result(
                         page,
                         set_tail,
@@ -205,7 +207,6 @@ pub fn MainPane() -> impl IntoView {
                         set_selected_original_line,
                         set_selected_line_source,
                     );
-                    set_search_status.set(String::new());
                 }
                 Err(_) => {
                     set_search_status.set(if navigate_previous {

--- a/logmancer-web/src/components/mod.rs
+++ b/logmancer-web/src/components/mod.rs
@@ -13,6 +13,7 @@ mod main_pane;
 mod pane_index_progress;
 mod progress_bar;
 mod search_panel;
+mod search_status;
 mod server_file_spotlight;
 
 pub use app::App;

--- a/logmancer-web/src/components/search_status.rs
+++ b/logmancer-web/src/components/search_status.rs
@@ -1,0 +1,65 @@
+use logmancer_core::{PageResult, SearchDisplayStatus};
+
+pub fn format_page_search_status(page: &PageResult) -> String {
+    page.search
+        .as_ref()
+        .map(|search| format_search_status(&search.display_status()))
+        .unwrap_or_default()
+}
+
+fn format_search_status(status: &SearchDisplayStatus) -> String {
+    let mut text = if status.total_matches == 0 {
+        if status.is_indexing {
+            format!("{} no matches yet", status.query)
+        } else {
+            format!("{} no matches", status.query)
+        }
+    } else if let Some(current_match_index) = status.current_match_index {
+        format!(
+            "{} {}/{}",
+            status.query, current_match_index, status.total_matches
+        )
+    } else {
+        format!("{} {} matches", status.query, status.total_matches)
+    };
+
+    if status.is_indexing {
+        text.push_str(" searching...");
+    }
+
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_search_status;
+    use logmancer_core::SearchDisplayStatus;
+
+    #[test]
+    fn format_search_status_shows_match_position() {
+        assert_eq!(
+            format_search_status(&SearchDisplayStatus {
+                query: "error".to_string(),
+                current_match_index: Some(3),
+                total_matches: 27,
+                total_matches_final: true,
+                is_indexing: false,
+            }),
+            "error 3/27"
+        );
+    }
+
+    #[test]
+    fn format_search_status_shows_no_matches() {
+        assert_eq!(
+            format_search_status(&SearchDisplayStatus {
+                query: "error".to_string(),
+                current_match_index: None,
+                total_matches: 0,
+                total_matches_final: true,
+                is_indexing: false,
+            }),
+            "error no matches"
+        );
+    }
+}


### PR DESCRIPTION
Closes #25

## Summary
- Add a core display-status DTO for search query, match position, totals, and indexing state.
- Show persistent search status in TUI and Web/Desktop, including no-match feedback.
- Include search metadata in page equality so UI redraws when search state changes.

## Changes
| File | Change |
|------|--------|
| `logmancer-core/src/models/search.rs` | Adds `SearchDisplayStatus` and derived helper methods. |
| `logmancer-core/src/models/page_result.rs` | Compares search/indexing/page content for redraw correctness. |
| `logmancer-tui/src/main.rs` | Formats visible search query, position, totals, and no-match states. |
| `logmancer-web/src/components/search_status.rs` | Adds Web search status formatter. |
| `logmancer-web/src/components/main_pane.rs` | Keeps status visible after search apply/navigation. |
| `logmancer-web/src/components/content_lines.rs` | Refreshes status from page results. |
| `CHANGELOG.md` | Documents the user-facing search status change. |

## Test Plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p logmancer-core display_status -- --nocapture`
- [x] `cargo test -p logmancer-tui format_search_status -- --nocapture`
- [x] `cargo test -p logmancer-web format_search_status -- --nocapture`
- [x] `cargo check -p logmancer-core -p logmancer-tui -p logmancer-web`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Shellcheck not applicable; no shell scripts modified
- [x] Docs/changelog updated for behavior change
- [x] Conventional commit format
- [x] No AI attribution trailers