### PR TITLE
feat(web): render visual rule highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ### Added
 
 - Core visual rules foundation with UI-neutral rule models, text/regex matching, array-order priority, per-rule case sensitivity, safe invalid-rule handling, and optional line style metadata for foreground/background colors (#63, #64, #65, #66).
+- The shared web viewer used by browser and desktop shells now renders safe whole-line visual-rule foreground/background styles (#68).
 
 ### Changed
 

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -15,7 +15,7 @@ use leptos::ev::{KeyboardEvent, WheelEvent};
 use leptos::logging::log;
 use leptos::prelude::*;
 use leptos::{component, html, view, IntoView};
-use logmancer_core::PageResult;
+use logmancer_core::{LineStyleIntent, PageResult, VisualColor};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -160,6 +160,30 @@ fn line_decorations_for_row(
         .unwrap_or_default()
 }
 
+fn visual_color_css(token: &VisualColor) -> Option<&'static str> {
+    match token.0.as_str() {
+        "error-foreground" => Some("#991b1b"),
+        "error-background" => Some("#fee2e2"),
+        "warning-foreground" => Some("#92400e"),
+        "warning-background" => Some("#fef3c7"),
+        _ => None,
+    }
+}
+
+fn line_style_css_variables(style: Option<&LineStyleIntent>) -> Option<String> {
+    let style = style?;
+    let mut declarations = Vec::with_capacity(2);
+
+    if let Some(color) = style.foreground.as_ref().and_then(visual_color_css) {
+        declarations.push(format!("--log-line-foreground: {color}"));
+    }
+    if let Some(color) = style.background.as_ref().and_then(visual_color_css) {
+        declarations.push(format!("--log-line-background: {color}"));
+    }
+
+    (!declarations.is_empty()).then(|| declarations.join("; "))
+}
+
 #[component]
 fn DecoratedLineText(line_text: String, decorations: Vec<LineDecoration>) -> impl IntoView {
     let segments = split_line_segments(&line_text, &decorations);
@@ -179,13 +203,19 @@ fn DecoratedLineText(line_text: String, decorations: Vec<LineDecoration>) -> imp
 fn LogLineRow(
     line_number: usize,
     line_text: String,
+    line_style: Option<LineStyleIntent>,
     decorations: Vec<LineDecoration>,
     selected_line: ReadSignal<Option<usize>>,
     select_line: Callback<usize>,
 ) -> impl IntoView {
+    let visual_style = line_style_css_variables(line_style.as_ref());
+    let has_visual_style = visual_style.is_some();
+
     view! {
         <div
             class:selected=move || selected_line.get() == Some(line_number)
+            class:visual-rule-line=has_visual_style
+            style=visual_style
             on:click=move |_| select_line.run(line_number)
         >
             <DecoratedLineText line_text=line_text decorations=decorations />
@@ -564,11 +594,13 @@ pub fn ContentLines(context: LogViewContext) -> impl IntoView {
                             { lines.into_iter().map(|line| {
                                 let line_number = line.number;
                                 let line_text = line.text;
+                                let line_style = line.style;
                                 let decorations = line_decorations_for_row(&decorations_by_line, line_number);
                                 view! {
                                     <LogLineRow
                                         line_number=line_number
                                         line_text=line_text
+                                        line_style=line_style
                                         decorations=decorations
                                         selected_line=selected_line
                                         select_line=select_line_callback
@@ -590,12 +622,13 @@ mod tests {
     use super::{
         can_auto_enable_global_follow, can_mutate_global_follow_state, is_at_end,
         is_editable_target, is_handled_key, keyboard_target_line, line_decorations_for_row,
-        search_segment_class, should_handle_focus_request, should_restore_focus,
-        tail_update_for_navigation, wheel_lines_to_jump, wheel_target_line, TailEndComparison,
-        TailNavigationUpdate, ARROW_DOWN, ARROW_UP, PAGE_DOWN, PAGE_UP,
+        line_style_css_variables, search_segment_class, should_handle_focus_request,
+        should_restore_focus, tail_update_for_navigation, wheel_lines_to_jump, wheel_target_line,
+        TailEndComparison, TailNavigationUpdate, ARROW_DOWN, ARROW_UP, PAGE_DOWN, PAGE_UP,
     };
     use crate::components::context::SelectionSource;
     use crate::components::line_decorations::{DecorationKind, LineDecoration};
+    use logmancer_core::{LineStyleIntent, VisualColor};
 
     fn decoration(start: usize, end: usize, kind: DecorationKind) -> LineDecoration {
         LineDecoration { start, end, kind }
@@ -676,6 +709,43 @@ mod tests {
         let decorations = line_decorations_for_row(&decorations_by_line, 8);
 
         assert_eq!(decorations, Vec::<LineDecoration>::new());
+    }
+
+    #[test]
+    fn known_visual_tokens_map_to_closed_css_variables() {
+        let style = LineStyleIntent {
+            foreground: Some(VisualColor("error-foreground".to_string())),
+            background: Some(VisualColor("error-background".to_string())),
+        };
+
+        assert_eq!(
+            line_style_css_variables(Some(&style)),
+            Some("--log-line-foreground: #991b1b; --log-line-background: #fee2e2".to_string())
+        );
+    }
+
+    #[test]
+    fn absent_or_unknown_visual_tokens_leave_row_unstyled() {
+        let style = LineStyleIntent {
+            foreground: Some(VisualColor("hotpink; background: url(bad)".to_string())),
+            background: None,
+        };
+
+        assert_eq!(line_style_css_variables(None), None);
+        assert_eq!(line_style_css_variables(Some(&style)), None);
+    }
+
+    #[test]
+    fn known_visual_tokens_render_without_forwarding_unknown_tokens() {
+        let style = LineStyleIntent {
+            foreground: Some(VisualColor("unknown".to_string())),
+            background: Some(VisualColor("warning-background".to_string())),
+        };
+
+        assert_eq!(
+            line_style_css_variables(Some(&style)),
+            Some("--log-line-background: #fef3c7".to_string())
+        );
     }
 
     #[test]

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -419,6 +419,11 @@ body {
   cursor: default;
 }
 
+.text-lines div.visual-rule-line {
+  color: var(--log-line-foreground, inherit);
+  background-color: var(--log-line-background, transparent);
+}
+
 .text-lines div.selected {
   background: #dbeafe;
   box-shadow: inset 0 0 0 1px #93c5fd;


### PR DESCRIPTION
Closes #68

## PR Type
- [x] New feature

## Summary
- Attach visual-rule decoration metadata to visible log lines.
- Render safe whole-line foreground/background styling in the web viewer.
- Preserve filtering, search, pagination, and navigation behavior.

## Changes
| File | Change |
|---|---|
| `logmancer-core/src/reader.rs` | Applies the active visual-rule snapshot while building page lines. |
| `logmancer-core/src/models/page_result.rs` | Carries optional UI-neutral line style metadata. |
| `logmancer-web/src/components/content_lines.rs` | Renders safe whole-line visual decoration. |

## Test Plan
- [x] Focused core visual-rule evaluation and reader tests passed.
- [x] Web rendering tests passed.
- [x] Native pre-PR receipt validation passed (`review-8bb2a2949b5ef093`).
- [x] Shellcheck N/A — no shell scripts changed.

## Chain Context

```text
#79 Visual Rules Core Foundation
  └─ 📍 This PR: Visual Rule Highlights
       └─ Persistence
            └─ Management UI
```

- **Start:** core visual-rule model from #79.
- **End:** active rules decorate visible lines without changing result sets.
- **Depends on:** #79.
- **Follow-up:** persistence, then management UI.
- **Rollback:** revert the three-file decoration integration; core foundation remains intact.

## Contributor Checklist
- [x] Linked approved issue #68.
- [x] Exactly one `type:*` label will be applied.
- [x] Tests and reviewed receipt are present.
- [x] Documentation impact evaluated; behavior documentation remains tracked by #70.
- [x] Conventional commit format used.
- [x] No AI attribution trailers.