### PR TITLE
feat(core): add visual rules management persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
+dependencies = [
+ "nix",
+ "rand 0.9.4",
+]
+
+[[package]]
 name = "attribute-derive"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +613,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -2932,13 +2948,17 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 name = "logmancer-core"
 version = "0.3.0"
 dependencies = [
+ "atomic-write-file",
  "crossbeam-channel",
  "dashmap",
  "log",
  "memmap2",
  "regex",
  "serde",
+ "serde_json",
+ "sha2",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3194,6 +3214,18 @@ name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/logmancer-core/Cargo.toml
+++ b/logmancer-core/Cargo.toml
@@ -11,6 +11,13 @@ dashmap = "6.1.0"
 uuid = {  version = "1.16.0", features = ['v4'] }
 crossbeam-channel = "0.5.15"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = { version = "1.0.145", optional = true }
+atomic-write-file = { version = "0.3.0", optional = true }
+sha2 = { version = "0.10.9", optional = true }
 
 [features]
 wasm = ["uuid/js"]
+native-persistence = ["dep:atomic-write-file", "dep:serde_json", "dep:sha2", "dep:windows-sys"]
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"], optional = true }

--- a/logmancer-core/src/lib.rs
+++ b/logmancer-core/src/lib.rs
@@ -5,12 +5,26 @@ mod reader;
 mod registry;
 mod timing;
 mod visual_rules;
+mod visual_rules_manager;
+#[cfg(feature = "native-persistence")]
+mod visual_rules_store;
 mod workers;
 
 pub use models::file_info::FileInfo;
 pub use models::page_result::{PageLine, PageResult};
 pub use models::search::{PageSearchResult, SearchDisplayStatus, SearchMatch, SearchStatus};
-pub use models::visual_rules::{LineStyleIntent, VisualColor, VisualMatcher, VisualRule};
+pub use models::visual_rules::{
+    LineStyleIntent, ManagedVisualRule, ValidationDiagnostic, ValidationError, ValidationReport,
+    ValidationSeverity, VisualColor, VisualMatcher, VisualRule, VisualRulesEnvelope,
+};
 pub use reader::LogReader;
 pub use registry::LogRegistry;
 pub use visual_rules::VisualRuleEvaluator;
+pub use visual_rules_manager::{
+    SaveOutcome, SaveResult, VisualRulesError, VisualRulesManager, VisualRulesState,
+};
+#[cfg(feature = "native-persistence")]
+pub use visual_rules_store::{
+    AtomicFileReplacer, NativeAtomicFileReplacer, NativeVisualRulesStore, StoreCommit,
+    VisualRulesStore,
+};

--- a/logmancer-core/src/models/mod.rs
+++ b/logmancer-core/src/models/mod.rs
@@ -7,4 +7,5 @@ pub mod visual_rules;
 pub use file_info::FileInfo;
 pub use page_result::{PageLine, PageResult};
 pub use search::SearchStatus;
-pub use visual_rules::{LineStyleIntent, VisualRule};
+#[allow(unused_imports)]
+pub use visual_rules::{LineStyleIntent, ValidationDiagnostic, ValidationSeverity, VisualRule};

--- a/logmancer-core/src/models/visual_rules.rs
+++ b/logmancer-core/src/models/visual_rules.rs
@@ -26,3 +26,158 @@ pub struct LineStyleIntent {
     pub foreground: Option<VisualColor>,
     pub background: Option<VisualColor>,
 }
+
+pub const MAX_STORED_VISUAL_RULES: usize = 100;
+pub const MAX_ENABLED_VISUAL_RULES: usize = 50;
+pub const MAX_VISUAL_RULE_PATTERN_LENGTH: usize = 512;
+pub const MAX_VISUAL_RULE_NAME_LENGTH: usize = 80;
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualRulesEnvelope {
+    pub schema_version: u32,
+    pub rules: Vec<ManagedVisualRule>,
+}
+
+impl VisualRulesEnvelope {
+    pub const MAX_PERSISTED_SIZE: usize = 256 * 1024;
+
+    pub fn new(rules: Vec<ManagedVisualRule>) -> Self {
+        Self {
+            schema_version: 1,
+            rules,
+        }
+    }
+
+    pub fn validate_for_save(&self) -> Result<ValidationReport, ValidationError> {
+        validate_envelope(self, false)
+    }
+
+    pub fn validate_for_load(&self) -> Result<ValidationReport, ValidationError> {
+        validate_envelope(self, true)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedVisualRule {
+    pub name: Option<String>,
+    pub enabled: bool,
+    pub matcher: VisualMatcher,
+    pub case_sensitive: bool,
+    pub style: LineStyleIntent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidationReport {
+    pub evaluator_rules: Vec<VisualRule>,
+    pub diagnostics: Vec<ValidationDiagnostic>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidationDiagnostic {
+    pub severity: ValidationSeverity,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ValidationSeverity {
+    Warning,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidationError {
+    pub message: String,
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+fn validate_envelope(
+    envelope: &VisualRulesEnvelope,
+    recover_entries: bool,
+) -> Result<ValidationReport, ValidationError> {
+    if envelope.schema_version != 1 {
+        return Err(ValidationError {
+            message: "unsupported schemaVersion".to_string(),
+        });
+    }
+    if envelope.rules.len() > MAX_STORED_VISUAL_RULES {
+        return Err(ValidationError {
+            message: "at most 100 rules may be stored".to_string(),
+        });
+    }
+    if envelope.rules.iter().filter(|rule| rule.enabled).count() > MAX_ENABLED_VISUAL_RULES {
+        return Err(ValidationError {
+            message: "at most 50 rules may be enabled".to_string(),
+        });
+    }
+
+    let mut evaluator_rules = Vec::new();
+    let mut diagnostics = Vec::new();
+    for (index, rule) in envelope.rules.iter().enumerate() {
+        match validate_rule(rule) {
+            Ok(()) if rule.enabled => evaluator_rules.push(VisualRule {
+                matcher: rule.matcher.clone(),
+                case_sensitive: rule.case_sensitive,
+                style: rule.style.clone(),
+            }),
+            Ok(()) => {}
+            Err(message) if recover_entries => diagnostics.push(ValidationDiagnostic {
+                severity: ValidationSeverity::Warning,
+                message: format!("rule {}: {}", index + 1, message),
+            }),
+            Err(message) => {
+                return Err(ValidationError {
+                    message: format!("rule {}: {}", index + 1, message),
+                });
+            }
+        }
+    }
+    Ok(ValidationReport {
+        evaluator_rules,
+        diagnostics,
+    })
+}
+
+fn validate_rule(rule: &ManagedVisualRule) -> Result<(), String> {
+    if rule
+        .name
+        .as_ref()
+        .is_some_and(|name| name.chars().count() > MAX_VISUAL_RULE_NAME_LENGTH)
+    {
+        return Err("name exceeds 80 characters".to_string());
+    }
+    let pattern = match &rule.matcher {
+        VisualMatcher::Text(pattern) | VisualMatcher::Regex(pattern) => pattern,
+    };
+    if pattern.chars().count() > MAX_VISUAL_RULE_PATTERN_LENGTH {
+        return Err("pattern exceeds 512 characters".to_string());
+    }
+    for color in [&rule.style.foreground, &rule.style.background]
+        .into_iter()
+        .flatten()
+    {
+        if !matches!(
+            color.0.as_str(),
+            "default" | "red" | "orange" | "yellow" | "green" | "cyan" | "blue" | "purple" | "gray"
+        ) {
+            return Err(format!("unsupported palette token '{}'", color.0));
+        }
+    }
+    if let VisualMatcher::Regex(pattern) = &rule.matcher
+        && regex::RegexBuilder::new(pattern)
+            .case_insensitive(!rule.case_sensitive)
+            .build()
+            .is_err()
+    {
+        return Err("invalid regex".to_string());
+    }
+    Ok(())
+}

--- a/logmancer-core/src/reader.rs
+++ b/logmancer-core/src/reader.rs
@@ -1,6 +1,6 @@
 use crate::handler::LogFileHandler;
-use crate::models::{FileInfo, LineStyleIntent, PageLine, PageResult, SearchStatus, VisualRule};
-use crate::visual_rules::VisualRuleEvaluator;
+use crate::models::{FileInfo, PageLine, PageResult, SearchStatus, VisualRule};
+use crate::{VisualRuleEvaluator, VisualRulesManager};
 use log::debug;
 use std::cmp::min;
 use std::io::{self};
@@ -8,7 +8,7 @@ use std::io::{self};
 pub struct LogReader {
     handler: LogFileHandler,
     current_view_start: usize,
-    visual_rule_evaluator: VisualRuleEvaluator,
+    visual_rules_manager: std::sync::Arc<VisualRulesManager>,
 }
 
 impl LogReader {
@@ -17,12 +17,35 @@ impl LogReader {
         Ok(LogReader {
             handler: file_log_handler,
             current_view_start: 0,
-            visual_rule_evaluator: VisualRuleEvaluator::default(),
+            visual_rules_manager: VisualRulesManager::in_memory(),
+        })
+    }
+
+    pub fn with_manager(
+        path: String,
+        visual_rules_manager: std::sync::Arc<VisualRulesManager>,
+    ) -> io::Result<Self> {
+        Ok(Self {
+            handler: LogFileHandler::new(path)?,
+            current_view_start: 0,
+            visual_rules_manager,
         })
     }
 
     pub fn set_visual_rules(&mut self, rules: Vec<VisualRule>) {
-        self.visual_rule_evaluator = VisualRuleEvaluator::compile(&rules);
+        let managed = rules
+            .into_iter()
+            .map(|rule| crate::ManagedVisualRule {
+                name: None,
+                enabled: true,
+                matcher: rule.matcher,
+                case_sensitive: rule.case_sensitive,
+                style: rule.style,
+            })
+            .collect();
+        let _ = self
+            .visual_rules_manager
+            .apply_memory(crate::VisualRulesEnvelope::new(managed));
     }
 
     /// Return file_id, path and other info about the open file
@@ -44,9 +67,10 @@ impl LogReader {
         let to_line = min(start_line + max_lines, read_ops.total_lines()?);
         let from_line = to_line.saturating_sub(max_lines);
         let mut lines = Vec::with_capacity(max_lines);
+        let evaluator = self.visual_rules_manager.snapshot();
         for current_line in from_line..to_line {
             let text = read_ops.read_line(current_line)?;
-            lines.push(self.page_line(current_line + 1, text));
+            lines.push(Self::page_line(&evaluator, current_line + 1, text));
         }
         let page = PageResult {
             lines,
@@ -69,9 +93,10 @@ impl LogReader {
         let total_lines = read_ops.total_lines()?;
         let start_line = total_lines.saturating_sub(max_lines);
         let mut lines = Vec::with_capacity(max_lines);
+        let evaluator = self.visual_rules_manager.snapshot();
         for current_line in start_line..total_lines {
             let text = read_ops.read_line(current_line)?;
-            lines.push(self.page_line(current_line + 1, text));
+            lines.push(Self::page_line(&evaluator, current_line + 1, text));
         }
         let page = PageResult {
             lines,
@@ -98,12 +123,13 @@ impl LogReader {
         let mut current_line = 0;
         let mut lines = Vec::with_capacity(max_lines);
         let mut visible_line_indexes = Vec::with_capacity(max_lines);
+        let evaluator = self.visual_rules_manager.snapshot();
 
         while lines.len() < max_lines && current_line < processed_lines {
             if let Some(line) = read_ops.read_filter_line(current_line)? {
                 if matched_lines >= start_line {
                     visible_line_indexes.push(current_line);
-                    lines.push(self.page_line(current_line + 1, line));
+                    lines.push(Self::page_line(&evaluator, current_line + 1, line));
                 }
                 matched_lines += 1;
             }
@@ -129,12 +155,13 @@ impl LogReader {
         let mut lines = Vec::with_capacity(max_lines);
         let mut visible_line_indexes = Vec::with_capacity(max_lines);
         let mut current_line = read_ops.total_lines()?;
+        let evaluator = self.visual_rules_manager.snapshot();
 
         while lines.len() < max_lines && current_line > 0 {
             current_line -= 1;
             if let Some(line) = read_ops.read_filter_line(current_line)? {
                 visible_line_indexes.push(current_line);
-                lines.push(self.page_line(current_line + 1, line));
+                lines.push(Self::page_line(&evaluator, current_line + 1, line));
             }
         }
         lines.reverse();
@@ -187,17 +214,13 @@ impl LogReader {
         self.read_page(start, max_lines)
     }
 
-    fn page_line(&self, number: usize, text: String) -> PageLine {
-        let style = self.evaluate_style(&text);
+    fn page_line(evaluator: &VisualRuleEvaluator, number: usize, text: String) -> PageLine {
+        let style = evaluator.evaluate(&text);
         PageLine {
             number,
             text,
             style,
         }
-    }
-
-    fn evaluate_style(&self, line: &str) -> Option<LineStyleIntent> {
-        self.visual_rule_evaluator.evaluate(line)
     }
 }
 

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -1,4 +1,4 @@
-use crate::LogReader;
+use crate::{LogReader, VisualRulesManager};
 use dashmap::DashMap;
 use dashmap::mapref::one::RefMut;
 use std::io;
@@ -7,19 +7,28 @@ use uuid::Uuid;
 
 pub struct LogRegistry {
     open_files: Arc<DashMap<Uuid, LogReader>>,
+    visual_rules_manager: Arc<VisualRulesManager>,
 }
 
 impl LogRegistry {
     pub fn new() -> Self {
         LogRegistry {
             open_files: Arc::new(DashMap::new()),
+            visual_rules_manager: VisualRulesManager::in_memory(),
+        }
+    }
+
+    pub fn with_manager(visual_rules_manager: Arc<VisualRulesManager>) -> Self {
+        Self {
+            open_files: Arc::new(DashMap::new()),
+            visual_rules_manager,
         }
     }
 
     /// Opens a new file and register with a UUID
     pub fn open_file(&self, path: &str) -> io::Result<String> {
         let uuid = Uuid::new_v4();
-        let reader = LogReader::new(path.to_string());
+        let reader = LogReader::with_manager(path.to_string(), self.visual_rules_manager.clone());
         self.open_files.insert(uuid, reader?);
         Ok(uuid.to_string())
     }

--- a/logmancer-core/src/visual_rules_manager.rs
+++ b/logmancer-core/src/visual_rules_manager.rs
@@ -1,0 +1,419 @@
+use crate::models::visual_rules::{ValidationDiagnostic, VisualRulesEnvelope};
+use crate::visual_rules::VisualRuleEvaluator;
+#[cfg(feature = "native-persistence")]
+use crate::visual_rules_store::{StoreCommit, VisualRulesStore};
+use std::sync::{Arc, Mutex, RwLock};
+
+#[cfg(feature = "native-persistence")]
+const PERSISTED_SIZE_ERROR: &str = "visual rules configuration exceeds 256 KiB";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SaveOutcome {
+    Committed,
+    CommittedWithWarning(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct VisualRulesState {
+    pub revision: u64,
+    pub envelope: VisualRulesEnvelope,
+    pub diagnostics: Vec<ValidationDiagnostic>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SaveResult {
+    pub revision: u64,
+    pub outcome: SaveOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum VisualRulesError {
+    Validation(String),
+    RevisionConflict,
+    SourceConflict,
+    Io(String),
+    Decode(String),
+}
+
+impl VisualRulesError {
+    pub fn is_source_conflict(&self) -> bool {
+        matches!(self, Self::SourceConflict)
+    }
+    pub fn is_io(&self) -> bool {
+        matches!(self, Self::Io(_))
+    }
+}
+
+impl std::fmt::Display for VisualRulesError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for VisualRulesError {}
+
+struct ManagerState {
+    revision: u64,
+    envelope: VisualRulesEnvelope,
+    source: Option<Vec<u8>>,
+    diagnostics: Vec<ValidationDiagnostic>,
+}
+
+pub struct VisualRulesManager {
+    evaluator: RwLock<Arc<VisualRuleEvaluator>>,
+    state: Mutex<ManagerState>,
+    #[cfg(feature = "native-persistence")]
+    store: Option<Arc<dyn VisualRulesStore>>,
+}
+
+impl VisualRulesManager {
+    pub fn in_memory() -> Arc<Self> {
+        Arc::new(Self {
+            evaluator: RwLock::new(Arc::new(VisualRuleEvaluator::default())),
+            state: Mutex::new(ManagerState {
+                revision: 0,
+                envelope: VisualRulesEnvelope::new(Vec::new()),
+                source: None,
+                diagnostics: Vec::new(),
+            }),
+            #[cfg(feature = "native-persistence")]
+            store: None,
+        })
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn with_store(store: Arc<dyn VisualRulesStore>) -> Arc<Self> {
+        let manager = match Arc::try_unwrap(Self::in_memory()) {
+            Ok(manager) => manager,
+            Err(_) => unreachable!("new manager has one owner"),
+        };
+        Arc::new(Self {
+            store: Some(store),
+            ..manager
+        })
+    }
+
+    pub fn snapshot(&self) -> Arc<VisualRuleEvaluator> {
+        self.evaluator
+            .read()
+            .expect("visual rules evaluator lock")
+            .clone()
+    }
+
+    pub fn state(&self) -> VisualRulesState {
+        let state = self.state.lock().expect("visual rules state lock");
+        VisualRulesState {
+            revision: state.revision,
+            envelope: state.envelope.clone(),
+            diagnostics: state.diagnostics.clone(),
+        }
+    }
+
+    pub fn apply_memory(
+        &self,
+        envelope: VisualRulesEnvelope,
+    ) -> Result<SaveResult, VisualRulesError> {
+        let report = envelope
+            .validate_for_save()
+            .map_err(|error| VisualRulesError::Validation(error.message))?;
+        let mut state = self.state.lock().expect("visual rules state lock");
+        self.publish(
+            &mut state,
+            envelope,
+            report.evaluator_rules,
+            report.diagnostics,
+            None,
+        );
+        Ok(SaveResult {
+            revision: state.revision,
+            outcome: SaveOutcome::Committed,
+        })
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn load(&self) -> Result<VisualRulesState, VisualRulesError> {
+        let mut state = self.state.lock().expect("visual rules state lock");
+        let source = self
+            .store
+            .as_ref()
+            .expect("native store")
+            .read()
+            .map_err(io_error)?;
+        if source
+            .as_ref()
+            .is_some_and(|bytes| bytes.len() > VisualRulesEnvelope::MAX_PERSISTED_SIZE)
+        {
+            state.revision += 1;
+            state.source = source;
+            state.diagnostics = vec![ValidationDiagnostic {
+                severity: crate::models::ValidationSeverity::Warning,
+                message: PERSISTED_SIZE_ERROR.to_string(),
+            }];
+            return Ok(VisualRulesState {
+                revision: state.revision,
+                envelope: state.envelope.clone(),
+                diagnostics: state.diagnostics.clone(),
+            });
+        }
+        let (envelope, report) = match source.as_deref() {
+            None | Some([]) => (VisualRulesEnvelope::new(Vec::new()), None),
+            Some(bytes) => match serde_json::from_slice::<VisualRulesEnvelope>(bytes)
+                .map_err(|error| error.to_string())
+                .and_then(|envelope| {
+                    envelope
+                        .validate_for_load()
+                        .map_err(|error| error.message)
+                        .map(|report| (envelope, report))
+                }) {
+                Ok((envelope, report)) => (envelope, Some(report)),
+                Err(message) => {
+                    state.revision += 1;
+                    state.source = source;
+                    state.diagnostics = vec![ValidationDiagnostic {
+                        severity: crate::models::ValidationSeverity::Warning,
+                        message,
+                    }];
+                    return Ok(VisualRulesState {
+                        revision: state.revision,
+                        envelope: state.envelope.clone(),
+                        diagnostics: state.diagnostics.clone(),
+                    });
+                }
+            },
+        };
+        let evaluator_rules = report
+            .as_ref()
+            .map(|report| report.evaluator_rules.clone())
+            .unwrap_or_default();
+        let diagnostics = report.map(|report| report.diagnostics).unwrap_or_default();
+        self.publish(&mut state, envelope, evaluator_rules, diagnostics, source);
+        Ok(VisualRulesState {
+            revision: state.revision,
+            envelope: state.envelope.clone(),
+            diagnostics: state.diagnostics.clone(),
+        })
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn save(
+        &self,
+        base_revision: u64,
+        envelope: VisualRulesEnvelope,
+    ) -> Result<SaveResult, VisualRulesError> {
+        self.persist(base_revision, envelope, false)
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn replace(
+        &self,
+        base_revision: u64,
+        envelope: VisualRulesEnvelope,
+    ) -> Result<SaveResult, VisualRulesError> {
+        self.persist(base_revision, envelope, true)
+    }
+
+    #[cfg(feature = "native-persistence")]
+    fn persist(
+        &self,
+        base_revision: u64,
+        envelope: VisualRulesEnvelope,
+        replace: bool,
+    ) -> Result<SaveResult, VisualRulesError> {
+        let report = envelope
+            .validate_for_save()
+            .map_err(|error| VisualRulesError::Validation(error.message))?;
+        let bytes = serde_json::to_vec(&envelope)
+            .map_err(|error| VisualRulesError::Decode(error.to_string()))?;
+        if bytes.len() > VisualRulesEnvelope::MAX_PERSISTED_SIZE {
+            return Err(VisualRulesError::Validation(
+                PERSISTED_SIZE_ERROR.to_string(),
+            ));
+        }
+        let mut state = self.state.lock().expect("visual rules state lock");
+        if state.revision != base_revision {
+            return Err(VisualRulesError::RevisionConflict);
+        }
+        let store = self.store.as_ref().expect("native store");
+        let commit = store
+            .compare_and_commit(state.source.as_deref(), &bytes, replace)
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::AlreadyExists {
+                    VisualRulesError::SourceConflict
+                } else {
+                    io_error(error)
+                }
+            })?;
+        self.publish(
+            &mut state,
+            envelope,
+            report.evaluator_rules,
+            report.diagnostics,
+            Some(bytes),
+        );
+        Ok(SaveResult {
+            revision: state.revision,
+            outcome: match commit {
+                StoreCommit::Committed => SaveOutcome::Committed,
+                StoreCommit::CommittedWithWarning(message) => {
+                    SaveOutcome::CommittedWithWarning(message)
+                }
+            },
+        })
+    }
+
+    fn publish(
+        &self,
+        state: &mut ManagerState,
+        envelope: VisualRulesEnvelope,
+        rules: Vec<crate::models::VisualRule>,
+        diagnostics: Vec<ValidationDiagnostic>,
+        source: Option<Vec<u8>>,
+    ) {
+        *self.evaluator.write().expect("visual rules evaluator lock") =
+            Arc::new(VisualRuleEvaluator::compile(&rules));
+        state.envelope = envelope;
+        state.diagnostics = diagnostics;
+        state.source = source;
+        state.revision += 1;
+    }
+}
+
+#[cfg(feature = "native-persistence")]
+fn io_error(error: std::io::Error) -> VisualRulesError {
+    VisualRulesError::Io(error.to_string())
+}
+
+#[cfg(all(test, feature = "native-persistence"))]
+mod tests {
+    use super::*;
+    use crate::{
+        LineStyleIntent, ManagedVisualRule, VisualColor, VisualMatcher, VisualRulesEnvelope,
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc::{self, Receiver, Sender};
+    use std::time::Duration;
+
+    struct PausingReadStore {
+        bytes: Mutex<Option<Vec<u8>>>,
+        pause_next_read: AtomicBool,
+        read_captured: Sender<()>,
+        release_read: Mutex<Receiver<()>>,
+        commit_finished: Sender<()>,
+    }
+
+    impl VisualRulesStore for PausingReadStore {
+        fn read(&self) -> std::io::Result<Option<Vec<u8>>> {
+            let bytes = self.bytes.lock().expect("store lock").clone();
+            if self.pause_next_read.swap(false, Ordering::SeqCst) {
+                self.read_captured.send(()).expect("report captured read");
+                self.release_read
+                    .lock()
+                    .expect("release receiver lock")
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("captured read was not released before timeout");
+            }
+            Ok(bytes)
+        }
+
+        fn save_new(&self, _bytes: &[u8]) -> std::io::Result<StoreCommit> {
+            unreachable!("the test replaces an existing source")
+        }
+
+        fn replace(&self, bytes: &[u8]) -> std::io::Result<StoreCommit> {
+            *self.bytes.lock().expect("store lock") = Some(bytes.to_vec());
+            Ok(StoreCommit::Committed)
+        }
+
+        fn compare_and_commit(
+            &self,
+            expected: Option<&[u8]>,
+            bytes: &[u8],
+            replace: bool,
+        ) -> std::io::Result<StoreCommit> {
+            let mut stored = self.bytes.lock().expect("store lock");
+            if stored.as_deref() != expected {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::AlreadyExists,
+                    "source changed before publication",
+                ));
+            }
+            assert!(replace, "the test replaces an existing source");
+            *stored = Some(bytes.to_vec());
+            self.commit_finished.send(()).expect("report commit");
+            Ok(StoreCommit::Committed)
+        }
+    }
+
+    fn envelope(pattern: &str) -> VisualRulesEnvelope {
+        VisualRulesEnvelope::new(vec![ManagedVisualRule {
+            name: Some("test rule".to_string()),
+            enabled: true,
+            matcher: VisualMatcher::Text(pattern.to_string()),
+            case_sensitive: false,
+            style: LineStyleIntent {
+                foreground: Some(VisualColor("red".to_string())),
+                background: Some(VisualColor("default".to_string())),
+            },
+        }])
+    }
+
+    #[test]
+    fn concurrent_load_cannot_overwrite_a_successful_save_in_memory() {
+        let initial_envelope = envelope("ERROR");
+        let saved_envelope = envelope("WARN");
+        let (read_captured_tx, read_captured_rx) = mpsc::channel();
+        let (release_read_tx, release_read_rx) = mpsc::channel();
+        let (commit_finished_tx, commit_finished_rx) = mpsc::channel();
+        let store = Arc::new(PausingReadStore {
+            bytes: Mutex::new(Some(
+                serde_json::to_vec(&initial_envelope).expect("serialize initial envelope"),
+            )),
+            pause_next_read: AtomicBool::new(false),
+            read_captured: read_captured_tx,
+            release_read: Mutex::new(release_read_rx),
+            commit_finished: commit_finished_tx,
+        });
+        let manager = VisualRulesManager::with_store(store.clone());
+        let initial = manager.load().expect("initial load");
+
+        store.pause_next_read.store(true, Ordering::SeqCst);
+        let loading_manager = manager.clone();
+        let load_thread = std::thread::spawn(move || loading_manager.load());
+        read_captured_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("concurrent load did not capture its source");
+
+        let load_holds_state = manager.state.try_lock().is_err();
+        let save_revision = initial.revision + u64::from(load_holds_state);
+        let saving_manager = manager.clone();
+        let save_thread =
+            std::thread::spawn(move || saving_manager.replace(save_revision, saved_envelope));
+
+        if load_holds_state {
+            release_read_tx.send(()).expect("release captured read");
+            commit_finished_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("save did not commit after load publication");
+        } else {
+            commit_finished_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("save did not commit while stale load was paused");
+            release_read_tx.send(()).expect("release captured read");
+        }
+
+        let saved = save_thread
+            .join()
+            .expect("save thread")
+            .expect("concurrent save");
+        load_thread
+            .join()
+            .expect("load thread")
+            .expect("concurrent load");
+
+        let state = manager.state();
+        assert_eq!(state.revision, saved.revision);
+        assert_eq!(state.envelope, envelope("WARN"));
+        assert!(manager.snapshot().evaluate("WARN").is_some());
+        assert_eq!(manager.snapshot().evaluate("ERROR"), None);
+    }
+}

--- a/logmancer-core/src/visual_rules_store.rs
+++ b/logmancer-core/src/visual_rules_store.rs
@@ -1,0 +1,255 @@
+#![cfg(feature = "native-persistence")]
+
+use crate::models::visual_rules::VisualRulesEnvelope;
+use atomic_write_file::AtomicWriteFile;
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static TEMPORARY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static COMMIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+const OVERSIZED_TOKEN_DOMAIN: &[u8] = b"logmancer:visual-rules:oversized:sha256:v1\0";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StoreCommit {
+    Committed,
+    CommittedWithWarning(String),
+}
+
+impl StoreCommit {
+    pub fn with_warning(message: impl Into<String>) -> Self {
+        Self::CommittedWithWarning(message.into())
+    }
+}
+
+pub trait VisualRulesStore: Send + Sync {
+    fn read(&self) -> io::Result<Option<Vec<u8>>>;
+    fn save_new(&self, bytes: &[u8]) -> io::Result<StoreCommit>;
+    fn replace(&self, bytes: &[u8]) -> io::Result<StoreCommit>;
+    fn compare_and_commit(
+        &self,
+        expected: Option<&[u8]>,
+        bytes: &[u8],
+        replace: bool,
+    ) -> io::Result<StoreCommit>;
+}
+
+pub trait AtomicFileReplacer: Send + Sync {
+    fn save_new(&self, path: &Path, bytes: &[u8]) -> io::Result<StoreCommit>;
+    fn replace(&self, path: &Path, bytes: &[u8]) -> io::Result<StoreCommit>;
+}
+
+#[derive(Clone)]
+pub struct NativeVisualRulesStore {
+    path: PathBuf,
+    replacer: Arc<dyn AtomicFileReplacer>,
+}
+
+impl NativeVisualRulesStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self::with_replacer(path, Arc::new(NativeAtomicFileReplacer))
+    }
+
+    pub fn with_replacer(path: PathBuf, replacer: Arc<dyn AtomicFileReplacer>) -> Self {
+        Self { path, replacer }
+    }
+}
+
+impl VisualRulesStore for NativeVisualRulesStore {
+    fn read(&self) -> io::Result<Option<Vec<u8>>> {
+        let mut file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let read_limit = VisualRulesEnvelope::MAX_PERSISTED_SIZE + 1;
+        let mut bytes = Vec::with_capacity(read_limit);
+        (&mut file)
+            .take(read_limit as u64)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() <= VisualRulesEnvelope::MAX_PERSISTED_SIZE {
+            return Ok(Some(bytes));
+        }
+
+        let mut digest = Sha256::new();
+        digest.update(&bytes);
+        let mut total_len = bytes.len() as u64;
+        let mut buffer = [0_u8; 8192];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+            total_len = total_len
+                .checked_add(read as u64)
+                .ok_or_else(|| io::Error::other("visual rules source length overflow"))?;
+        }
+
+        bytes.clear();
+        bytes.extend_from_slice(OVERSIZED_TOKEN_DOMAIN);
+        bytes.extend_from_slice(&total_len.to_be_bytes());
+        bytes.extend_from_slice(&digest.finalize());
+        bytes.resize(read_limit, 0);
+        Ok(Some(bytes))
+    }
+
+    fn save_new(&self, bytes: &[u8]) -> io::Result<StoreCommit> {
+        self.replacer.save_new(&self.path, bytes)
+    }
+
+    fn replace(&self, bytes: &[u8]) -> io::Result<StoreCommit> {
+        self.replacer.replace(&self.path, bytes)
+    }
+
+    fn compare_and_commit(
+        &self,
+        expected: Option<&[u8]>,
+        bytes: &[u8],
+        replace: bool,
+    ) -> io::Result<StoreCommit> {
+        let _commit = COMMIT_LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .map_err(|_| io::Error::other("visual rules commit lock poisoned"))?;
+        let mut lock_path = self.path.as_os_str().to_os_string();
+        lock_path.push(".lock");
+        let lock_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(PathBuf::from(lock_path))?;
+        lock_file.lock()?;
+        let result = (|| {
+            if self.read()?.as_deref() != expected {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    "visual rules source changed before publication",
+                ));
+            }
+            if replace {
+                self.replace(bytes)
+            } else {
+                self.save_new(bytes)
+            }
+        })();
+        match (result, lock_file.unlock()) {
+            (Ok(commit), Ok(())) => Ok(commit),
+            (Err(error), _) | (_, Err(error)) => Err(error),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct NativeAtomicFileReplacer;
+
+impl AtomicFileReplacer for NativeAtomicFileReplacer {
+    #[cfg(unix)]
+    fn save_new(&self, path: &Path, bytes: &[u8]) -> io::Result<StoreCommit> {
+        let temporary_path = temporary_path(path);
+        let mut temporary = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary_path)?;
+        temporary.write_all(bytes)?;
+        temporary.sync_all()?;
+        drop(temporary);
+
+        if let Err(error) = fs::hard_link(&temporary_path, path) {
+            let _ = fs::remove_file(&temporary_path);
+            return Err(error);
+        }
+
+        let cleanup = fs::remove_file(&temporary_path).and_then(|_| sync_parent(path));
+        match cleanup {
+            Ok(()) => Ok(StoreCommit::Committed),
+            Err(error) => Ok(StoreCommit::with_warning(error.to_string())),
+        }
+    }
+
+    #[cfg(windows)]
+    fn save_new(&self, path: &Path, bytes: &[u8]) -> io::Result<StoreCommit> {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{MOVEFILE_WRITE_THROUGH, MoveFileExW};
+
+        let temporary_path = temporary_path(path);
+        let mut temporary = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary_path)?;
+        temporary.write_all(bytes)?;
+        temporary.sync_all()?;
+        drop(temporary);
+
+        let source: Vec<u16> = temporary_path
+            .as_os_str()
+            .encode_wide()
+            .chain(Some(0))
+            .collect();
+        let target: Vec<u16> = path.as_os_str().encode_wide().chain(Some(0)).collect();
+        if unsafe { MoveFileExW(source.as_ptr(), target.as_ptr(), MOVEFILE_WRITE_THROUGH) } == 0 {
+            let error = io::Error::last_os_error();
+            let _ = fs::remove_file(&temporary_path);
+            return Err(error);
+        }
+        Ok(StoreCommit::Committed)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    fn save_new(&self, _path: &Path, _bytes: &[u8]) -> io::Result<StoreCommit> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "native first-save unsupported",
+        ))
+    }
+
+    fn replace(&self, path: &Path, bytes: &[u8]) -> io::Result<StoreCommit> {
+        let backup = timestamped_backup_path(path)?;
+        fs::copy(path, &backup)?;
+        File::open(&backup)?.sync_all()?;
+
+        let mut file = AtomicWriteFile::options().open(path)?;
+        file.write_all(bytes)?;
+        file.commit()?;
+        match sync_parent(path) {
+            Ok(()) => Ok(StoreCommit::Committed),
+            Err(error) => Ok(StoreCommit::with_warning(error.to_string())),
+        }
+    }
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let sequence = TEMPORARY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    parent.join(format!(
+        ".{}.{}.{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("visual-rules"),
+        std::process::id(),
+        sequence
+    ))
+}
+
+fn timestamped_backup_path(path: &Path) -> io::Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_millis();
+    Ok(path.with_extension(format!("{timestamp}.bak")))
+}
+
+#[cfg(unix)]
+fn sync_parent(path: &Path) -> io::Result<()> {
+    File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent(_path: &Path) -> io::Result<()> {
+    Ok(())
+}

--- a/logmancer-core/tests/visual_rules_management.rs
+++ b/logmancer-core/tests/visual_rules_management.rs
@@ -1,0 +1,1110 @@
+#![cfg(feature = "native-persistence")]
+
+use logmancer_core::{
+    AtomicFileReplacer, LineStyleIntent, LogRegistry, ManagedVisualRule, NativeVisualRulesStore,
+    SaveOutcome, StoreCommit, ValidationSeverity, VisualColor, VisualMatcher, VisualRulesEnvelope,
+    VisualRulesError, VisualRulesManager, VisualRulesStore,
+};
+use std::fs::File;
+use std::io::{BufRead, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, Sender};
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn style(foreground: Option<&str>, background: Option<&str>) -> LineStyleIntent {
+    LineStyleIntent {
+        foreground: foreground.map(|value| VisualColor(value.to_string())),
+        background: background.map(|value| VisualColor(value.to_string())),
+    }
+}
+
+fn red_style() -> Option<LineStyleIntent> {
+    Some(style(Some("red"), Some("default")))
+}
+
+fn rule(pattern: &str) -> ManagedVisualRule {
+    ManagedVisualRule {
+        name: Some("important".to_string()),
+        enabled: true,
+        matcher: VisualMatcher::Text(pattern.to_string()),
+        case_sensitive: false,
+        style: style(Some("red"), Some("default")),
+    }
+}
+
+fn oversized_valid_envelope() -> VisualRulesEnvelope {
+    let mut oversized_rule = rule(&"\u{1}".repeat(512));
+    oversized_rule.name = Some("\u{1}".repeat(80));
+    oversized_rule.enabled = false;
+    let envelope = VisualRulesEnvelope::new(vec![oversized_rule; 100]);
+
+    envelope
+        .validate_for_save()
+        .expect("character-count limits remain valid");
+    assert!(
+        serde_json::to_vec(&envelope)
+            .expect("serialize oversized envelope")
+            .len()
+            > VisualRulesEnvelope::MAX_PERSISTED_SIZE
+    );
+    envelope
+}
+
+fn envelope_with_serialized_size(target: usize) -> VisualRulesEnvelope {
+    let empty_rule = ManagedVisualRule {
+        name: Some(String::new()),
+        enabled: false,
+        matcher: VisualMatcher::Text(String::new()),
+        case_sensitive: false,
+        style: style(Some("red"), Some("default")),
+    };
+    let mut envelope = VisualRulesEnvelope::new(vec![empty_rule; 100]);
+    let baseline = serde_json::to_vec(&envelope)
+        .expect("serialize baseline envelope")
+        .len();
+    let extra = target
+        .checked_sub(baseline)
+        .expect("target exceeds baseline");
+    let mut escaped = extra / 6;
+    let mut ascii = extra % 6;
+
+    let mut fill = |capacity| {
+        let escaped_count = escaped.min(capacity);
+        escaped -= escaped_count;
+        let ascii_count = ascii.min(capacity - escaped_count);
+        ascii -= ascii_count;
+        "\u{1}".repeat(escaped_count) + &"x".repeat(ascii_count)
+    };
+    for rule in &mut envelope.rules {
+        rule.matcher = VisualMatcher::Text(fill(512));
+        rule.name = Some(fill(80));
+    }
+    assert_eq!((escaped, ascii), (0, 0));
+    assert!(envelope.validate_for_save().is_ok());
+    let size = serde_json::to_vec(&envelope)
+        .expect("serialize boundary envelope")
+        .len();
+    assert_eq!(size, target);
+    envelope
+}
+
+#[test]
+fn envelope_validation_enforces_limits_palette_and_enabled_conversion() {
+    let envelope = VisualRulesEnvelope::new(vec![rule("ERROR")]);
+
+    let validated = envelope.validate_for_save().expect("valid envelope");
+    assert_eq!(validated.evaluator_rules.len(), 1);
+    assert_eq!(
+        validated.evaluator_rules[0].matcher,
+        VisualMatcher::Text("ERROR".to_string())
+    );
+
+    let mut disabled = rule("[");
+    disabled.enabled = false;
+    disabled.matcher = VisualMatcher::Regex("[".to_string());
+    let report = VisualRulesEnvelope::new(vec![disabled])
+        .validate_for_load()
+        .expect("disabled invalid regex is recoverable");
+    assert!(report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.severity == ValidationSeverity::Warning && diagnostic.message.contains("regex")
+    }));
+    assert!(report.evaluator_rules.is_empty());
+}
+
+#[test]
+fn envelope_validation_rejects_limits_and_recovers_valid_siblings_in_order() {
+    let mut bad = rule(&"x".repeat(513));
+    bad.name = Some("n".repeat(81));
+    bad.style = style(Some("not-a-palette-token"), None);
+    let envelope = VisualRulesEnvelope::new(vec![rule("first"), bad, rule("last")]);
+
+    let report = envelope
+        .validate_for_load()
+        .expect("entry failure is recoverable");
+    assert_eq!(report.evaluator_rules.len(), 2);
+    assert_eq!(
+        report.evaluator_rules[0].matcher,
+        VisualMatcher::Text("first".to_string())
+    );
+    assert_eq!(
+        report.evaluator_rules[1].matcher,
+        VisualMatcher::Text("last".to_string())
+    );
+    assert_eq!(report.diagnostics.len(), 1);
+
+    let too_many =
+        VisualRulesEnvelope::new((0..101).map(|index| rule(&index.to_string())).collect());
+    assert!(too_many.validate_for_load().is_err());
+}
+
+fn temp_log_path(name: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("logmancer-{name}-{suffix}.log"))
+}
+
+fn wait_for_indexed_lines(registry: &LogRegistry, file_id: &str, expected: usize) {
+    for _ in 0..20 {
+        if registry
+            .get_reader(file_id)
+            .expect("reader")
+            .file_info()
+            .expect("file info")
+            .total_lines
+            >= expected
+        {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    panic!("reader did not index {expected} lines");
+}
+
+#[test]
+fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_navigation() {
+    let path = temp_log_path("visual-rules-snapshot");
+    let mut file = File::create(&path).expect("create log");
+    writeln!(file, "INFO boot").expect("write");
+    writeln!(file, "ERROR disk").expect("write");
+    writeln!(file, "WARN cache").expect("write");
+    drop(file);
+
+    let manager = VisualRulesManager::in_memory();
+    let registry = LogRegistry::with_manager(manager.clone());
+    let first_id = registry
+        .open_file(path.to_str().expect("path"))
+        .expect("open first");
+    manager
+        .apply_memory(VisualRulesEnvelope::new(vec![rule("ERROR")]))
+        .expect("apply first snapshot");
+
+    wait_for_indexed_lines(&registry, &first_id, 3);
+
+    let first_page = registry
+        .get_reader(&first_id)
+        .expect("first reader")
+        .read_page(0, 3)
+        .expect("read page");
+    assert_eq!(
+        first_page
+            .lines
+            .iter()
+            .map(|line| line.number)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3]
+    );
+    assert_eq!(
+        first_page.lines[1].style,
+        Some(style(Some("red"), Some("default")))
+    );
+
+    manager
+        .apply_memory(VisualRulesEnvelope::new(vec![rule("WARN")]))
+        .expect("swap snapshot");
+    let second_id = registry
+        .open_file(path.to_str().expect("path"))
+        .expect("open second");
+    wait_for_indexed_lines(&registry, &second_id, 3);
+    let second_page = registry
+        .get_reader(&second_id)
+        .expect("second reader")
+        .read_page(0, 3)
+        .expect("read future reader");
+    assert_eq!(second_page.lines[1].style, None);
+    assert_eq!(
+        second_page.lines[2].style,
+        Some(style(Some("red"), Some("default")))
+    );
+
+    let mut reader = registry.get_reader(&first_id).expect("first reader");
+    reader.filter("ERROR|WARN".to_string());
+    let filtered = reader.read_filter(0, 3).expect("filtered read");
+    assert_eq!(
+        filtered
+            .lines
+            .iter()
+            .map(|line| line.number)
+            .collect::<Vec<_>>(),
+        vec![2, 3]
+    );
+    let searched = reader.apply_search("WARN".to_string(), 3).expect("search");
+    assert_eq!(
+        searched
+            .lines
+            .iter()
+            .map(|line| line.number)
+            .collect::<Vec<_>>(),
+        vec![2, 3, 4]
+    );
+    assert_eq!(reader.search_status().query.as_deref(), Some("WARN"));
+
+    std::fs::remove_file(path).expect("remove log");
+}
+
+fn temp_config_path(name: &str) -> std::path::PathBuf {
+    let suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!("logmancer-{name}-{suffix}.json"))
+}
+
+fn native_manager(path: &std::path::Path) -> std::sync::Arc<VisualRulesManager> {
+    VisualRulesManager::with_store(std::sync::Arc::new(NativeVisualRulesStore::new(
+        path.to_path_buf(),
+    )))
+}
+
+struct ProcessPausingReplacer;
+
+impl AtomicFileReplacer for ProcessPausingReplacer {
+    fn save_new(&self, _path: &std::path::Path, _bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        unreachable!("the process proof replaces an existing file")
+    }
+
+    fn replace(&self, path: &std::path::Path, bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        println!("EVENT PUBLISH");
+        std::io::stdout().flush()?;
+        let mut release = String::new();
+        std::io::stdin().read_line(&mut release)?;
+        assert_eq!(release.trim(), "RELEASE");
+        std::fs::write(path, bytes)?;
+        Ok(StoreCommit::Committed)
+    }
+}
+
+#[test]
+fn native_store_process_worker() {
+    let Some(path) = std::env::var_os("LOGMANCER_PROCESS_STORE_PATH") else {
+        return;
+    };
+    let pattern = std::env::var("LOGMANCER_PROCESS_PATTERN").expect("worker pattern");
+    let store = NativeVisualRulesStore::with_replacer(
+        std::path::PathBuf::from(path),
+        std::sync::Arc::new(ProcessPausingReplacer),
+    );
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(store));
+    let state = manager.load().expect("worker load");
+
+    println!("EVENT READY");
+    std::io::stdout().flush().expect("flush ready event");
+    let mut start = String::new();
+    std::io::stdin().read_line(&mut start).expect("read start");
+    assert_eq!(start.trim(), "START");
+
+    let result = manager.replace(
+        state.revision,
+        VisualRulesEnvelope::new(vec![rule(&pattern)]),
+    );
+    let outcome = match result {
+        Ok(_) => "COMMITTED",
+        Err(error) if error.is_source_conflict() => "CONFLICT",
+        Err(error) => panic!("unexpected worker error: {error}"),
+    };
+    println!("EVENT RESULT {outcome}");
+    std::io::stdout().flush().expect("flush result event");
+}
+
+fn spawn_store_worker(
+    id: usize,
+    path: &std::path::Path,
+    pattern: &str,
+    events: Sender<(usize, String)>,
+) -> (Child, ChildStdin) {
+    let mut child = Command::new(std::env::current_exe().expect("test executable"))
+        .args(["--exact", "native_store_process_worker", "--nocapture"])
+        .env("LOGMANCER_PROCESS_STORE_PATH", path)
+        .env("LOGMANCER_PROCESS_PATTERN", pattern)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("spawn store worker");
+    let stdout = child.stdout.take().expect("worker stdout");
+    std::thread::spawn(move || {
+        for line in std::io::BufReader::new(stdout)
+            .lines()
+            .map_while(Result::ok)
+        {
+            if let Some(event) = line.strip_prefix("EVENT ") {
+                events.send((id, event.to_string())).expect("send event");
+            }
+        }
+    });
+    let stdin = child.stdin.take().expect("worker stdin");
+    (child, stdin)
+}
+
+fn process_event(events: &Receiver<(usize, String)>) -> (usize, String) {
+    events
+        .recv_timeout(Duration::from_secs(5))
+        .expect("worker event before deadlock timeout")
+}
+
+#[test]
+fn separate_processes_serialize_native_compare_and_commit() {
+    let path = temp_config_path("visual-rules-process-lock");
+    let source = serde_json::to_vec(&VisualRulesEnvelope::new(vec![rule("ERROR")]))
+        .expect("serialize source");
+    std::fs::write(&path, source).expect("write source");
+    let (event_tx, event_rx) = mpsc::channel();
+    let (mut first, mut first_stdin) = spawn_store_worker(0, &path, "WARN", event_tx.clone());
+    let (mut second, mut second_stdin) = spawn_store_worker(1, &path, "INFO", event_tx);
+
+    let mut ready = [false; 2];
+    while !ready.iter().all(|value| *value) {
+        let (id, event) = process_event(&event_rx);
+        assert_eq!(event, "READY");
+        ready[id] = true;
+    }
+    writeln!(first_stdin, "START").expect("start first worker");
+    writeln!(second_stdin, "START").expect("start second worker");
+
+    let (publisher, event) = process_event(&event_rx);
+    assert_eq!(event, "PUBLISH");
+    let mut publications = 1;
+    let mut results = Vec::new();
+    match event_rx.recv_timeout(Duration::from_secs(2)) {
+        Ok((id, event)) => {
+            assert_eq!(event, "PUBLISH");
+            publications += 1;
+            writeln!([&mut first_stdin, &mut second_stdin][id], "RELEASE")
+                .expect("release second publisher");
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {}
+        Err(error) => panic!("worker event channel failed: {error}"),
+    }
+    writeln!([&mut first_stdin, &mut second_stdin][publisher], "RELEASE")
+        .expect("release first publisher");
+
+    while results.len() < 2 {
+        let (id, event) = process_event(&event_rx);
+        if event == "PUBLISH" {
+            publications += 1;
+            writeln!([&mut first_stdin, &mut second_stdin][id], "RELEASE")
+                .expect("release publisher");
+        } else if let Some(result) = event.strip_prefix("RESULT ") {
+            results.push(result.to_string());
+        } else {
+            panic!("unexpected worker event: {event}");
+        }
+    }
+    assert!(first.wait().expect("first worker status").success());
+    assert!(second.wait().expect("second worker status").success());
+    results.sort();
+    assert_eq!(publications, 1);
+    assert_eq!(results, ["COMMITTED", "CONFLICT"]);
+
+    std::fs::remove_file(&path).expect("remove config");
+    let mut lock_path = path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    std::fs::remove_file(lock_path).expect("remove lock file");
+}
+
+#[test]
+fn native_persistence_handles_missing_first_save_replace_and_source_conflicts() {
+    let path = temp_config_path("visual-rules-persistence");
+    let store = NativeVisualRulesStore::new(path.clone());
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(store));
+
+    let loaded = manager.load().expect("missing config loads safely");
+    assert_eq!(loaded.revision, 1);
+    assert!(loaded.envelope.rules.is_empty());
+
+    let saved = manager
+        .save(
+            loaded.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR")]),
+        )
+        .expect("first save");
+    assert_eq!(saved.outcome, SaveOutcome::Committed);
+    assert!(path.exists());
+
+    let replaced = manager
+        .replace(saved.revision, VisualRulesEnvelope::new(vec![rule("WARN")]))
+        .expect("replace creates a backup before publication");
+    assert_eq!(replaced.outcome, SaveOutcome::Committed);
+    let backup_prefix = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .expect("config file stem")
+        .to_string();
+    let backups: Vec<_> = std::fs::read_dir(path.parent().expect("parent"))
+        .expect("read config directory")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|candidate| {
+            candidate
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(&backup_prefix) && name.ends_with(".bak"))
+        })
+        .collect();
+    assert_eq!(backups.len(), 1);
+    assert!(
+        String::from_utf8(std::fs::read(&backups[0]).expect("read backup"))
+            .expect("backup JSON")
+            .contains("ERROR")
+    );
+    assert!(
+        String::from_utf8(std::fs::read(&path).expect("read replacement"))
+            .expect("replacement JSON")
+            .contains("WARN")
+    );
+
+    std::fs::write(&path, "{\"schemaVersion\":1,\"rules\":[]}").expect("external write");
+    let conflict = manager.save(
+        replaced.revision,
+        VisualRulesEnvelope::new(vec![rule("INFO")]),
+    );
+    assert!(
+        conflict
+            .expect_err("changed source conflicts")
+            .is_source_conflict()
+    );
+
+    std::fs::remove_file(backups[0].clone()).expect("remove backup");
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn failed_publication_does_not_mutate_snapshot_and_warning_reconciles_commit() {
+    let path = temp_config_path("visual-rules-failure");
+    let store = NativeVisualRulesStore::new(path.clone());
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(store));
+    let initial = manager.load().expect("initial load");
+
+    let blocked_path = path
+        .parent()
+        .expect("parent")
+        .join("missing-parent")
+        .join("rules.json");
+    let blocked = VisualRulesManager::with_store(std::sync::Arc::new(NativeVisualRulesStore::new(
+        blocked_path,
+    )));
+    let before = blocked.snapshot();
+    let failure = blocked.save(0, VisualRulesEnvelope::new(vec![rule("ERROR")]));
+    assert!(failure.expect_err("pre-publication write fails").is_io());
+    assert_eq!(
+        blocked.snapshot().evaluate("ERROR"),
+        before.evaluate("ERROR")
+    );
+
+    let committed = manager
+        .save(
+            initial.revision,
+            VisualRulesEnvelope::new(vec![rule("WARN")]),
+        )
+        .expect("save");
+    assert_eq!(committed.outcome, SaveOutcome::Committed);
+    assert_eq!(
+        manager.snapshot().evaluate("WARN"),
+        Some(style(Some("red"), Some("default")))
+    );
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn envelope_load_failure_retains_the_last_good_snapshot_and_reports_a_diagnostic() {
+    let path = temp_config_path("visual-rules-recovery");
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(NativeVisualRulesStore::new(
+        path.clone(),
+    )));
+    let initial = manager.load().expect("initial load");
+    let saved = manager
+        .save(
+            initial.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR")]),
+        )
+        .expect("first save");
+
+    std::fs::write(&path, "not-json").expect("corrupt config");
+    let recovered = manager.load().expect("malformed config recovers");
+    assert_eq!(recovered.revision, saved.revision + 1);
+    assert_eq!(
+        manager.snapshot().evaluate("ERROR"),
+        Some(style(Some("red"), Some("default")))
+    );
+    assert_eq!(recovered.diagnostics.len(), 1);
+    assert!(recovered.diagnostics[0].message.contains("expected"));
+
+    let repaired = manager
+        .replace(
+            recovered.revision,
+            VisualRulesEnvelope::new(vec![rule("WARN")]),
+        )
+        .expect("replace repairs the observed malformed source");
+    assert_eq!(repaired.outcome, SaveOutcome::Committed);
+    assert_eq!(
+        manager.snapshot().evaluate("WARN"),
+        Some(style(Some("red"), Some("default")))
+    );
+
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn save_rejects_more_than_fifty_enabled_rules_without_mutation() {
+    let path = temp_config_path("visual-rules-enabled-limit");
+    let manager = native_manager(&path);
+    let initial = manager.load().expect("missing config loads");
+    let error = manager
+        .save(
+            initial.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR"); 51]),
+        )
+        .expect_err("enabled-rule limit is enforced on save");
+
+    assert_eq!(
+        error,
+        VisualRulesError::Validation("at most 50 rules may be enabled".to_string())
+    );
+    assert!(!path.exists());
+    assert_eq!(manager.state().revision, initial.revision);
+    assert_eq!(manager.state().envelope, initial.envelope);
+    assert_eq!(manager.snapshot().evaluate("ERROR"), None);
+}
+
+#[test]
+fn unsupported_schema_load_preserves_last_good_state_and_allows_repair() {
+    let path = temp_config_path("visual-rules-schema-recovery");
+    let manager = native_manager(&path);
+    let loaded = manager.load().expect("missing config loads");
+    let saved = manager
+        .save(
+            loaded.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR")]),
+        )
+        .expect("save last-known-good config");
+    std::fs::write(&path, r#"{"schemaVersion":2,"rules":[]}"#).expect("write future schema");
+
+    let recovered = manager.load().expect("unsupported schema recovers");
+    assert_eq!(recovered.revision, saved.revision + 1);
+    assert_eq!(recovered.envelope, manager.state().envelope);
+    assert_eq!(recovered.envelope.rules, vec![rule("ERROR")]);
+    assert_eq!(
+        recovered.diagnostics[0].message,
+        "unsupported schemaVersion"
+    );
+    assert_eq!(
+        recovered.diagnostics[0].severity,
+        ValidationSeverity::Warning
+    );
+    assert_eq!(manager.snapshot().evaluate("ERROR"), red_style());
+
+    manager
+        .replace(
+            recovered.revision,
+            VisualRulesEnvelope::new(vec![rule("WARN")]),
+        )
+        .expect("replace repairs the observed unsupported source");
+    assert_eq!(manager.snapshot().evaluate("WARN"), red_style());
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn manager_enforces_exact_persisted_size_boundary() {
+    let path = temp_config_path("visual-rules-exact-size");
+    let manager = native_manager(&path);
+    let loaded = manager.load().expect("missing config loads");
+    let accepted = envelope_with_serialized_size(262_144);
+    let saved = manager
+        .save(loaded.revision, accepted.clone())
+        .expect("exactly 256 KiB is accepted");
+    let persisted = std::fs::read(&path).expect("read accepted boundary");
+    assert_eq!(persisted.len(), 262_144);
+    assert_eq!(manager.state().envelope, accepted);
+
+    let rejected = envelope_with_serialized_size(262_145);
+    let error = manager
+        .replace(saved.revision, rejected)
+        .expect_err("one byte over 256 KiB is rejected");
+    assert_eq!(
+        error,
+        VisualRulesError::Validation("visual rules configuration exceeds 256 KiB".to_string())
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read unchanged boundary"),
+        persisted
+    );
+    assert_eq!(manager.state().revision, saved.revision);
+    assert_eq!(manager.state().envelope, accepted);
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn over_count_loads_preserve_last_good_state_and_report_diagnostics() {
+    for (name, invalid, expected) in [
+        (
+            "stored",
+            VisualRulesEnvelope::new(
+                (0..101)
+                    .map(|index| {
+                        let mut rule = rule(&index.to_string());
+                        rule.enabled = false;
+                        rule
+                    })
+                    .collect(),
+            ),
+            "at most 100 rules may be stored",
+        ),
+        (
+            "enabled",
+            VisualRulesEnvelope::new(vec![rule("WARN"); 51]),
+            "at most 50 rules may be enabled",
+        ),
+    ] {
+        let path = temp_config_path(name);
+        let good = VisualRulesEnvelope::new(vec![rule("ERROR")]);
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&good).expect("serialize good config"),
+        )
+        .expect("write good config");
+        let manager = native_manager(&path);
+        let loaded = manager.load().expect("good config loads");
+        std::fs::write(
+            &path,
+            serde_json::to_vec(&invalid).expect("serialize over-count config"),
+        )
+        .expect("write over-count config");
+
+        let recovered = manager.load().expect("over-count config recovers");
+        assert_eq!(recovered.revision, loaded.revision + 1);
+        assert_eq!(recovered.envelope, good);
+        assert_eq!(recovered.diagnostics[0].message, expected);
+        assert_eq!(
+            recovered.diagnostics[0].severity,
+            ValidationSeverity::Warning
+        );
+        assert_eq!(manager.snapshot().evaluate("ERROR"), red_style());
+        assert_eq!(manager.snapshot().evaluate("WARN"), None);
+        std::fs::remove_file(path).expect("remove config");
+    }
+}
+
+#[test]
+fn stale_base_revision_leaves_manager_and_persistence_unchanged() {
+    let path = temp_config_path("visual-rules-stale-revision");
+    let manager = native_manager(&path);
+    let loaded = manager.load().expect("missing config loads");
+    let saved = manager
+        .save(
+            loaded.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR")]),
+        )
+        .expect("save current revision");
+    let before = manager.state();
+    let persisted = std::fs::read(&path).expect("read current config");
+
+    let error = manager
+        .replace(
+            loaded.revision,
+            VisualRulesEnvelope::new(vec![rule("WARN")]),
+        )
+        .expect_err("stale revision conflicts");
+    assert_eq!(error, VisualRulesError::RevisionConflict);
+    assert_eq!(
+        std::fs::read(&path).expect("read unchanged config"),
+        persisted
+    );
+    assert_eq!(manager.state().revision, before.revision);
+    assert_eq!(manager.state().envelope, before.envelope);
+    assert_eq!(manager.state().diagnostics, before.diagnostics);
+    assert_eq!(manager.snapshot().evaluate("ERROR"), red_style());
+    assert_eq!(manager.snapshot().evaluate("WARN"), None);
+
+    manager
+        .replace(saved.revision, VisualRulesEnvelope::new(vec![rule("INFO")]))
+        .expect("unchanged source remains replaceable at the current revision");
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn oversized_native_load_is_bounded_and_retains_the_last_good_state() {
+    let path = temp_config_path("visual-rules-oversized-load");
+    let initial_envelope = VisualRulesEnvelope::new(vec![rule("ERROR")]);
+    std::fs::write(
+        &path,
+        serde_json::to_vec(&initial_envelope).expect("serialize initial envelope"),
+    )
+    .expect("write initial config");
+    let store = std::sync::Arc::new(NativeVisualRulesStore::new(path.clone()));
+    let manager = VisualRulesManager::with_store(store.clone());
+    let initial = manager.load().expect("initial config loads");
+
+    let oversized_bytes =
+        serde_json::to_vec(&oversized_valid_envelope()).expect("serialize oversized envelope");
+    std::fs::write(&path, oversized_bytes).expect("write oversized config");
+    let bounded_source = store
+        .read()
+        .expect("read oversized source")
+        .expect("source");
+    assert_eq!(
+        bounded_source.len(),
+        VisualRulesEnvelope::MAX_PERSISTED_SIZE + 1
+    );
+
+    let recovered = manager.load().expect("oversized config recovers");
+    assert_eq!(recovered.revision, initial.revision + 1);
+    assert_eq!(recovered.envelope, initial_envelope);
+    assert_eq!(recovered.diagnostics.len(), 1);
+    assert!(recovered.diagnostics[0].message.contains("256 KiB"));
+    assert_eq!(
+        manager.snapshot().evaluate("ERROR"),
+        Some(style(Some("red"), Some("default")))
+    );
+
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn oversized_tail_change_conflicts_until_the_complete_source_is_reloaded() {
+    let path = temp_config_path("visual-rules-oversized-tail-conflict");
+    let initial_envelope = VisualRulesEnvelope::new(vec![rule("ERROR")]);
+    std::fs::write(
+        &path,
+        serde_json::to_vec(&initial_envelope).expect("serialize initial envelope"),
+    )
+    .expect("write initial config");
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(NativeVisualRulesStore::new(
+        path.clone(),
+    )));
+    manager.load().expect("initial config loads");
+
+    let mut oversized = vec![b'a'; VisualRulesEnvelope::MAX_PERSISTED_SIZE + 4096];
+    std::fs::write(&path, &oversized).expect("write oversized config");
+    let recovered = manager.load().expect("oversized config recovers");
+    assert_eq!(recovered.envelope, initial_envelope);
+    assert!(recovered.diagnostics[0].message.contains("256 KiB"));
+
+    oversized[VisualRulesEnvelope::MAX_PERSISTED_SIZE + 1024] = b'b';
+    std::fs::write(&path, &oversized).expect("mutate only the unread tail");
+    let before_conflict = manager.state();
+    let conflict = manager.replace(
+        recovered.revision,
+        VisualRulesEnvelope::new(vec![rule("WARN")]),
+    );
+    assert!(
+        conflict
+            .expect_err("tail-only source change conflicts")
+            .is_source_conflict()
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read mutated source"),
+        oversized
+    );
+    assert_eq!(manager.state().revision, before_conflict.revision);
+    assert_eq!(manager.state().envelope, before_conflict.envelope);
+    assert_eq!(
+        manager.snapshot().evaluate("ERROR"),
+        Some(style(Some("red"), Some("default")))
+    );
+
+    let observed = manager.load().expect("changed oversized source reloads");
+    let repaired = manager
+        .replace(
+            observed.revision,
+            VisualRulesEnvelope::new(vec![rule("WARN")]),
+        )
+        .expect("unchanged oversized source can be repaired");
+    assert_eq!(repaired.outcome, SaveOutcome::Committed);
+    assert_eq!(
+        std::fs::read(&path).expect("read repaired source"),
+        serde_json::to_vec(&VisualRulesEnvelope::new(vec![rule("WARN")]))
+            .expect("serialize repaired source")
+    );
+    assert_eq!(
+        manager.snapshot().evaluate("WARN"),
+        Some(style(Some("red"), Some("default")))
+    );
+
+    std::fs::remove_file(path).expect("remove config");
+}
+
+#[test]
+fn oversized_serialized_save_and_replace_leave_state_and_source_unchanged() {
+    let path = temp_config_path("visual-rules-oversized-save");
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(NativeVisualRulesStore::new(
+        path.clone(),
+    )));
+    let initial = manager.load().expect("missing config loads");
+    let oversized = oversized_valid_envelope();
+
+    let save_error = manager
+        .save(initial.revision, oversized.clone())
+        .expect_err("oversized first save is rejected");
+    assert!(save_error.to_string().contains("256 KiB"));
+    assert!(!path.exists());
+    assert_eq!(manager.state().revision, initial.revision);
+    assert_eq!(manager.state().envelope, initial.envelope);
+    assert_eq!(manager.snapshot().evaluate("ERROR"), None);
+
+    let saved = manager
+        .save(
+            initial.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR")]),
+        )
+        .expect("valid save still uses the unchanged source and revision");
+    let persisted = std::fs::read(&path).expect("read persisted config");
+    let before_replace = manager.state();
+
+    let replace_error = manager
+        .replace(saved.revision, oversized)
+        .expect_err("oversized replacement is rejected");
+    assert!(replace_error.to_string().contains("256 KiB"));
+    assert_eq!(
+        std::fs::read(&path).expect("read unchanged config"),
+        persisted
+    );
+    assert_eq!(manager.state().revision, before_replace.revision);
+    assert_eq!(manager.state().envelope, before_replace.envelope);
+    assert_eq!(
+        manager.snapshot().evaluate("ERROR"),
+        Some(style(Some("red"), Some("default")))
+    );
+
+    std::fs::remove_file(path).expect("remove config");
+}
+
+struct PausingReplacer {
+    replacement_count: std::sync::atomic::AtomicUsize,
+    first_replacement_started: std::sync::mpsc::Sender<()>,
+    release_first_replacement: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+}
+
+impl AtomicFileReplacer for PausingReplacer {
+    fn save_new(&self, _path: &std::path::Path, _bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        unreachable!("the test replaces an existing file")
+    }
+
+    fn replace(&self, path: &std::path::Path, bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        if self
+            .replacement_count
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            == 0
+        {
+            self.first_replacement_started
+                .send(())
+                .expect("report first replacement");
+            self.release_first_replacement
+                .lock()
+                .expect("release receiver lock")
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("first replacement was not released before timeout");
+        }
+        std::fs::write(path, bytes)?;
+        Ok(StoreCommit::Committed)
+    }
+}
+
+#[test]
+fn separate_native_stores_serialize_concurrent_manager_replacements() {
+    let path = temp_config_path("visual-rules-concurrent-replace");
+    let source = serde_json::to_vec(&VisualRulesEnvelope::new(vec![rule("ERROR")]))
+        .expect("serialize source");
+    std::fs::write(&path, source).expect("write source");
+
+    let (replacement_started_tx, replacement_started_rx) = std::sync::mpsc::channel();
+    let (release_replacement_tx, release_replacement_rx) = std::sync::mpsc::channel();
+    let replacer = std::sync::Arc::new(PausingReplacer {
+        replacement_count: std::sync::atomic::AtomicUsize::new(0),
+        first_replacement_started: replacement_started_tx,
+        release_first_replacement: std::sync::Mutex::new(release_replacement_rx),
+    });
+    let first_store = NativeVisualRulesStore::with_replacer(path.clone(), replacer.clone());
+    let second_store = NativeVisualRulesStore::with_replacer(path.clone(), replacer);
+    let first = VisualRulesManager::with_store(std::sync::Arc::new(first_store));
+    let second = VisualRulesManager::with_store(std::sync::Arc::new(second_store));
+    let first_state = first.load().expect("first manager load");
+    let second_state = second.load().expect("second manager load");
+
+    let first_thread = std::thread::spawn(move || {
+        first.replace(
+            first_state.revision,
+            VisualRulesEnvelope::new(vec![rule("WARN")]),
+        )
+    });
+    replacement_started_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("first replacement did not reach the publication boundary");
+
+    let (second_attempted_tx, second_attempted_rx) = std::sync::mpsc::channel();
+    let second_thread = std::thread::spawn(move || {
+        second_attempted_tx
+            .send(())
+            .expect("report second replacement attempt");
+        second.replace(
+            second_state.revision,
+            VisualRulesEnvelope::new(vec![rule("INFO")]),
+        )
+    });
+    second_attempted_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("second manager did not attempt replacement");
+    release_replacement_tx
+        .send(())
+        .expect("release first replacement");
+
+    let first_result = first_thread.join().expect("first manager thread");
+    let second_result = second_thread.join().expect("second manager thread");
+
+    assert_eq!(
+        usize::from(first_result.is_ok()) + usize::from(second_result.is_ok()),
+        1
+    );
+    assert!(
+        first_result
+            .err()
+            .or_else(|| second_result.err())
+            .expect("one stale source conflicts")
+            .is_source_conflict()
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read committed source"),
+        serde_json::to_vec(&VisualRulesEnvelope::new(vec![rule("WARN")]))
+            .expect("serialize committed replacement")
+    );
+
+    std::fs::remove_file(path).expect("remove config");
+}
+
+struct WarningStore {
+    bytes: std::sync::Mutex<Option<Vec<u8>>>,
+}
+
+impl WarningStore {
+    fn missing() -> Self {
+        Self {
+            bytes: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl VisualRulesStore for WarningStore {
+    fn read(&self) -> std::io::Result<Option<Vec<u8>>> {
+        Ok(self.bytes.lock().expect("store lock").clone())
+    }
+
+    fn save_new(&self, bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        let mut stored = self.bytes.lock().expect("store lock");
+        if stored.is_some() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "target appeared before publication",
+            ));
+        }
+        *stored = Some(bytes.to_vec());
+        Ok(StoreCommit::with_warning("parent directory sync failed"))
+    }
+
+    fn replace(&self, _bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        unreachable!("first save uses save_new")
+    }
+
+    fn compare_and_commit(
+        &self,
+        expected: Option<&[u8]>,
+        bytes: &[u8],
+        replace: bool,
+    ) -> std::io::Result<StoreCommit> {
+        if self.read()?.as_deref() != expected {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "source changed before publication",
+            ));
+        }
+        if replace {
+            self.replace(bytes)
+        } else {
+            self.save_new(bytes)
+        }
+    }
+}
+
+#[test]
+fn post_publication_warning_commits_snapshot_revision_and_source_once() {
+    let store = std::sync::Arc::new(WarningStore::missing());
+    let manager = VisualRulesManager::with_store(store.clone());
+    let initial = manager.load().expect("missing store loads");
+
+    let result = manager
+        .save(
+            initial.revision,
+            VisualRulesEnvelope::new(vec![rule("ERROR")]),
+        )
+        .expect("publication warning is committed");
+    assert_eq!(
+        result.outcome,
+        SaveOutcome::CommittedWithWarning("parent directory sync failed".to_string())
+    );
+    assert_eq!(result.revision, initial.revision + 1);
+    assert_eq!(
+        manager.snapshot().evaluate("ERROR"),
+        Some(style(Some("red"), Some("default")))
+    );
+    assert!(store.read().expect("stored bytes").is_some());
+
+    let conflict = manager.save(
+        result.revision,
+        VisualRulesEnvelope::new(vec![rule("WARN")]),
+    );
+    assert!(
+        conflict
+            .expect_err("second first-save cannot clobber")
+            .is_source_conflict()
+    );
+}
+
+struct ConcurrentCreatorStore;
+
+impl VisualRulesStore for ConcurrentCreatorStore {
+    fn read(&self) -> std::io::Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+
+    fn save_new(&self, _bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::AlreadyExists,
+            "another process published first",
+        ))
+    }
+
+    fn replace(&self, _bytes: &[u8]) -> std::io::Result<StoreCommit> {
+        unreachable!("missing target must use no-clobber save")
+    }
+
+    fn compare_and_commit(
+        &self,
+        _expected: Option<&[u8]>,
+        _bytes: &[u8],
+        _replace: bool,
+    ) -> std::io::Result<StoreCommit> {
+        self.save_new(&[])
+    }
+}
+
+#[test]
+fn first_save_never_clobbers_a_concurrently_created_target() {
+    let manager = VisualRulesManager::with_store(std::sync::Arc::new(ConcurrentCreatorStore));
+    let initial = manager.load().expect("missing store loads");
+    let before = manager.snapshot();
+
+    let failure = manager.save(
+        initial.revision,
+        VisualRulesEnvelope::new(vec![rule("ERROR")]),
+    );
+    assert!(
+        failure
+            .expect_err("concurrent target conflicts")
+            .is_source_conflict()
+    );
+    assert_eq!(manager.state().revision, initial.revision);
+    assert_eq!(
+        manager.snapshot().evaluate("ERROR"),
+        before.evaluate("ERROR")
+    );
+}


### PR DESCRIPTION
Closes #67

## PR Type
- [x] New feature

## Summary
- Add versioned visual-rules management state and validation.
- Persist rules atomically with conflict detection, locking, backups, and bounded file size.
- Share live rule snapshots with current and future log readers.

## Changes
| Area | Change |
|---|---|
| Core model | Versioned envelope, limits, palette validation, diagnostics, and conversion. |
| Manager | Revisions, source conflicts, immutable snapshots, save/replace semantics. |
| Native store | Bounded reads, inter-process locking, atomic publication, and backups. |
| Tests | Native persistence, recovery, concurrency, size-limit, and reader behavior coverage. |

## Test Plan
- [x] `cargo test -p logmancer-core --features native-persistence` — 44 passed, 1 ignored.
- [x] Formatting and workspace Clippy passed.
- [x] Native pre-push and pre-PR receipt validation passed (`review-abfb75a35688868b`).
- [x] Shellcheck N/A — no shell scripts changed.

## Review Size Exception

Maintainer-approved `size:exception`: 2,063 authored changed lines. The unit is intentionally cohesive because validation, persistence, locking, recovery, manager publication, and their behavior-first tests form one rollback boundary. It was reviewed through the full 4R native review.

## Chain Context

```text
#79 Visual Rules Core Foundation
  └─ #80 Visual Rule Highlights
       └─ 📍 This PR: Management Persistence
            └─ Management UI
```

- **Start:** #80 provides decoration metadata and rendering.
- **End:** one validated, persisted global rules envelope drives shared reader snapshots.
- **Depends on:** #80.
- **Follow-up:** management UI and desktop wiring.
- **Rollback:** revert the core management/store/registry integration; #80 highlighting remains usable with in-memory rules.

## Contributor Checklist
- [x] Linked approved issue #67.
- [x] Exactly one `type:*` label will be applied.
- [x] Tests and reviewed receipt are present.
- [x] Documentation impact evaluated; behavior documentation remains tracked by #70.
- [x] Conventional commit format used.
- [x] No AI attribution trailers.