### PR TITLE
fix(desktop): support external dev server mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed
+
+- Desktop development mode can now run against an external `cargo leptos watch` server without embedding the Leptos/Axum server in the Tauri crate, reducing `tauri dev --no-default-features` compile work.
+
+### Fixed
+
+- Desktop external-server mode now preserves desktop runtime detection across hydration and log navigation, so native file opening and drag/drop continue to work while avoiding duplicate Home file buttons.
+- Server-root file opening now accepts native-picker absolute paths only after canonicalizing them inside `LOGMANCER_SERVER_FILE_ROOT`.
+
 ## [0.3.0] - 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tempfile",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/logmancer-desktop/Cargo.toml
+++ b/logmancer-desktop/Cargo.toml
@@ -20,8 +20,13 @@ tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 logmancer-core = { path = "../logmancer-core" }
-logmancer-web = { path = "../logmancer-web", features = ["ssr"] }
+logmancer-web = { path = "../logmancer-web", features = ["ssr"], optional = true }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[features]
+default = ["embedded-server"]
+embedded-server = ["dep:logmancer-web"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -1,22 +1,55 @@
 use logmancer_core::LogRegistry;
-use logmancer_web::{
-    file_opening::enable_desktop_ssr_runtime, init_backend_logging, start_leptos_with_registry,
-    try_open_initial_file,
-};
-use std::net::TcpStream;
+use std::net::{TcpStream, ToSocketAddrs};
+#[cfg(any(feature = "embedded-server", test))]
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
-use tauri::{Manager, Url, WindowEvent};
+use tauri::{Manager, Url};
 use tauri_plugin_dialog::DialogExt;
 use tracing::{info, warn};
 
+#[cfg(feature = "embedded-server")]
+use {
+    logmancer_web::{
+        file_opening::enable_desktop_ssr_runtime, start_leptos_with_registry, try_open_initial_file,
+    },
+    tauri::WindowEvent,
+};
+
+#[cfg(not(feature = "embedded-server"))]
+const EXTERNAL_DEV_SERVER_URL: &str = "http://localhost:3000?runtime=desktop";
+
+#[cfg(not(feature = "embedded-server"))]
+const EXTERNAL_SERVER_FALLBACK_URL: &str = "data:text/html;charset=utf-8,%3C!doctype%20html%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3ELogmancer%20desktop%3C/title%3E%3Cbody%20style%3D%22font-family%3Asystem-ui%3Bmargin%3A2rem%3Bline-height%3A1.5%22%3E%3Ch1%3ELogmancer%20web%20server%20is%20not%20running%3C/h1%3E%3Cp%3EStart%20it%20with%3A%3C/p%3E%3Cpre%3Ecargo%20leptos%20watch%20--project%20logmancer-web%3C/pre%3E%3Cp%3EThen%20restart%20the%20desktop%20app.%3C/p%3E%3C/body%3E";
+
 #[derive(Clone)]
 struct DesktopState {
+    #[cfg_attr(not(feature = "embedded-server"), allow(dead_code))]
     registry: Arc<LogRegistry>,
 }
 
+fn wait_for_tcp_server<A>(addr: A, attempts: u32, delay: Duration) -> bool
+where
+    A: ToSocketAddrs + Copy,
+{
+    for _ in 0..attempts {
+        if TcpStream::connect(addr).is_ok() {
+            return true;
+        }
+        sleep(delay);
+    }
+
+    false
+}
+
+#[cfg(not(feature = "embedded-server"))]
+fn wait_for_external_dev_server() -> bool {
+    wait_for_tcp_server(("127.0.0.1", 3000), 40, Duration::from_millis(50))
+        || wait_for_tcp_server(("localhost", 3000), 10, Duration::from_millis(50))
+}
+
+#[cfg(any(feature = "embedded-server", test))]
 fn path_basename(path: &Path) -> String {
     path.file_name()
         .and_then(|name| name.to_str())
@@ -24,6 +57,7 @@ fn path_basename(path: &Path) -> String {
         .to_string()
 }
 
+#[cfg(any(feature = "embedded-server", test))]
 fn open_selected_log_file(
     registry: &LogRegistry,
     selected_path: Option<PathBuf>,
@@ -56,6 +90,7 @@ fn open_selected_log_file(
     }
 }
 
+#[cfg(any(feature = "embedded-server", test))]
 fn open_dropped_log_path(registry: &LogRegistry, selected_path: PathBuf) -> Result<String, String> {
     let file_name = path_basename(&selected_path);
     info!(file_name = %file_name, "Native dropped path received");
@@ -64,6 +99,7 @@ fn open_dropped_log_path(registry: &LogRegistry, selected_path: PathBuf) -> Resu
         .ok_or_else(|| "Dropped file path was not provided.".to_string())
 }
 
+#[cfg(any(feature = "embedded-server", test))]
 fn open_first_dropped_log_path(
     registry: &LogRegistry,
     paths: Vec<PathBuf>,
@@ -76,21 +112,7 @@ fn open_first_dropped_log_path(
     open_dropped_log_path(registry, path).map(Some)
 }
 
-fn wait_for_embedded_server(port: u16) {
-    for _ in 0..50 {
-        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-            return;
-        }
-
-        sleep(Duration::from_millis(50));
-    }
-
-    warn!(
-        "Embedded SSR server did not accept connections before desktop navigation port={}",
-        port
-    );
-}
-
+#[cfg(feature = "embedded-server")]
 #[tauri::command]
 async fn open_native_log_file(
     app: tauri::AppHandle,
@@ -109,9 +131,45 @@ async fn open_native_log_file(
     open_selected_log_file(state.registry.as_ref(), selected_path, "native_picker")
 }
 
+#[cfg(not(feature = "embedded-server"))]
+#[tauri::command]
+async fn open_native_log_file(
+    app: tauri::AppHandle,
+    _state: tauri::State<'_, DesktopState>,
+) -> Result<Option<String>, String> {
+    info!("Native open command invoked from webview (external server mode)");
+    let selected_path = app
+        .dialog()
+        .file()
+        .blocking_pick_file()
+        .map(|path| {
+            path.into_path()
+                .map_err(|error| format!("Could not resolve selected file path: {error}"))
+        })
+        .transpose()?;
+    match selected_path {
+        Some(path) => {
+            let path_str = path.to_string_lossy().to_string();
+            info!(
+                "Returning file path for external server (filename={})",
+                path.file_name()
+                    .map(|n| n.to_string_lossy())
+                    .unwrap_or_default()
+            );
+            // Prefix with "path:" so the WASM code can distinguish from a UUID file_id
+            Ok(Some(format!("path:{}", path_str)))
+        }
+        None => {
+            info!("Native file open cancelled");
+            Ok(None)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::TcpListener;
     use std::thread::sleep;
     use std::time::Duration;
 
@@ -211,86 +269,150 @@ mod tests {
         assert!(!capability.contains("fs:"));
         assert!(!capability.contains("shell:"));
     }
+
+    #[test]
+    fn wait_for_tcp_server_detects_available_listener() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        assert!(wait_for_tcp_server(addr, 1, Duration::ZERO));
+    }
+
+    #[test]
+    fn wait_for_tcp_server_returns_false_when_unavailable() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        assert!(!wait_for_tcp_server(addr, 1, Duration::ZERO));
+    }
+}
+
+fn init_desktop_logging() {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info,logmancer_desktop=debug"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(false)
+        .try_init();
+}
+
+#[cfg(feature = "embedded-server")]
+fn wait_for_embedded_server(port: u16) {
+    if wait_for_tcp_server(("127.0.0.1", port), 50, Duration::from_millis(50)) {
+        return;
+    }
+
+    warn!(
+        "Embedded SSR server did not accept connections before desktop navigation port={}",
+        port
+    );
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    init_backend_logging();
-    enable_desktop_ssr_runtime();
-    info!("Desktop runtime configured for embedded SSR rendering");
+    init_desktop_logging();
     let initial_path = std::env::args()
         .nth(1)
         .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
-    info!(initial_path = ?initial_path, "Resolved desktop initial file argument");
+    info!(
+        initial_file_provided = initial_path.is_some(),
+        "Resolved desktop initial file argument"
+    );
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .manage(DesktopState {
             registry: Arc::new(LogRegistry::new()),
         })
         .invoke_handler(tauri::generate_handler![open_native_log_file])
-        .setup(move |app| {
-            let registry = app.state::<DesktopState>().registry.clone();
-            let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
-            let port = std::net::TcpListener::bind("127.0.0.1:0")
-                .expect("Could not open a socket")
-                .local_addr()
-                .expect("The address could not be obtained")
-                .port();
-            info!("Spawning embedded SSR server on port={}", port);
-            tauri::async_runtime::spawn(async move {
-                info!("Embedded SSR server task started");
-                start_leptos_with_registry(port, registry).await
-            });
-            wait_for_embedded_server(port);
-            let window = app.get_webview_window("main").unwrap();
-            let registry_for_drop = app.state::<DesktopState>().registry.clone();
-            let window_for_drop = window.clone();
-            window.on_window_event(move |event| match event {
-                WindowEvent::DragDrop(tauri::DragDropEvent::Enter { paths, .. }) => {
-                    info!(
-                        path_count = paths.len(),
-                        "Native file drop entered desktop window"
-                    );
-                }
-                WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) => {
-                    info!(
-                        path_count = paths.len(),
-                        "Native file drop completed on desktop window"
-                    );
-                    match open_first_dropped_log_path(registry_for_drop.as_ref(), paths.clone()) {
-                        Ok(Some(file_id)) => {
-                            let target = format!("http://127.0.0.1:{port}/log/{file_id}");
-                            info!(file_id, "Navigating after native file drop");
-                            if let Err(error) =
-                                window_for_drop.navigate(Url::parse(&target).unwrap())
-                            {
-                                warn!(%error, "Could not navigate after native file drop");
-                            }
-                        }
-                        Ok(None) => {
-                            warn!("Native file drop completed without file paths");
-                        }
-                        Err(error) => {
-                            warn!(%error, "Could not open native dropped file");
+        .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_opener::init());
+
+    #[cfg(feature = "embedded-server")]
+    let builder = builder.setup(move |app| {
+        enable_desktop_ssr_runtime();
+        info!("Desktop runtime configured for embedded SSR rendering");
+
+        let registry = app.state::<DesktopState>().registry.clone();
+        let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("Could not open a socket")
+            .local_addr()
+            .expect("The address could not be obtained")
+            .port();
+        info!("Spawning embedded SSR server on port={}", port);
+        tauri::async_runtime::spawn(async move {
+            info!("Embedded SSR server task started");
+            start_leptos_with_registry(port, registry).await
+        });
+        wait_for_embedded_server(port);
+        let window = app.get_webview_window("main").unwrap();
+        let registry_for_drop = app.state::<DesktopState>().registry.clone();
+        let window_for_drop = window.clone();
+        window.on_window_event(move |event| match event {
+            WindowEvent::DragDrop(tauri::DragDropEvent::Enter { paths, .. }) => {
+                info!(
+                    path_count = paths.len(),
+                    "Native file drop entered desktop window"
+                );
+            }
+            WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) => {
+                info!(
+                    path_count = paths.len(),
+                    "Native file drop completed on desktop window"
+                );
+                match open_first_dropped_log_path(registry_for_drop.as_ref(), paths.clone()) {
+                    Ok(Some(file_id)) => {
+                        let target = format!(
+                            "http://127.0.0.1:{port}/log/{file_id}?runtime=desktop-embedded"
+                        );
+                        info!(file_id, "Navigating after native file drop");
+                        if let Err(error) = window_for_drop.navigate(Url::parse(&target).unwrap()) {
+                            warn!(%error, "Could not navigate after native file drop");
                         }
                     }
+                    Ok(None) => warn!("Native file drop completed without file paths"),
+                    Err(error) => warn!(%error, "Could not open native dropped file"),
                 }
-                WindowEvent::DragDrop(tauri::DragDropEvent::Over { .. }) => {}
-                WindowEvent::DragDrop(tauri::DragDropEvent::Leave) => {
-                    info!("Native file drop left desktop window");
-                }
-                _ => {}
-            });
-            let target = match initial_file_id {
-                Some(file_id) => format!("http://127.0.0.1:{port}/log/{file_id}"),
-                None => format!("http://127.0.0.1:{port}?runtime=desktop"),
-            };
-            info!("Navigating desktop window to {}", target);
-            window.navigate(Url::parse(target.as_str()).unwrap())?;
-            Ok(())
-        })
-        .plugin(tauri_plugin_dialog::init())
-        .plugin(tauri_plugin_opener::init())
+            }
+            WindowEvent::DragDrop(tauri::DragDropEvent::Over { .. }) => {}
+            WindowEvent::DragDrop(tauri::DragDropEvent::Leave) => {
+                info!("Native file drop left desktop window");
+            }
+            _ => {}
+        });
+        let target = match initial_file_id {
+            Some(file_id) => {
+                format!("http://127.0.0.1:{port}/log/{file_id}?runtime=desktop-embedded")
+            }
+            None => format!("http://127.0.0.1:{port}?runtime=desktop-embedded"),
+        };
+        info!("Navigating desktop window to {}", target);
+        window.navigate(Url::parse(target.as_str()).unwrap())?;
+        Ok(())
+    });
+
+    #[cfg(not(feature = "embedded-server"))]
+    let builder = builder.setup(move |app| {
+        let window = app.get_webview_window("main").unwrap();
+        if wait_for_external_dev_server() {
+            info!(
+                "External server mode: navigating desktop window to {}",
+                EXTERNAL_DEV_SERVER_URL
+            );
+            window.navigate(Url::parse(EXTERNAL_DEV_SERVER_URL)?)?;
+        } else {
+            warn!(
+                "External server mode could not reach localhost:3000. Start it with `cargo leptos watch --project logmancer-web`, then restart the desktop app."
+            );
+            if let Err(error) = window.navigate(Url::parse(EXTERNAL_SERVER_FALLBACK_URL)?) {
+                warn!(%error, "Could not navigate to external server fallback page");
+            }
+        }
+        Ok(())
+    });
+
+    builder
         .run(tauri::generate_context!())
         .expect("Error while running tauri application");
 }

--- a/logmancer-desktop/tauri.conf.json
+++ b/logmancer-desktop/tauri.conf.json
@@ -4,8 +4,7 @@
   "version": "0.3.0",
   "identifier": "com.ignsabbag.logmancer",
   "build": {
-    "beforeDevCommand": "cargo leptos watch --project logmancer-web",
-    "devUrl": "http://localhost:3000",
+    "devUrl": "http://localhost:3000?runtime=desktop",
     "beforeBuildCommand": "cargo leptos build --release --project logmancer-web",
     "frontendDist": "../target/site"
   },

--- a/logmancer-web/src/api/server_browser.rs
+++ b/logmancer-web/src/api/server_browser.rs
@@ -218,35 +218,37 @@ fn resolve_root_bound_path(
         PathBuf::from(trimmed)
     };
 
-    if requested.is_absolute() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            "invalid_path",
-            "Invalid path token.",
-        ));
-    }
-
-    for component in requested.components() {
-        match component {
-            Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "invalid_path",
-                    "Invalid path token.",
-                ));
+    let canonical = if requested.is_absolute() {
+        requested.canonicalize().map_err(|_| {
+            (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Requested path was not found.",
+            )
+        })?
+    } else {
+        for component in requested.components() {
+            match component {
+                Component::ParentDir | Component::Prefix(_) | Component::RootDir => {
+                    return Err((
+                        StatusCode::BAD_REQUEST,
+                        "invalid_path",
+                        "Invalid path token.",
+                    ));
+                }
+                _ => {}
             }
-            _ => {}
         }
-    }
 
-    let joined = root.canonical_path.join(&requested);
-    let canonical = joined.canonicalize().map_err(|_| {
-        (
-            StatusCode::NOT_FOUND,
-            "not_found",
-            "Requested path was not found.",
-        )
-    })?;
+        let joined = root.canonical_path.join(&requested);
+        joined.canonicalize().map_err(|_| {
+            (
+                StatusCode::NOT_FOUND,
+                "not_found",
+                "Requested path was not found.",
+            )
+        })?
+    };
 
     if !canonical.starts_with(&root.canonical_path) {
         return Err((
@@ -309,9 +311,37 @@ mod tests {
     }
 
     #[test]
-    fn rejects_absolute_path() {
+    fn accepts_absolute_path_inside_root() {
         let (_dir, root) = mk_root();
-        let result = resolve_root_bound_path(&root, "/etc/passwd");
+        let path = root.canonical_path.join("inside.log");
+        std::fs::write(&path, "hello").unwrap();
+
+        let result = resolve_root_bound_path(&root, &path.to_string_lossy()).unwrap();
+
+        assert_eq!(result, path);
+    }
+
+    #[test]
+    fn server_browser_accepts_native_picker_absolute_path_inside_root() {
+        let (_dir, root) = mk_root();
+        let path = root.canonical_path.join("native-picker.log");
+        std::fs::write(&path, "opened from native picker").unwrap();
+
+        let result = resolve_root_bound_path(&root, &path.to_string_lossy()).unwrap();
+
+        assert_eq!(result, path);
+        assert!(is_text_readable(&result));
+    }
+
+    #[test]
+    fn rejects_absolute_path_outside_root() {
+        let (_dir, root) = mk_root();
+        let outside = tempfile::tempdir().unwrap();
+        let path = outside.path().join("outside.log");
+        std::fs::write(&path, "hello").unwrap();
+
+        let result = resolve_root_bound_path(&root, &path.to_string_lossy());
+
         assert!(result.is_err());
     }
 

--- a/logmancer-web/src/components/home.rs
+++ b/logmancer-web/src/components/home.rs
@@ -2,7 +2,7 @@ use crate::browser_api_client::{fetch_server_browser_status, upload_local_file};
 use crate::components::ServerFileSpotlight;
 use crate::file_opening::{
     detect_file_opening_runtime, initial_file_opening_capabilities, open_native_log_file,
-    resolve_file_opening_capabilities,
+    resolve_file_opening_capabilities, should_ignore_dom_drop,
 };
 use leptos::logging::log;
 use leptos::prelude::*;
@@ -93,7 +93,10 @@ pub fn Home() -> impl IntoView {
             match open_native_log_file().await {
                 Ok(Some(file_id)) => {
                     log!("Home native open succeeded file_id={}", file_id);
-                    navigate(&format!("/log/{file_id}"), Default::default());
+                    navigate(
+                        &log_route_for_file_id(&file_id, &current_location_search()),
+                        Default::default(),
+                    );
                 }
                 Ok(None) => {
                     log!("Home native open cancelled");
@@ -116,7 +119,10 @@ pub fn Home() -> impl IntoView {
         spawn_local(async move {
             match upload_local_file(file).await {
                 Ok(file_id) => {
-                    navigate(&format!("/log/{file_id}"), Default::default());
+                    navigate(
+                        &log_route_for_file_id(&file_id, &current_location_search()),
+                        Default::default(),
+                    );
                 }
                 Err(err) => {
                     log!("Error uploading file: {}", err);
@@ -161,10 +167,8 @@ pub fn Home() -> impl IntoView {
         ev.prevent_default();
         set_is_dragging.set(false);
 
-        if file_opening_capabilities
-            .get_untracked()
-            .desktop_native_open
-        {
+        let capabilities = file_opening_capabilities.get_untracked();
+        if should_ignore_dom_drop(capabilities) {
             log!("Desktop DOM drop ignored; native Tauri drop listener handles file paths");
             return;
         }
@@ -219,7 +223,10 @@ pub fn Home() -> impl IntoView {
                             }}
                         </p>
 
-                        <Show when=move || file_opening_capabilities.get().browser_upload>
+                        <Show when=move || {
+                            let capabilities = file_opening_capabilities.get();
+                            capabilities.browser_upload && !capabilities.desktop_native_open
+                        }>
                             <input
                                 id="home-local-file-input"
                                 class="home-file-input"
@@ -292,5 +299,75 @@ pub fn Home() -> impl IntoView {
 
             <ServerFileSpotlight is_open=is_spotlight_open set_is_open=set_is_spotlight_open />
         </main>
+    }
+}
+
+fn current_location_search() -> String {
+    web_sys::window()
+        .and_then(|window| window.location().search().ok())
+        .unwrap_or_default()
+}
+
+fn log_route_for_file_id(file_id: &str, current_search: &str) -> String {
+    let route = format!("/log/{file_id}");
+
+    match runtime_marker_from_search(current_search) {
+        Some(runtime) => format!("{route}?runtime={runtime}"),
+        None => route,
+    }
+}
+
+fn runtime_marker_from_search(current_search: &str) -> Option<&'static str> {
+    let query = current_search.strip_prefix('?').unwrap_or(current_search);
+
+    query.split('&').find_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        if key != "runtime" {
+            return None;
+        }
+
+        match value {
+            "desktop" => Some("desktop"),
+            "desktop-embedded" => Some("desktop-embedded"),
+            _ => None,
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_open_file_id_uses_log_route_contract() {
+        assert_eq!(log_route_for_file_id("abc123", ""), "/log/abc123");
+    }
+
+    #[test]
+    fn log_route_preserves_external_desktop_runtime_marker() {
+        assert_eq!(
+            log_route_for_file_id("abc123", "?runtime=desktop"),
+            "/log/abc123?runtime=desktop"
+        );
+    }
+
+    #[test]
+    fn log_route_preserves_embedded_desktop_runtime_marker() {
+        assert_eq!(
+            log_route_for_file_id("abc123", "?runtime=desktop-embedded"),
+            "/log/abc123?runtime=desktop-embedded"
+        );
+    }
+
+    #[test]
+    fn log_route_only_preserves_known_runtime_marker() {
+        assert_eq!(
+            log_route_for_file_id("abc123", "?runtime=desktop-embedded&file=/etc/passwd"),
+            "/log/abc123?runtime=desktop-embedded"
+        );
+        assert_eq!(
+            log_route_for_file_id("abc123", "?runtime=unknown"),
+            "/log/abc123"
+        );
     }
 }

--- a/logmancer-web/src/file_opening.rs
+++ b/logmancer-web/src/file_opening.rs
@@ -7,7 +7,8 @@ static DESKTOP_SSR_RUNTIME: AtomicBool = AtomicBool::new(false);
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FileOpeningRuntime {
     Web,
-    Desktop,
+    DesktopEmbedded,
+    DesktopExternal,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -24,12 +25,21 @@ pub fn resolve_file_opening_capabilities(runtime: FileOpeningRuntime) -> FileOpe
             server_browser: true,
             desktop_native_open: false,
         },
-        FileOpeningRuntime::Desktop => FileOpeningCapabilities {
+        FileOpeningRuntime::DesktopEmbedded => FileOpeningCapabilities {
             browser_upload: false,
             server_browser: false,
             desktop_native_open: true,
         },
+        FileOpeningRuntime::DesktopExternal => FileOpeningCapabilities {
+            browser_upload: true,
+            server_browser: false,
+            desktop_native_open: true,
+        },
     }
+}
+
+pub fn should_ignore_dom_drop(capabilities: FileOpeningCapabilities) -> bool {
+    capabilities.desktop_native_open && !capabilities.browser_upload
 }
 
 pub fn initial_file_opening_capabilities() -> FileOpeningCapabilities {
@@ -51,7 +61,7 @@ fn initial_file_opening_runtime() -> FileOpeningRuntime {
     );
 
     if is_desktop {
-        FileOpeningRuntime::Desktop
+        FileOpeningRuntime::DesktopEmbedded
     } else {
         FileOpeningRuntime::Web
     }
@@ -59,7 +69,11 @@ fn initial_file_opening_runtime() -> FileOpeningRuntime {
 
 #[cfg(feature = "hydrate")]
 fn initial_file_opening_runtime() -> FileOpeningRuntime {
-    detect_file_opening_runtime()
+    let window = leptos::prelude::window();
+    let search = window.location().search().unwrap_or_default();
+    let origin = window.location().origin().unwrap_or_default();
+
+    resolve_initial_hydration_file_opening_runtime(&search, &origin)
 }
 
 #[cfg(not(any(feature = "ssr", feature = "hydrate")))]
@@ -75,32 +89,72 @@ fn is_desktop_runtime_marker(search: &str) -> bool {
         .any(|param| param == "runtime=desktop")
 }
 
+#[cfg(any(feature = "hydrate", test))]
+fn is_embedded_desktop_runtime_marker(search: &str) -> bool {
+    search
+        .trim_start_matches('?')
+        .split('&')
+        .any(|param| param == "runtime=desktop-embedded")
+}
+
+#[cfg(any(feature = "hydrate", test))]
+fn is_external_desktop_origin(origin: &str) -> bool {
+    origin == "http://localhost:3000" || origin == "http://127.0.0.1:3000"
+}
+
+#[cfg(any(feature = "hydrate", test))]
+fn resolve_detected_file_opening_runtime(
+    search: &str,
+    origin: &str,
+    has_tauri_global: bool,
+) -> FileOpeningRuntime {
+    let has_desktop_marker = is_desktop_runtime_marker(search);
+    let has_embedded_desktop_marker = is_embedded_desktop_runtime_marker(search);
+
+    if has_embedded_desktop_marker {
+        FileOpeningRuntime::DesktopEmbedded
+    } else if is_external_desktop_origin(origin) && (has_desktop_marker || has_tauri_global) {
+        FileOpeningRuntime::DesktopExternal
+    } else if has_desktop_marker || has_tauri_global {
+        FileOpeningRuntime::DesktopEmbedded
+    } else {
+        FileOpeningRuntime::Web
+    }
+}
+
+#[cfg(any(feature = "hydrate", test))]
+fn resolve_initial_hydration_file_opening_runtime(
+    search: &str,
+    origin: &str,
+) -> FileOpeningRuntime {
+    if is_embedded_desktop_runtime_marker(search) && !is_external_desktop_origin(origin) {
+        FileOpeningRuntime::DesktopEmbedded
+    } else {
+        FileOpeningRuntime::Web
+    }
+}
+
 #[cfg(feature = "hydrate")]
 pub fn detect_file_opening_runtime() -> FileOpeningRuntime {
     let window = leptos::prelude::window();
     let search = window.location().search().unwrap_or_default();
-    let has_desktop_marker = is_desktop_runtime_marker(&search);
+    let origin = window.location().origin().unwrap_or_default();
     let tauri_key = wasm_bindgen::JsValue::from_str("__TAURI__");
     let has_tauri_global = js_sys::Reflect::get(window.as_ref(), &tauri_key)
         .map(|value| !value.is_undefined() && !value.is_null())
         .unwrap_or(false);
+    let runtime = resolve_detected_file_opening_runtime(&search, &origin, has_tauri_global);
 
     leptos::logging::log!(
-        "File opening runtime detection: search='{}' desktop_marker={} tauri_global={}",
-        search,
-        has_desktop_marker,
-        has_tauri_global
+        "File opening runtime detection: desktop_marker={} embedded_desktop_marker={} external_desktop_origin={} tauri_global={} runtime={:?}",
+        is_desktop_runtime_marker(&search),
+        is_embedded_desktop_runtime_marker(&search),
+        is_external_desktop_origin(&origin),
+        has_tauri_global,
+        runtime
     );
 
-    if has_desktop_marker {
-        return FileOpeningRuntime::Desktop;
-    }
-
-    if has_tauri_global {
-        FileOpeningRuntime::Desktop
-    } else {
-        FileOpeningRuntime::Web
-    }
+    runtime
 }
 
 #[cfg(not(feature = "hydrate"))]
@@ -139,11 +193,41 @@ pub async fn open_native_log_file() -> Result<Option<String>, String> {
         leptos::logging::log!("Desktop native file picker cancelled");
         Ok(None)
     } else {
-        let file_id = value.as_string().ok_or_else(|| {
-            "Desktop native file opening returned an invalid file id.".to_string()
+        let result = value.as_string().ok_or_else(|| {
+            "Desktop native file opening returned an invalid response.".to_string()
         })?;
-        leptos::logging::log!("Desktop native file picker opened file_id={}", file_id);
-        Ok(Some(file_id))
+
+        match resolve_native_open_result(&result) {
+            NativeOpenResult::ServerPath(path) => {
+                leptos::logging::log!(
+                    "Desktop native file picker returned path, opening via server API"
+                );
+                let file_id =
+                    crate::browser_api_client::open_server_browser_file(path.to_string()).await?;
+                leptos::logging::log!("Server API opened file_id={}", file_id);
+                Ok(Some(file_id))
+            }
+            NativeOpenResult::FileId(file_id) => {
+                leptos::logging::log!("Desktop native file picker opened file_id={}", file_id);
+                Ok(Some(file_id.to_string()))
+            }
+        }
+    }
+}
+
+#[cfg(any(feature = "hydrate", test))]
+#[derive(Debug, Eq, PartialEq)]
+enum NativeOpenResult<'a> {
+    ServerPath(&'a str),
+    FileId(&'a str),
+}
+
+#[cfg(any(feature = "hydrate", test))]
+fn resolve_native_open_result(result: &str) -> NativeOpenResult<'_> {
+    if let Some(path) = result.strip_prefix("path:") {
+        NativeOpenResult::ServerPath(path)
+    } else {
+        NativeOpenResult::FileId(result)
     }
 }
 
@@ -166,12 +250,35 @@ mod tests {
     }
 
     #[test]
-    fn desktop_runtime_hides_upload_and_exposes_native_open() {
-        let capabilities = resolve_file_opening_capabilities(FileOpeningRuntime::Desktop);
+    fn embedded_desktop_runtime_hides_upload_and_exposes_native_open() {
+        let capabilities = resolve_file_opening_capabilities(FileOpeningRuntime::DesktopEmbedded);
 
         assert!(!capabilities.browser_upload);
         assert!(!capabilities.server_browser);
         assert!(capabilities.desktop_native_open);
+    }
+
+    #[test]
+    fn external_desktop_runtime_allows_dom_upload_and_native_open() {
+        let capabilities = resolve_file_opening_capabilities(FileOpeningRuntime::DesktopExternal);
+
+        assert!(capabilities.browser_upload);
+        assert!(!capabilities.server_browser);
+        assert!(capabilities.desktop_native_open);
+    }
+
+    #[test]
+    fn file_opening_external_desktop_dom_drop_remains_allowed_with_native_open() {
+        let capabilities = resolve_file_opening_capabilities(FileOpeningRuntime::DesktopExternal);
+
+        assert!(!should_ignore_dom_drop(capabilities));
+    }
+
+    #[test]
+    fn file_opening_embedded_desktop_dom_drop_remains_ignored() {
+        let capabilities = resolve_file_opening_capabilities(FileOpeningRuntime::DesktopEmbedded);
+
+        assert!(should_ignore_dom_drop(capabilities));
     }
 
     #[test]
@@ -187,5 +294,126 @@ mod tests {
         assert!(is_desktop_runtime_marker("?runtime=desktop"));
         assert!(is_desktop_runtime_marker("?foo=bar&runtime=desktop"));
         assert!(!is_desktop_runtime_marker("?runtime=web"));
+    }
+
+    #[test]
+    fn embedded_desktop_runtime_marker_is_detected_from_query_string() {
+        assert!(is_embedded_desktop_runtime_marker(
+            "?runtime=desktop-embedded"
+        ));
+        assert!(is_embedded_desktop_runtime_marker(
+            "?foo=bar&runtime=desktop-embedded"
+        ));
+        assert!(!is_embedded_desktop_runtime_marker("?runtime=desktop"));
+    }
+
+    #[test]
+    fn initial_hydration_external_desktop_dev_matches_web_ssr_tree() {
+        assert_eq!(
+            resolve_initial_hydration_file_opening_runtime(
+                "?runtime=desktop",
+                "http://localhost:3000"
+            ),
+            FileOpeningRuntime::Web
+        );
+    }
+
+    #[test]
+    fn initial_hydration_embedded_desktop_matches_embedded_ssr_tree() {
+        assert_eq!(
+            resolve_initial_hydration_file_opening_runtime(
+                "?runtime=desktop-embedded",
+                "http://127.0.0.1:43123"
+            ),
+            FileOpeningRuntime::DesktopEmbedded
+        );
+    }
+
+    #[test]
+    fn initial_hydration_normal_web_matches_web_ssr_tree() {
+        assert_eq!(
+            resolve_initial_hydration_file_opening_runtime("", "http://localhost:3000"),
+            FileOpeningRuntime::Web
+        );
+    }
+
+    #[test]
+    fn desktop_marker_on_external_dev_origin_detects_external_desktop() {
+        assert_eq!(
+            resolve_detected_file_opening_runtime(
+                "?runtime=desktop",
+                "http://localhost:3000",
+                true
+            ),
+            FileOpeningRuntime::DesktopExternal
+        );
+    }
+
+    #[test]
+    fn desktop_marker_on_external_dev_origin_detects_external_desktop_before_tauri_global() {
+        assert_eq!(
+            resolve_detected_file_opening_runtime(
+                "?runtime=desktop",
+                "http://localhost:3000",
+                false
+            ),
+            FileOpeningRuntime::DesktopExternal
+        );
+    }
+
+    #[test]
+    fn tauri_global_on_external_dev_origin_detects_external_desktop_without_marker() {
+        assert_eq!(
+            resolve_detected_file_opening_runtime("", "http://localhost:3000", true),
+            FileOpeningRuntime::DesktopExternal
+        );
+    }
+
+    #[test]
+    fn external_dev_origin_without_tauri_global_or_marker_stays_web() {
+        assert_eq!(
+            resolve_detected_file_opening_runtime("", "http://localhost:3000", false),
+            FileOpeningRuntime::Web
+        );
+    }
+
+    #[test]
+    fn desktop_marker_on_embedded_origin_detects_embedded_desktop() {
+        assert_eq!(
+            resolve_detected_file_opening_runtime(
+                "?runtime=desktop",
+                "http://127.0.0.1:43123",
+                true
+            ),
+            FileOpeningRuntime::DesktopEmbedded
+        );
+    }
+
+    #[test]
+    fn embedded_desktop_marker_detects_embedded_desktop_after_hydration() {
+        assert_eq!(
+            resolve_detected_file_opening_runtime(
+                "?runtime=desktop-embedded",
+                "http://127.0.0.1:43123",
+                true
+            ),
+            FileOpeningRuntime::DesktopEmbedded
+        );
+    }
+
+    #[test]
+    fn file_opening_native_picker_path_result_uses_server_api_contract() {
+        assert_eq!(
+            resolve_native_open_result("path:/var/log/system.log"),
+            NativeOpenResult::ServerPath("/var/log/system.log")
+        );
+    }
+
+    #[test]
+    fn file_opening_native_picker_file_id_result_uses_route_contract() {
+        assert_eq!(
+            resolve_native_open_result("file-123"),
+            NativeOpenResult::FileId("file-123")
+        );
     }
 }

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -102,14 +102,19 @@ pub fn try_open_initial_file(
         .map(str::trim)
         .filter(|path| !path.is_empty())?;
 
-    info!("Attempting to open initial file path={}", path);
+    let file_name = std::path::Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("<unnamed>");
+
+    info!(file_name = %file_name, "Attempting to open initial file");
     match registry.open_file(path) {
         Ok(file_id) => {
             info!("Initial file opened successfully file_id={}", file_id);
             Some(file_id)
         }
         Err(error) => {
-            warn!("Could not open initial file path={} error={}", path, error);
+            warn!(file_name = %file_name, %error, "Could not open initial file");
             error!("Continuing startup without initial file");
             None
         }


### PR DESCRIPTION
Closes #77

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Makes `logmancer-web` optional in the desktop crate behind the embedded-server feature so external desktop dev can avoid compiling the Leptos/Axum server.
- Adds external desktop runtime handling that preserves hydration, native picker, drag/drop upload, and runtime markers across navigation.
- Keeps native-picker absolute paths root-bound through `LOGMANCER_SERVER_FILE_ROOT` and adds a visible fallback when the external web server is unavailable.

## Changes
| File | Change |
|------|--------|
| `logmancer-desktop/Cargo.toml` | Makes `logmancer-web` optional behind `embedded-server` and adds direct desktop logging dependency. |
| `logmancer-desktop/src/lib.rs` | Splits embedded/external desktop startup, adds external server availability fallback, preserves embedded runtime markers, and redacts full path logging. |
| `logmancer-desktop/tauri.conf.json` | Removes automatic web dev command and marks external desktop dev URL. |
| `logmancer-web/src/file_opening.rs` | Adds external vs embedded desktop runtime detection, hydration-safe initial runtime handling, native picker result parsing, and tests. |
| `logmancer-web/src/components/home.rs` | Preserves runtime query markers, enables external drag/drop upload without duplicate file buttons, and adds route tests. |
| `logmancer-web/src/api/server_browser.rs` | Accepts native-picker absolute paths only when canonicalized inside the configured server root. |
| `logmancer-web/src/lib.rs` | Redacts initial file path logging. |
| `CHANGELOG.md` | Documents the desktop development behavior change and fixes. |

## Test Plan
- [x] `cargo fmt`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo check -p logmancer-desktop --no-default-features`
- [x] `cargo test -p logmancer-desktop --lib --no-default-features`
- [x] `cargo test -p logmancer-web file_opening --lib`
- [x] `cargo test -p logmancer-web home --lib`
- [x] `cargo test -p logmancer-web --features ssr server_browser --lib`
- [x] Manually tested external desktop dev native opening/drag-drop behavior.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No scripts modified; shellcheck not applicable
- [x] Docs/changelog updated for behavior change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers