### PR TITLE
feat(core): add visual rules foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added
+
+- Core visual rules foundation with UI-neutral rule models, text/regex matching, array-order priority, per-rule case sensitivity, safe invalid-rule handling, and optional line style metadata for foreground/background colors (#63, #64, #65, #66).
+
 ### Changed
 
 - Desktop development mode can now run against an external `cargo leptos watch` server without embedding the Leptos/Axum server in the Tauri crate, reducing `tauri dev --no-default-features` compile work.

--- a/docs/adr/0003-core-visual-rules-as-line-style.md
+++ b/docs/adr/0003-core-visual-rules-as-line-style.md
@@ -1,0 +1,40 @@
+# ADR 0003: Core Visual Rules as Line Style Intent
+
+- Status: Accepted
+- Date: 2026-07-15
+
+## Context
+
+Visual rules need a shared core contract before web, TUI, desktop, or persisted configuration can render user-defined highlights consistently.
+
+Logmancer Web already has span-based search decorations (`LineDecoration { start, end, kind }`) for inline match highlighting. Reusing that model for visual rules would couple core behavior to web rendering concerns and blur two different responsibilities: base line styling and inline overlays.
+
+## Decision
+
+Core visual rules produce whole-line style intent through `PageLine::style` and `LineStyleIntent`.
+
+Visual rules do not produce span-based decorations. Existing web search decorations remain an inline overlay concern.
+
+| Area | Decision |
+|---|---|
+| Scope | Visual rules are core-owned and UI-neutral. |
+| Output | Matching rules attach optional whole-line foreground/background style intent to `PageLine`. |
+| Priority | Array order defines priority; the first matching rule wins. |
+| Matching | Rules support text and regex matchers with per-rule case sensitivity. |
+| Invalid rules | Invalid rules are skipped/disabled safely; reads must not crash. |
+| Non-interference | Visual rules do not alter visibility, filtering, search, pagination, tail behavior, or navigation. |
+| Rendering | UI layers decide how to render `LineStyleIntent`; web span decorations remain separate. |
+| Persistence | Saving/loading visual rules is out of scope for this decision. |
+
+## Consequences
+
+- Core can expose visual-rule results without depending on CSS, Ratatui, Leptos, or web-specific decoration kinds.
+- Web can later combine visual rules as a base line style with search highlights as inline overlays.
+- Future persistence work can store UI-neutral rule definitions instead of frontend-specific render metadata.
+- Consumers must treat `PageLine::style` as optional metadata; undecorated reads remain valid.
+
+## Verification
+
+- Core tests cover text and regex matching, per-rule case sensitivity, array-order priority, invalid regex skipping, and reader non-interference.
+- `cargo test -p logmancer-core` verifies core behavior.
+- `cargo clippy --workspace -- -D warnings` verifies the workspace remains lint-clean before PR.

--- a/logmancer-core/src/file_ops/read.rs
+++ b/logmancer-core/src/file_ops/read.rs
@@ -47,6 +47,10 @@ impl<'a> FileReadOps<'a> {
     }
 
     pub fn read_filter_line(&self, line_number: usize) -> io::Result<Option<String>> {
+        if line_number >= self.log_file.filter.len() {
+            return Ok(None);
+        }
+
         if self.log_file.filter[line_number] {
             Ok(Some(self.read_line(line_number)?))
         } else {
@@ -221,6 +225,30 @@ mod tests {
         assert_eq!(batch[0].line_index, 0);
         assert_eq!(batch[1].line_index, 0);
         assert_eq!(batch[2].line_index, 2);
+
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn read_filter_line_returns_none_for_unprocessed_filter_bounds() {
+        let path = temp_file_path("read-filter-line-unprocessed-bounds");
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "alpha").unwrap();
+        write!(file, "beta").unwrap();
+        drop(file);
+
+        let log_file = RwLock::new(LogFile::new(path.to_string_lossy().into_owned()).unwrap());
+        let mut write_ops = FileWriteOps::new(std::sync::Arc::new(log_file));
+        while !write_ops.index_lines().unwrap() {}
+
+        let shared = write_ops.log_file();
+        let read_guard = shared.read().unwrap();
+        let read_ops = FileReadOps::new(read_guard);
+
+        assert_eq!(read_ops.total_lines().unwrap(), 2);
+        assert_eq!(read_ops.processed_filter_lines().unwrap(), 0);
+        assert_eq!(read_ops.read_filter_line(0).unwrap(), None);
+        assert_eq!(read_ops.read_filter_line(2).unwrap(), None);
 
         std::fs::remove_file(path).unwrap();
     }

--- a/logmancer-core/src/lib.rs
+++ b/logmancer-core/src/lib.rs
@@ -4,10 +4,13 @@ mod models;
 mod reader;
 mod registry;
 mod timing;
+mod visual_rules;
 mod workers;
 
 pub use models::file_info::FileInfo;
 pub use models::page_result::{PageLine, PageResult};
 pub use models::search::{PageSearchResult, SearchDisplayStatus, SearchMatch, SearchStatus};
+pub use models::visual_rules::{LineStyleIntent, VisualColor, VisualMatcher, VisualRule};
 pub use reader::LogReader;
 pub use registry::LogRegistry;
+pub use visual_rules::VisualRuleEvaluator;

--- a/logmancer-core/src/models/mod.rs
+++ b/logmancer-core/src/models/mod.rs
@@ -2,7 +2,9 @@ pub mod file_info;
 pub mod log_file;
 pub mod page_result;
 pub mod search;
+pub mod visual_rules;
 
 pub use file_info::FileInfo;
 pub use page_result::{PageLine, PageResult};
 pub use search::SearchStatus;
+pub use visual_rules::{LineStyleIntent, VisualRule};

--- a/logmancer-core/src/models/page_result.rs
+++ b/logmancer-core/src/models/page_result.rs
@@ -1,11 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 use crate::models::search::PageSearchResult;
+use crate::models::visual_rules::LineStyleIntent;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct PageLine {
     pub number: usize,
     pub text: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<LineStyleIntent>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/logmancer-core/src/models/visual_rules.rs
+++ b/logmancer-core/src/models/visual_rules.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct VisualRule {
+    pub matcher: VisualMatcher,
+    pub case_sensitive: bool,
+    pub style: LineStyleIntent,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum VisualMatcher {
+    Text(String),
+    Regex(String),
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(transparent)]
+/// UI-neutral color token carried by core.
+///
+/// Consumers must validate and map this value before rendering it as CSS,
+/// terminal styles, or any other UI-specific color representation.
+pub struct VisualColor(pub String);
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct LineStyleIntent {
+    pub foreground: Option<VisualColor>,
+    pub background: Option<VisualColor>,
+}

--- a/logmancer-core/src/reader.rs
+++ b/logmancer-core/src/reader.rs
@@ -1,5 +1,6 @@
 use crate::handler::LogFileHandler;
-use crate::models::{FileInfo, PageLine, PageResult, SearchStatus};
+use crate::models::{FileInfo, LineStyleIntent, PageLine, PageResult, SearchStatus, VisualRule};
+use crate::visual_rules::VisualRuleEvaluator;
 use log::debug;
 use std::cmp::min;
 use std::io::{self};
@@ -7,6 +8,7 @@ use std::io::{self};
 pub struct LogReader {
     handler: LogFileHandler,
     current_view_start: usize,
+    visual_rule_evaluator: VisualRuleEvaluator,
 }
 
 impl LogReader {
@@ -15,7 +17,12 @@ impl LogReader {
         Ok(LogReader {
             handler: file_log_handler,
             current_view_start: 0,
+            visual_rule_evaluator: VisualRuleEvaluator::default(),
         })
+    }
+
+    pub fn set_visual_rules(&mut self, rules: Vec<VisualRule>) {
+        self.visual_rule_evaluator = VisualRuleEvaluator::compile(&rules);
     }
 
     /// Return file_id, path and other info about the open file
@@ -38,10 +45,8 @@ impl LogReader {
         let from_line = to_line.saturating_sub(max_lines);
         let mut lines = Vec::with_capacity(max_lines);
         for current_line in from_line..to_line {
-            lines.push(PageLine {
-                number: current_line + 1,
-                text: read_ops.read_line(current_line)?,
-            });
+            let text = read_ops.read_line(current_line)?;
+            lines.push(self.page_line(current_line + 1, text));
         }
         let page = PageResult {
             lines,
@@ -65,10 +70,8 @@ impl LogReader {
         let start_line = total_lines.saturating_sub(max_lines);
         let mut lines = Vec::with_capacity(max_lines);
         for current_line in start_line..total_lines {
-            lines.push(PageLine {
-                number: current_line + 1,
-                text: read_ops.read_line(current_line)?,
-            });
+            let text = read_ops.read_line(current_line)?;
+            lines.push(self.page_line(current_line + 1, text));
         }
         let page = PageResult {
             lines,
@@ -100,10 +103,7 @@ impl LogReader {
             if let Some(line) = read_ops.read_filter_line(current_line)? {
                 if matched_lines >= start_line {
                     visible_line_indexes.push(current_line);
-                    lines.push(PageLine {
-                        number: current_line + 1,
-                        text: line,
-                    });
+                    lines.push(self.page_line(current_line + 1, line));
                 }
                 matched_lines += 1;
             }
@@ -134,10 +134,7 @@ impl LogReader {
             current_line -= 1;
             if let Some(line) = read_ops.read_filter_line(current_line)? {
                 visible_line_indexes.push(current_line);
-                lines.push(PageLine {
-                    number: current_line + 1,
-                    text: line,
-                });
+                lines.push(self.page_line(current_line + 1, line));
             }
         }
         lines.reverse();
@@ -189,11 +186,25 @@ impl LogReader {
             .unwrap_or(0);
         self.read_page(start, max_lines)
     }
+
+    fn page_line(&self, number: usize, text: String) -> PageLine {
+        let style = self.evaluate_style(&text);
+        PageLine {
+            number,
+            text,
+            style,
+        }
+    }
+
+    fn evaluate_style(&self, line: &str) -> Option<LineStyleIntent> {
+        self.visual_rule_evaluator.evaluate(line)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{LineStyleIntent, VisualColor, VisualMatcher, VisualRule};
     use std::fs::File;
     use std::io::Write;
     use std::path::PathBuf;
@@ -209,6 +220,12 @@ mod tests {
         std::env::temp_dir().join(format!("logmancer-{name}-{suffix}.log"))
     }
 
+    fn keep_temp_file_for_background_workers(_path: PathBuf) {
+        // LogReader workers outlive the reader values in these tests. Removing
+        // the file before the test process exits can make the reload worker
+        // report a missing file even though the assertions already passed.
+    }
+
     fn wait_search_ready(reader: &LogReader) {
         for _ in 0..40 {
             let status = reader.search_status();
@@ -217,6 +234,51 @@ mod tests {
             }
             sleep(Duration::from_millis(20));
         }
+    }
+
+    fn wait_total_lines(reader: &LogReader, expected: usize) {
+        for _ in 0..10 {
+            if reader.file_info().unwrap().total_lines >= expected {
+                return;
+            }
+            sleep(Duration::from_millis(50));
+        }
+
+        panic!("timed out waiting for {expected} total lines");
+    }
+
+    fn wait_filtered_lines(reader: &mut LogReader, expected: usize) {
+        for _ in 0..40 {
+            let page = reader.read_filter(0, expected.max(1)).unwrap();
+            if page.total_lines >= expected && page.lines.len() >= expected {
+                return;
+            }
+            sleep(Duration::from_millis(20));
+        }
+
+        panic!("timed out waiting for {expected} filtered lines");
+    }
+
+    fn style(foreground: &str, background: &str) -> LineStyleIntent {
+        LineStyleIntent {
+            foreground: Some(VisualColor(foreground.to_string())),
+            background: Some(VisualColor(background.to_string())),
+        }
+    }
+
+    fn visual_rule(pattern: &str, foreground: &str) -> VisualRule {
+        VisualRule {
+            matcher: VisualMatcher::Text(pattern.to_string()),
+            case_sensitive: false,
+            style: style(foreground, "default"),
+        }
+    }
+
+    fn line_identity(page: &PageResult) -> Vec<(usize, String)> {
+        page.lines
+            .iter()
+            .map(|line| (line.number, line.text.clone()))
+            .collect()
     }
 
     #[test]
@@ -239,6 +301,7 @@ mod tests {
             vec![PageLine {
                 number: 2,
                 text: "beta match".to_string(),
+                style: None,
             }]
         );
 
@@ -249,6 +312,7 @@ mod tests {
             vec![PageLine {
                 number: 4,
                 text: "delta match".to_string(),
+                style: None,
             }]
         );
 
@@ -306,10 +370,12 @@ mod tests {
                 PageLine {
                     number: 2,
                     text: "one".to_string(),
+                    style: None,
                 },
                 PageLine {
                     number: 3,
                     text: "two".to_string(),
+                    style: None,
                 },
             ]
         );
@@ -343,15 +409,106 @@ mod tests {
                 PageLine {
                     number: 1,
                     text: "first".to_string(),
+                    style: None,
                 },
                 PageLine {
                     number: 2,
                     text: "second".to_string(),
+                    style: None,
                 },
             ]
         );
 
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn visual_rules_style_page_and_tail_without_changing_visible_lines() {
+        let path = temp_file_path("visual-rules-page-tail");
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "INFO boot").unwrap();
+        writeln!(file, "WARN cache").unwrap();
+        write!(file, "ERROR disk").unwrap();
+        drop(file);
+
+        let mut plain_reader = LogReader::new(path.to_string_lossy().into_owned()).unwrap();
+        wait_total_lines(&plain_reader, 3);
+        let plain_page = plain_reader.read_page(0, 3).unwrap();
+        let plain_tail = plain_reader.tail(2, false).unwrap();
+
+        let mut styled_reader = LogReader::new(path.to_string_lossy().into_owned()).unwrap();
+        wait_total_lines(&styled_reader, 3);
+        styled_reader.set_visual_rules(vec![visual_rule("error", "red")]);
+
+        let styled_page = styled_reader.read_page(0, 3).unwrap();
+        let styled_tail = styled_reader.tail(2, false).unwrap();
+
+        assert_eq!(line_identity(&styled_page), line_identity(&plain_page));
+        assert_eq!(styled_page.start_line, plain_page.start_line);
+        assert_eq!(styled_page.total_lines, plain_page.total_lines);
+        assert_eq!(styled_page.search, plain_page.search);
+        assert_eq!(styled_page.lines[0].style, None);
+        assert_eq!(styled_page.lines[2].style, Some(style("red", "default")));
+
+        assert_eq!(line_identity(&styled_tail), line_identity(&plain_tail));
+        assert_eq!(styled_tail.start_line, plain_tail.start_line);
+        assert_eq!(styled_tail.total_lines, plain_tail.total_lines);
+        assert_eq!(styled_tail.lines[1].style, Some(style("red", "default")));
+
+        keep_temp_file_for_background_workers(path);
+    }
+
+    #[test]
+    fn visual_rules_do_not_change_filtered_reads_or_tail_filter_outcome() {
+        let path = temp_file_path("visual-rules-filter-tail");
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "INFO boot").unwrap();
+        writeln!(file, "WARN cache").unwrap();
+        writeln!(file, "ERROR disk").unwrap();
+        drop(file);
+
+        let mut plain_reader = LogReader::new(path.to_string_lossy().into_owned()).unwrap();
+        wait_total_lines(&plain_reader, 3);
+        plain_reader.filter("WARN|ERROR".to_string());
+        wait_filtered_lines(&mut plain_reader, 2);
+        let plain_filter = plain_reader.read_filter(0, 10).unwrap();
+        let plain_tail_filter = plain_reader.tail_filter(2, false).unwrap();
+
+        let mut styled_reader = LogReader::new(path.to_string_lossy().into_owned()).unwrap();
+        wait_total_lines(&styled_reader, 3);
+        styled_reader.filter("WARN|ERROR".to_string());
+        wait_filtered_lines(&mut styled_reader, 2);
+        styled_reader.set_visual_rules(vec![visual_rule("warn", "yellow")]);
+        let styled_filter = styled_reader.read_filter(0, 10).unwrap();
+        let styled_tail_filter = styled_reader.tail_filter(2, false).unwrap();
+
+        assert_eq!(line_identity(&styled_filter), line_identity(&plain_filter));
+        assert_eq!(styled_filter.start_line, plain_filter.start_line);
+        assert_eq!(styled_filter.total_lines, plain_filter.total_lines);
+        assert_eq!(styled_filter.search, plain_filter.search);
+        assert_eq!(
+            styled_filter.lines[0].style,
+            Some(style("yellow", "default"))
+        );
+        assert_eq!(styled_filter.lines[1].style, None);
+
+        assert_eq!(
+            line_identity(&styled_tail_filter),
+            line_identity(&plain_tail_filter)
+        );
+        assert_eq!(styled_tail_filter.start_line, plain_tail_filter.start_line);
+        assert_eq!(
+            styled_tail_filter.total_lines,
+            plain_tail_filter.total_lines
+        );
+        assert_eq!(styled_tail_filter.search, plain_tail_filter.search);
+        assert_eq!(
+            styled_tail_filter.lines[0].style,
+            Some(style("yellow", "default"))
+        );
+        assert_eq!(styled_tail_filter.lines[1].style, None);
+
+        keep_temp_file_for_background_workers(path);
     }
 
     #[test]

--- a/logmancer-core/src/visual_rules.rs
+++ b/logmancer-core/src/visual_rules.rs
@@ -1,0 +1,163 @@
+use regex::{Regex, RegexBuilder};
+
+use crate::models::visual_rules::{LineStyleIntent, VisualMatcher, VisualRule};
+
+#[derive(Clone, Debug, Default)]
+pub struct VisualRuleEvaluator {
+    rules: Vec<CompiledVisualRule>,
+}
+
+#[derive(Clone, Debug)]
+struct CompiledVisualRule {
+    matcher: CompiledVisualMatcher,
+    style: LineStyleIntent,
+}
+
+#[derive(Clone, Debug)]
+enum CompiledVisualMatcher {
+    Text {
+        pattern: String,
+        case_sensitive: bool,
+    },
+    Regex(Regex),
+}
+
+impl VisualRuleEvaluator {
+    pub fn compile(rules: &[VisualRule]) -> Self {
+        let rules = rules
+            .iter()
+            .filter_map(CompiledVisualRule::compile)
+            .collect();
+
+        Self { rules }
+    }
+
+    pub fn evaluate(&self, line: &str) -> Option<LineStyleIntent> {
+        self.rules
+            .iter()
+            .find(|rule| rule.matches(line))
+            .map(|rule| rule.style.clone())
+    }
+}
+
+impl CompiledVisualRule {
+    fn compile(rule: &VisualRule) -> Option<Self> {
+        let matcher = match &rule.matcher {
+            VisualMatcher::Text(pattern) => CompiledVisualMatcher::Text {
+                pattern: normalize_text(pattern, rule.case_sensitive),
+                case_sensitive: rule.case_sensitive,
+            },
+            VisualMatcher::Regex(pattern) => RegexBuilder::new(pattern)
+                .case_insensitive(!rule.case_sensitive)
+                .build()
+                .ok()
+                .map(CompiledVisualMatcher::Regex)?,
+        };
+
+        Some(Self {
+            matcher,
+            style: rule.style.clone(),
+        })
+    }
+
+    fn matches(&self, line: &str) -> bool {
+        match &self.matcher {
+            CompiledVisualMatcher::Text {
+                pattern,
+                case_sensitive,
+            } => normalize_text(line, *case_sensitive).contains(pattern),
+            CompiledVisualMatcher::Regex(regex) => regex.is_match(line),
+        }
+    }
+}
+
+fn normalize_text(value: &str, case_sensitive: bool) -> String {
+    if case_sensitive {
+        value.to_string()
+    } else {
+        value.to_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{LineStyleIntent, VisualColor, VisualMatcher, VisualRule};
+
+    fn style(foreground: &str, background: &str) -> LineStyleIntent {
+        LineStyleIntent {
+            foreground: Some(VisualColor(foreground.to_string())),
+            background: Some(VisualColor(background.to_string())),
+        }
+    }
+
+    fn text_rule(pattern: &str, case_sensitive: bool, foreground: &str) -> VisualRule {
+        VisualRule {
+            matcher: VisualMatcher::Text(pattern.to_string()),
+            case_sensitive,
+            style: style(foreground, "default"),
+        }
+    }
+
+    fn regex_rule(pattern: &str, case_sensitive: bool, foreground: &str) -> VisualRule {
+        VisualRule {
+            matcher: VisualMatcher::Regex(pattern.to_string()),
+            case_sensitive,
+            style: style(foreground, "default"),
+        }
+    }
+
+    #[test]
+    fn visual_rules_text_match_respects_case_control() {
+        let insensitive = VisualRuleEvaluator::compile(&[text_rule("error", false, "red")]);
+        assert_eq!(
+            insensitive.evaluate("Error: disk full"),
+            Some(style("red", "default"))
+        );
+
+        let sensitive = VisualRuleEvaluator::compile(&[text_rule("error", true, "red")]);
+        assert_eq!(sensitive.evaluate("Error: disk full"), None);
+    }
+
+    #[test]
+    fn visual_rules_regex_match_uses_valid_patterns() {
+        let evaluator = VisualRuleEvaluator::compile(&[regex_rule("^WARN:", true, "yellow")]);
+
+        assert_eq!(
+            evaluator.evaluate("WARN: cache unavailable"),
+            Some(style("yellow", "default"))
+        );
+        assert_eq!(evaluator.evaluate("INFO: cache unavailable"), None);
+    }
+
+    #[test]
+    fn visual_rules_first_matching_rule_wins() {
+        let evaluator = VisualRuleEvaluator::compile(&[
+            text_rule("timeout", false, "orange"),
+            text_rule("timeout", false, "blue"),
+        ]);
+
+        assert_eq!(
+            evaluator.evaluate("request timeout"),
+            Some(style("orange", "default"))
+        );
+        assert_eq!(
+            evaluator.evaluate("request timeout"),
+            Some(style("orange", "default"))
+        );
+    }
+
+    #[test]
+    fn visual_rules_invalid_regex_is_skipped_without_blocking_valid_rules() {
+        let evaluator = VisualRuleEvaluator::compile(&[
+            regex_rule("[", true, "broken"),
+            text_rule("panic", false, "red"),
+        ]);
+
+        assert_eq!(
+            evaluator.evaluate("thread panic observed"),
+            Some(style("red", "default"))
+        );
+        assert_eq!(evaluator.evaluate("thread healthy"), None);
+    }
+}


### PR DESCRIPTION
## Linked Issues

Closes #63
Closes #64
Closes #65
Closes #66

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Adds UI-neutral core visual-rule models with text/regex matching, per-rule case sensitivity, invalid-regex safety, and first-match priority by rule order.
- Adds optional whole-line `PageLine::style` metadata and wires style evaluation into page, tail, filter, and tail-filter reads without changing visible-line behavior.
- Documents the architectural boundary between core line style intent and web span-based search decorations in ADR 0003.

## Changes

| File | Change |
|------|--------|
| `logmancer-core/src/models/visual_rules.rs` | Adds visual-rule model, matcher, color token, and line style intent. |
| `logmancer-core/src/visual_rules.rs` | Adds compiled evaluator, matching behavior, priority, and unit tests. |
| `logmancer-core/src/models/page_result.rs` | Adds optional `PageLine::style` metadata. |
| `logmancer-core/src/reader.rs` | Applies visual-rule styles to returned lines and adds non-interference regression tests. |
| `logmancer-core/src/file_ops/read.rs` | Handles unprocessed filter bounds safely and covers it with regression test. |
| `docs/adr/0003-core-visual-rules-as-line-style.md` | Documents core line-style decision and web decoration boundary. |
| `CHANGELOG.md` | Adds the visual-rules core foundation entry under Unreleased. |

## Test Plan

- [x] `cargo fmt`
- [x] `cargo test -p logmancer-core` — 24 passed, 1 ignored
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Fresh 4R review completed; no blockers remaining

## Notes

- #67 persistence/config saving is intentionally out of scope.
- OpenSpec artifacts remain ignored and are not included in this PR.
- Future UI/persistence work should validate/map `VisualColor` before rendering and consider rule-count/pattern limits.

## Contributor Checklist

- [x] Linked approved issues
- [x] Added exactly one `type:*` label
- [x] Ran required Rust quality gates
- [x] Docs updated for the architecture decision
- [x] Conventional commit format
- [x] No AI attribution trailers