### PR TITLE
feat(web): add visual rules management UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ### Added
 
 - Core visual rules foundation with UI-neutral rule models, text/regex matching, array-order priority, per-rule case sensitivity, safe invalid-rule handling, and optional line style metadata for foreground/background colors (#63, #64, #65, #66).
-- The shared web viewer used by browser and desktop shells now renders safe whole-line visual-rule foreground/background styles (#68).
+- The shared web viewer used by browser and desktop shells now renders safe whole-line visual-rule foreground/background styles, with an opt-in debug fixture for end-to-end development testing (#68).
+- Web and desktop visual-rules management now loads and saves one revision-checked global configuration through the shared core persistence manager.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,7 @@ dependencies = [
  "logmancer-core",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tower",

--- a/examples/visual-rules.dev.json
+++ b/examples/visual-rules.dev.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 1,
+  "rules": [
+    {
+      "name": "Errors",
+      "enabled": true,
+      "matcher": { "Text": "ERROR" },
+      "caseSensitive": false,
+      "style": {
+        "foreground": "red",
+        "background": "default"
+      }
+    },
+    {
+      "name": "Warnings",
+      "enabled": true,
+      "matcher": { "Regex": "^WARN\\b" },
+      "caseSensitive": false,
+      "style": {
+        "foreground": "yellow",
+        "background": "default"
+      }
+    },
+    {
+      "name": "Debug (disabled)",
+      "enabled": false,
+      "matcher": { "Text": "DEBUG" },
+      "caseSensitive": false,
+      "style": {
+        "foreground": "cyan",
+        "background": "default"
+      }
+    }
+  ]
+}

--- a/logmancer-desktop/Cargo.toml
+++ b/logmancer-desktop/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
-logmancer-core = { path = "../logmancer-core" }
+logmancer-core = { path = "../logmancer-core", features = ["native-persistence"] }
 logmancer-web = { path = "../logmancer-web", features = ["ssr"], optional = true }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -3,6 +3,7 @@ use std::net::{TcpStream, ToSocketAddrs};
 #[cfg(any(feature = "embedded-server", test))]
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::thread::sleep;
 use std::time::Duration;
 use tauri::{Manager, Url};
@@ -12,7 +13,8 @@ use tracing::{info, warn};
 #[cfg(feature = "embedded-server")]
 use {
     logmancer_web::{
-        file_opening::enable_desktop_ssr_runtime, start_leptos_with_registry, try_open_initial_file,
+        file_opening::enable_desktop_ssr_runtime, start_leptos_with_registry_and_manager,
+        try_open_initial_file, visual_rules_runtime,
     },
     tauri::WindowEvent,
 };
@@ -26,7 +28,22 @@ const EXTERNAL_SERVER_FALLBACK_URL: &str = "data:text/html;charset=utf-8,%3C!doc
 #[derive(Clone)]
 struct DesktopState {
     #[cfg_attr(not(feature = "embedded-server"), allow(dead_code))]
-    registry: Arc<LogRegistry>,
+    registry: Arc<RwLock<Arc<LogRegistry>>>,
+}
+
+impl DesktopState {
+    fn registry(&self) -> Arc<LogRegistry> {
+        self.registry.read().expect("desktop registry lock").clone()
+    }
+}
+
+#[cfg(any(feature = "embedded-server", test))]
+fn visual_rules_store_path(config_dir: Option<PathBuf>) -> Result<PathBuf, String> {
+    config_dir
+        .map(|directory| directory.join("visual-rules.json"))
+        .ok_or_else(|| {
+            "Could not resolve the Tauri app configuration directory for visual rules.".to_string()
+        })
 }
 
 fn wait_for_tcp_server<A>(addr: A, attempts: u32, delay: Duration) -> bool
@@ -128,7 +145,7 @@ async fn open_native_log_file(
                 .map_err(|error| format!("Could not resolve selected file path: {error}"))
         })
         .transpose()?;
-    open_selected_log_file(state.registry.as_ref(), selected_path, "native_picker")
+    open_selected_log_file(state.registry().as_ref(), selected_path, "native_picker")
 }
 
 #[cfg(not(feature = "embedded-server"))]
@@ -172,6 +189,13 @@ mod tests {
     use std::net::TcpListener;
     use std::thread::sleep;
     use std::time::Duration;
+
+    #[test]
+    fn visual_rules_path_resolution_failure_writes_nowhere() {
+        let error = visual_rules_store_path(None).unwrap_err();
+
+        assert!(error.contains("app configuration directory"));
+    }
 
     #[test]
     fn opening_no_selected_path_returns_none_without_requiring_server_root() {
@@ -322,7 +346,7 @@ pub fn run() {
 
     let builder = tauri::Builder::default()
         .manage(DesktopState {
-            registry: Arc::new(LogRegistry::new()),
+            registry: Arc::new(RwLock::new(Arc::new(LogRegistry::new()))),
         })
         .invoke_handler(tauri::generate_handler![open_native_log_file])
         .plugin(tauri_plugin_dialog::init())
@@ -333,7 +357,11 @@ pub fn run() {
         enable_desktop_ssr_runtime();
         info!("Desktop runtime configured for embedded SSR rendering");
 
-        let registry = app.state::<DesktopState>().registry.clone();
+        let state = app.state::<DesktopState>();
+        let visual_rules_path = visual_rules_store_path(app.path().app_config_dir().ok())
+            .map_err(std::io::Error::other)?;
+        let (registry, visual_rules_manager) = visual_rules_runtime(visual_rules_path);
+        *state.registry.write().expect("desktop registry lock") = registry.clone();
         let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
         let port = std::net::TcpListener::bind("127.0.0.1:0")
             .expect("Could not open a socket")
@@ -343,11 +371,11 @@ pub fn run() {
         info!("Spawning embedded SSR server on port={}", port);
         tauri::async_runtime::spawn(async move {
             info!("Embedded SSR server task started");
-            start_leptos_with_registry(port, registry).await
+            start_leptos_with_registry_and_manager(port, registry, visual_rules_manager).await
         });
         wait_for_embedded_server(port);
         let window = app.get_webview_window("main").unwrap();
-        let registry_for_drop = app.state::<DesktopState>().registry.clone();
+        let registry_for_drop = app.state::<DesktopState>().registry();
         let window_for_drop = window.clone();
         window.on_window_event(move |event| match event {
             WindowEvent::DragDrop(tauri::DragDropEvent::Enter { paths, .. }) => {

--- a/logmancer-web/Cargo.toml
+++ b/logmancer-web/Cargo.toml
@@ -34,6 +34,7 @@ hydrate = [
     "dep:wasm-bindgen",
 ]
 ssr = [
+    "logmancer-core/native-persistence",
     "dep:axum",
     "dep:tokio",
     "dep:leptos_axum",
@@ -49,6 +50,7 @@ external-server = []
 [dev-dependencies]
 tempfile = "3"
 tower = "0.5"
+serde_json = "1.0"
 
 [package.metadata.leptos]
 # The name used by wasm-bindgen/cargo-leptos for the JS/WASM bundle. Defaults to the crate name

--- a/logmancer-web/src/api/commons.rs
+++ b/logmancer-web/src/api/commons.rs
@@ -1,3 +1,4 @@
+use logmancer_core::VisualRulesEnvelope;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -14,6 +15,21 @@ pub struct OpenServerFileResponse {
 pub struct ApiError {
     pub code: String,
     pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualRulesSaveRequest {
+    pub base_revision: u64,
+    pub envelope: VisualRulesEnvelope,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct VisualRulesResponse {
+    pub revision: u64,
+    pub envelope: VisualRulesEnvelope,
+    pub diagnostics: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/logmancer-web/src/api/config.rs
+++ b/logmancer-web/src/api/config.rs
@@ -6,10 +6,13 @@ use crate::api::server_browser::{
     server_browser_list, server_browser_open, server_browser_status, ServerFileRoot,
 };
 use crate::api::upload_file::upload_file;
+use crate::api::visual_rules::{
+    get_visual_rules, replace_visual_rules, retry_visual_rules, save_visual_rules,
+};
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
-use logmancer_core::LogRegistry;
+use logmancer_core::{LogRegistry, VisualRulesManager};
 use std::sync::Arc;
 
 const LOG_UPLOAD_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
@@ -17,10 +20,14 @@ const LOG_UPLOAD_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 #[derive(Clone)]
 pub struct AppState {
     pub registry: Arc<LogRegistry>,
+    pub visual_rules_manager: Arc<VisualRulesManager>,
     pub server_file_root: Option<ServerFileRoot>,
 }
 
-pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
+pub fn api_routes_with_registry_and_manager<T>(
+    registry: Arc<LogRegistry>,
+    visual_rules_manager: Arc<VisualRulesManager>,
+) -> Router<T> {
     let server_file_root = ServerFileRoot::from_env();
 
     Router::new()
@@ -38,11 +45,20 @@ pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
         .route("/search-status", get(search_status))
         .route("/search-next", get(search_next))
         .route("/search-previous", get(search_previous))
+        .route("/visual-rules", get(get_visual_rules))
+        .route("/visual-rules/save", post(save_visual_rules))
+        .route("/visual-rules/retry", post(retry_visual_rules))
+        .route("/visual-rules/replace", post(replace_visual_rules))
         .layer(DefaultBodyLimit::max(LOG_UPLOAD_BODY_LIMIT_BYTES))
         .with_state(AppState {
             registry,
+            visual_rules_manager,
             server_file_root,
         })
+}
+
+pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
+    api_routes_with_registry_and_manager(registry, VisualRulesManager::in_memory())
 }
 
 pub fn api_routes<T>() -> Router<T> {
@@ -54,7 +70,21 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Method, Request, StatusCode};
+    use logmancer_core::{NativeVisualRulesStore, VisualRulesEnvelope, VisualRulesManager};
+    use std::sync::Arc;
     use tower::ServiceExt;
+
+    fn visual_rules_router() -> Router {
+        let directory = tempfile::tempdir().unwrap().keep();
+        let manager = VisualRulesManager::with_store(Arc::new(NativeVisualRulesStore::new(
+            directory.join("visual-rules.json"),
+        )));
+        manager.load().unwrap();
+        api_routes_with_registry_and_manager(
+            Arc::new(LogRegistry::with_manager(manager.clone())),
+            manager,
+        )
+    }
 
     #[tokio::test]
     async fn normal_web_router_does_not_register_open_server_file() {
@@ -70,5 +100,94 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn visual_rules_rejects_wrong_method_unknown_route_and_malformed_body_without_mutation() {
+        let router = visual_rules_router();
+        let wrong_method = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/visual-rules/save")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(wrong_method.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+        let unknown = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/visual-rules/unknown")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+
+        let malformed = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/visual-rules/save")
+                    .header("content-type", "application/json")
+                    .body(Body::from("not json"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/visual-rules")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn visual_rules_rejects_stale_revision_without_mutating_saved_envelope() {
+        let router = visual_rules_router();
+        let body = serde_json::json!({
+            "baseRevision": 99,
+            "envelope": VisualRulesEnvelope::new(Vec::new()),
+        })
+        .to_string();
+
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/visual-rules/save")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn development_visual_rules_example_uses_the_current_envelope_schema() {
+        let envelope: VisualRulesEnvelope =
+            serde_json::from_str(include_str!("../../../examples/visual-rules.dev.json")).unwrap();
+
+        let report = envelope.validate_for_save().unwrap();
+        assert_eq!(envelope.schema_version, 1);
+        assert_eq!(report.evaluator_rules.len(), 2);
     }
 }

--- a/logmancer-web/src/api/mod.rs
+++ b/logmancer-web/src/api/mod.rs
@@ -20,3 +20,6 @@ pub mod server_browser;
 
 #[cfg(feature = "ssr")]
 pub mod search;
+
+#[cfg(feature = "ssr")]
+pub mod visual_rules;

--- a/logmancer-web/src/api/visual_rules.rs
+++ b/logmancer-web/src/api/visual_rules.rs
@@ -1,0 +1,124 @@
+use crate::api::commons::{ApiError, VisualRulesResponse, VisualRulesSaveRequest};
+use crate::api::config::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use logmancer_core::{SaveOutcome, SaveResult, VisualRulesEnvelope, VisualRulesError};
+
+pub async fn get_visual_rules(State(app_state): State<AppState>) -> impl IntoResponse {
+    let state = app_state.visual_rules_manager.state();
+    (
+        StatusCode::OK,
+        Json(VisualRulesResponse {
+            revision: state.revision,
+            envelope: state.envelope,
+            diagnostics: state
+                .diagnostics
+                .into_iter()
+                .map(|diagnostic| diagnostic.message)
+                .collect(),
+        }),
+    )
+}
+
+pub async fn save_visual_rules(
+    State(app_state): State<AppState>,
+    Json(request): Json<VisualRulesSaveRequest>,
+) -> Response {
+    let envelope = request.envelope.clone();
+    match app_state
+        .visual_rules_manager
+        .save(request.base_revision, request.envelope)
+    {
+        Ok(result) => {
+            (StatusCode::OK, Json(visual_rules_success(result, envelope))).into_response()
+        }
+        Err(error) => visual_rules_error(error),
+    }
+}
+
+pub async fn retry_visual_rules(State(app_state): State<AppState>) -> Response {
+    match app_state.visual_rules_manager.load() {
+        Ok(state) => (
+            StatusCode::OK,
+            Json(VisualRulesResponse {
+                revision: state.revision,
+                envelope: state.envelope,
+                diagnostics: state
+                    .diagnostics
+                    .into_iter()
+                    .map(|diagnostic| diagnostic.message)
+                    .collect(),
+            }),
+        )
+            .into_response(),
+        Err(error) => visual_rules_error(error),
+    }
+}
+
+pub async fn replace_visual_rules(
+    State(app_state): State<AppState>,
+    Json(request): Json<VisualRulesSaveRequest>,
+) -> Response {
+    let envelope = request.envelope.clone();
+    match app_state
+        .visual_rules_manager
+        .replace(request.base_revision, request.envelope)
+    {
+        Ok(result) => {
+            (StatusCode::OK, Json(visual_rules_success(result, envelope))).into_response()
+        }
+        Err(error) => visual_rules_error(error),
+    }
+}
+
+fn visual_rules_success(result: SaveResult, envelope: VisualRulesEnvelope) -> VisualRulesResponse {
+    VisualRulesResponse {
+        revision: result.revision,
+        envelope,
+        diagnostics: match result.outcome {
+            SaveOutcome::Committed => Vec::new(),
+            SaveOutcome::CommittedWithWarning(message) => vec![message],
+        },
+    }
+}
+
+fn visual_rules_error(error: VisualRulesError) -> Response {
+    let status = match error {
+        VisualRulesError::Validation(_) | VisualRulesError::Decode(_) => {
+            StatusCode::UNPROCESSABLE_ENTITY
+        }
+        VisualRulesError::RevisionConflict | VisualRulesError::SourceConflict => {
+            StatusCode::CONFLICT
+        }
+        VisualRulesError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    (
+        status,
+        Json(ApiError {
+            code: "visual_rules_error".to_string(),
+            message: error.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success_payload_uses_the_completed_operation_snapshot() {
+        let envelope = VisualRulesEnvelope::new(Vec::new());
+        let response = visual_rules_success(
+            SaveResult {
+                revision: 7,
+                outcome: SaveOutcome::Committed,
+            },
+            envelope.clone(),
+        );
+        assert_eq!(response.revision, 7);
+        assert_eq!(response.envelope, envelope);
+    }
+}

--- a/logmancer-web/src/browser_api_client.rs
+++ b/logmancer-web/src/browser_api_client.rs
@@ -3,8 +3,12 @@ use crate::api::commons::{
     ReadPageRequest, SearchNavigateRequest, SearchStatusRequest, ServerBrowserListRequest,
     ServerBrowserListResponse, ServerBrowserOpenRequest, ServerBrowserStatusResponse, TailRequest,
 };
+#[cfg(target_arch = "wasm32")]
+use crate::api::commons::{VisualRulesResponse, VisualRulesSaveRequest};
 use leptos::prelude::{window, ServerFnError};
 use leptos::wasm_bindgen::{JsCast, JsValue};
+#[cfg(target_arch = "wasm32")]
+use logmancer_core::FileInfo;
 use logmancer_core::PageResult;
 use wasm_bindgen_futures::JsFuture;
 use web_sys::{FormData, RequestInit, Response};
@@ -34,6 +38,95 @@ pub async fn fetch_page(
     };
     let result = request.send().await?.json::<PageResult>().await?;
     Ok(result)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_file_info(file_id: String) -> Result<FileInfo, String> {
+    let base = window()
+        .location()
+        .origin()
+        .map_err(|_| "Could not detect application origin.".to_string())?;
+    let response = reqwest::Client::new()
+        .get(format!("{base}/api/file_info"))
+        .query(&crate::api::commons::FileInfoRequest { file_id })
+        .send()
+        .await
+        .map_err(|_| "Could not connect to the server.".to_string())?;
+
+    if response.status().is_success() {
+        response
+            .json::<FileInfo>()
+            .await
+            .map_err(|_| "Could not parse file information.".to_string())
+    } else {
+        Err(parse_api_error_message(response, "Could not load file information.").await)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_visual_rules() -> Result<VisualRulesResponse, String> {
+    request_visual_rules("/api/visual-rules", reqwest::Method::GET).await
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn retry_visual_rules() -> Result<VisualRulesResponse, String> {
+    request_visual_rules("/api/visual-rules/retry", reqwest::Method::POST).await
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn request_visual_rules(
+    path: &str,
+    method: reqwest::Method,
+) -> Result<VisualRulesResponse, String> {
+    let base = window()
+        .location()
+        .origin()
+        .map_err(|_| "Could not detect application origin.".to_string())?;
+    let request = reqwest::Client::new().request(method, format!("{base}{path}"));
+    let response = request
+        .send()
+        .await
+        .map_err(|_| "Could not connect to the server.".to_string())?;
+    if response.status().is_success() {
+        response
+            .json()
+            .await
+            .map_err(|_| "Could not parse visual rules.".to_string())
+    } else {
+        Err(parse_api_error_message(response, "Could not load visual rules.").await)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn save_visual_rules(
+    base_revision: u64,
+    envelope: logmancer_core::VisualRulesEnvelope,
+    replace: bool,
+) -> Result<VisualRulesResponse, String> {
+    let base = window()
+        .location()
+        .origin()
+        .map_err(|_| "Could not detect application origin.".to_string())?;
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{base}/api/visual-rules/{}",
+            if replace { "replace" } else { "save" }
+        ))
+        .json(&VisualRulesSaveRequest {
+            base_revision,
+            envelope,
+        })
+        .send()
+        .await
+        .map_err(|_| "Could not connect to the server.".to_string())?;
+    if response.status().is_success() {
+        response
+            .json()
+            .await
+            .map_err(|_| "Could not parse saved visual rules.".to_string())
+    } else {
+        Err(parse_api_error_message(response, "Could not save visual rules.").await)
+    }
 }
 
 pub async fn apply_filter(file_id: String, filter: String) -> Result<String, ServerFnError> {

--- a/logmancer-web/src/components/app_bar.rs
+++ b/logmancer-web/src/components/app_bar.rs
@@ -1,0 +1,20 @@
+use leptos::html;
+use leptos::prelude::*;
+
+#[component]
+pub fn AppBar(
+    path: String,
+    open_visual_rules: Callback<()>,
+    visual_rules_button_ref: NodeRef<html::Button>,
+) -> impl IntoView {
+    view! {
+        <header class="app-bar">
+            <span class="app-bar__spacer"></span>
+            <span class="app-bar__filename" title=path.clone() aria-label=format!("Open file: {path}")>{path.clone()}</span>
+            <div class="app-bar__actions">
+                <button node_ref=visual_rules_button_ref type="button" on:click=move |_| open_visual_rules.run(())>"Visual Rules"</button>
+                <button type="button" aria-label="Future actions" title="Future actions">"…"</button>
+            </div>
+        </header>
+    }
+}

--- a/logmancer-web/src/components/content_lines.rs
+++ b/logmancer-web/src/components/content_lines.rs
@@ -160,13 +160,31 @@ fn line_decorations_for_row(
         .unwrap_or_default()
 }
 
-fn visual_color_css(token: &VisualColor) -> Option<&'static str> {
-    match token.0.as_str() {
-        "error-foreground" => Some("#991b1b"),
-        "error-background" => Some("#fee2e2"),
-        "warning-foreground" => Some("#92400e"),
-        "warning-background" => Some("#fef3c7"),
-        _ => None,
+#[derive(Clone, Copy)]
+enum VisualColorRole {
+    Foreground,
+    Background,
+}
+
+fn visual_color_css(token: &VisualColor, role: VisualColorRole) -> Option<&'static str> {
+    match (token.0.as_str(), role) {
+        ("red", VisualColorRole::Foreground) => Some("#b91c1c"),
+        ("red", VisualColorRole::Background) => Some("#fee2e2"),
+        ("orange", VisualColorRole::Foreground) => Some("#c2410c"),
+        ("orange", VisualColorRole::Background) => Some("#ffedd5"),
+        ("yellow", VisualColorRole::Foreground) => Some("#a16207"),
+        ("yellow", VisualColorRole::Background) => Some("#fef9c3"),
+        ("green", VisualColorRole::Foreground) => Some("#15803d"),
+        ("green", VisualColorRole::Background) => Some("#dcfce7"),
+        ("cyan", VisualColorRole::Foreground) => Some("#0e7490"),
+        ("cyan", VisualColorRole::Background) => Some("#cffafe"),
+        ("blue", VisualColorRole::Foreground) => Some("#1d4ed8"),
+        ("blue", VisualColorRole::Background) => Some("#dbeafe"),
+        ("purple", VisualColorRole::Foreground) => Some("#7e22ce"),
+        ("purple", VisualColorRole::Background) => Some("#f3e8ff"),
+        ("gray", VisualColorRole::Foreground) => Some("#4b5563"),
+        ("gray", VisualColorRole::Background) => Some("#f3f4f6"),
+        ("default", _) | (_, _) => None,
     }
 }
 
@@ -174,10 +192,18 @@ fn line_style_css_variables(style: Option<&LineStyleIntent>) -> Option<String> {
     let style = style?;
     let mut declarations = Vec::with_capacity(2);
 
-    if let Some(color) = style.foreground.as_ref().and_then(visual_color_css) {
+    if let Some(color) = style
+        .foreground
+        .as_ref()
+        .and_then(|token| visual_color_css(token, VisualColorRole::Foreground))
+    {
         declarations.push(format!("--log-line-foreground: {color}"));
     }
-    if let Some(color) = style.background.as_ref().and_then(visual_color_css) {
+    if let Some(color) = style
+        .background
+        .as_ref()
+        .and_then(|token| visual_color_css(token, VisualColorRole::Background))
+    {
         declarations.push(format!("--log-line-background: {color}"));
     }
 
@@ -623,8 +649,9 @@ mod tests {
         can_auto_enable_global_follow, can_mutate_global_follow_state, is_at_end,
         is_editable_target, is_handled_key, keyboard_target_line, line_decorations_for_row,
         line_style_css_variables, search_segment_class, should_handle_focus_request,
-        should_restore_focus, tail_update_for_navigation, wheel_lines_to_jump, wheel_target_line,
-        TailEndComparison, TailNavigationUpdate, ARROW_DOWN, ARROW_UP, PAGE_DOWN, PAGE_UP,
+        should_restore_focus, tail_update_for_navigation, visual_color_css, wheel_lines_to_jump,
+        wheel_target_line, TailEndComparison, TailNavigationUpdate, VisualColorRole, ARROW_DOWN,
+        ARROW_UP, PAGE_DOWN, PAGE_UP,
     };
     use crate::components::context::SelectionSource;
     use crate::components::line_decorations::{DecorationKind, LineDecoration};
@@ -712,23 +739,35 @@ mod tests {
     }
 
     #[test]
-    fn known_visual_tokens_map_to_closed_css_variables() {
-        let style = LineStyleIntent {
-            foreground: Some(VisualColor("error-foreground".to_string())),
-            background: Some(VisualColor("error-background".to_string())),
-        };
+    fn canonical_visual_tokens_map_to_role_appropriate_shades() {
+        let mappings = [
+            ("red", "#b91c1c", "#fee2e2"),
+            ("orange", "#c2410c", "#ffedd5"),
+            ("yellow", "#a16207", "#fef9c3"),
+            ("green", "#15803d", "#dcfce7"),
+            ("cyan", "#0e7490", "#cffafe"),
+            ("blue", "#1d4ed8", "#dbeafe"),
+            ("purple", "#7e22ce", "#f3e8ff"),
+            ("gray", "#4b5563", "#f3f4f6"),
+        ];
 
-        assert_eq!(
-            line_style_css_variables(Some(&style)),
-            Some("--log-line-foreground: #991b1b; --log-line-background: #fee2e2".to_string())
-        );
+        for (token, foreground, background) in mappings {
+            assert_eq!(
+                visual_color_css(&VisualColor(token.to_string()), VisualColorRole::Foreground),
+                Some(foreground)
+            );
+            assert_eq!(
+                visual_color_css(&VisualColor(token.to_string()), VisualColorRole::Background),
+                Some(background)
+            );
+        }
     }
 
     #[test]
-    fn absent_or_unknown_visual_tokens_leave_row_unstyled() {
+    fn default_absent_or_unknown_visual_tokens_leave_row_unstyled() {
         let style = LineStyleIntent {
-            foreground: Some(VisualColor("hotpink; background: url(bad)".to_string())),
-            background: None,
+            foreground: Some(VisualColor("default".to_string())),
+            background: Some(VisualColor("hotpink; background: url(bad)".to_string())),
         };
 
         assert_eq!(line_style_css_variables(None), None);
@@ -739,12 +778,12 @@ mod tests {
     fn known_visual_tokens_render_without_forwarding_unknown_tokens() {
         let style = LineStyleIntent {
             foreground: Some(VisualColor("unknown".to_string())),
-            background: Some(VisualColor("warning-background".to_string())),
+            background: Some(VisualColor("yellow".to_string())),
         };
 
         assert_eq!(
             line_style_css_variables(Some(&style)),
-            Some("--log-line-background: #fef3c7".to_string())
+            Some("--log-line-background: #fef9c3".to_string())
         );
     }
 

--- a/logmancer-web/src/components/filter_pane.rs
+++ b/logmancer-web/src/components/filter_pane.rs
@@ -14,7 +14,7 @@ use leptos::task::spawn_local;
 use leptos::{component, view, IntoView};
 
 #[component]
-pub fn FilterPane() -> impl IntoView {
+pub fn FilterPane(refresh_generation: ReadSignal<u64>) -> impl IntoView {
     let LogFileContext { file_id, .. } = use_context().expect("LogFileContext not found");
 
     let div_ref = NodeRef::<Div>::new();
@@ -38,6 +38,7 @@ pub fn FilterPane() -> impl IntoView {
     let (start_line, set_start_line) = signal(0_usize);
     let (page_size, set_page_size) = signal(50_usize);
     let filter_page = LocalResource::new(move || {
+        refresh_generation.track();
         let file_id = file_id.get();
         let start = start_line.get();
         let size = page_size.get();

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -1,3 +1,5 @@
+#[cfg(target_arch = "wasm32")]
+use crate::browser_api_client::fetch_file_info;
 use crate::components::context::{
     ActivePaneContext, LogContentFocusContext, LogFileContext, SearchCommandContext,
     SearchUiContext, SelectionContext, SelectionSource,
@@ -5,6 +7,7 @@ use crate::components::context::{
 use crate::components::filter_pane::FilterPane;
 use crate::components::main_pane::MainPane;
 use crate::components::search_panel::SearchPanel;
+use crate::components::{AppBar, VisualRules};
 #[cfg(target_arch = "wasm32")]
 use leptos::ev::{keydown, KeyboardEvent};
 use leptos::html;
@@ -24,6 +27,15 @@ fn is_editable_element(tag_name: &str, content_editable: Option<&str>) -> bool {
             .unwrap_or(false)
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+fn should_handle_viewer_shortcut(
+    is_editable_target: bool,
+    is_visual_rules_target: bool,
+    allowed_in_editable_target: bool,
+) -> bool {
+    !is_visual_rules_target && (allowed_in_editable_target || !is_editable_target)
+}
+
 #[cfg(target_arch = "wasm32")]
 fn is_editable_target(target: Option<&leptos::web_sys::HtmlElement>) -> bool {
     target
@@ -34,6 +46,29 @@ fn is_editable_target(target: Option<&leptos::web_sys::HtmlElement>) -> bool {
             ) || element.is_content_editable()
         })
         .unwrap_or(false)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_visual_rules_target(target: Option<&leptos::web_sys::HtmlElement>) -> bool {
+    target
+        .and_then(|element| {
+            element
+                .closest(r#"[data-viewer-shortcuts="ignore"]"#)
+                .ok()
+                .flatten()
+        })
+        .is_some()
+}
+
+#[cfg_attr(not(any(target_arch = "wasm32", test)), allow(dead_code))]
+fn app_bar_path(file_info: Option<&logmancer_core::FileInfo>, fallback: &str) -> String {
+    file_info
+        .map(|file_info| file_info.path.clone())
+        .unwrap_or_else(|| fallback.to_string())
+}
+
+fn next_refresh_generation(current: u64) -> u64 {
+    current.wrapping_add(1)
 }
 
 #[component]
@@ -60,6 +95,23 @@ pub fn LogView() -> impl IntoView {
     let _ = (&request_search_next, &request_search_previous);
     let (log_content_focus_request, request_log_content_focus) = signal(0_u64);
     let log_view_ref: NodeRef<html::Div> = NodeRef::new();
+    let (visual_rules_open, set_visual_rules_open) = signal(false);
+    let visual_rules_button_ref: NodeRef<html::Button> = NodeRef::new();
+    let (visual_rules_refresh_generation, set_visual_rules_refresh_generation) = signal(0_u64);
+    let (file_path, set_file_path) = signal(file_id.get_untracked());
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = set_file_path;
+
+    #[cfg(target_arch = "wasm32")]
+    Effect::new(move |_| {
+        let current_file_id = file_id.get();
+        set_file_path.set(current_file_id.clone());
+        leptos::task::spawn_local(async move {
+            if let Ok(info) = fetch_file_info(current_file_id).await {
+                set_file_path.set(app_bar_path(Some(&info), ""));
+            }
+        });
+    });
 
     let focus_main_content = move || {
         set_active_pane.set(SelectionSource::Main);
@@ -90,20 +142,29 @@ pub fn LogView() -> impl IntoView {
                 .target()
                 .and_then(|target| target.dyn_into::<leptos::web_sys::HtmlElement>().ok());
             let is_editable_target = is_editable_target(target.as_ref());
-            let opens_with_slash =
-                ev.key() == "/" && !ev.ctrl_key() && !ev.meta_key() && !ev.alt_key();
-            let opens_with_find =
-                (ev.ctrl_key() || ev.meta_key()) && ev.key().eq_ignore_ascii_case("f");
+            let is_visual_rules_target = is_visual_rules_target(target.as_ref());
+            let opens_with_slash = ev.key() == "/"
+                && !ev.ctrl_key()
+                && !ev.meta_key()
+                && !ev.alt_key()
+                && should_handle_viewer_shortcut(is_editable_target, is_visual_rules_target, false);
+            let opens_with_find = (ev.ctrl_key() || ev.meta_key())
+                && ev.key().eq_ignore_ascii_case("f")
+                && should_handle_viewer_shortcut(is_editable_target, is_visual_rules_target, true);
             let search_next = ev.key() == "n"
-                && !is_editable_target
                 && !ev.ctrl_key()
                 && !ev.meta_key()
-                && !ev.alt_key();
+                && !ev.alt_key()
+                && should_handle_viewer_shortcut(is_editable_target, is_visual_rules_target, false);
             let search_previous = ev.key() == "N"
-                && !is_editable_target
                 && !ev.ctrl_key()
                 && !ev.meta_key()
-                && !ev.alt_key();
+                && !ev.alt_key()
+                && should_handle_viewer_shortcut(is_editable_target, is_visual_rules_target, false);
+
+            if is_visual_rules_target {
+                return;
+            }
 
             if ev.key() == "Escape" {
                 if search_panel_visible.get_untracked() {
@@ -112,7 +173,7 @@ pub fn LogView() -> impl IntoView {
                 return;
             }
 
-            if opens_with_find || (opens_with_slash && !is_editable_target) {
+            if opens_with_find || opens_with_slash {
                 ev.prevent_default();
                 open_search_panel();
                 return;
@@ -222,6 +283,11 @@ pub fn LogView() -> impl IntoView {
             on:pointerleave=move |_| set_is_resizing.set(false)
             tabindex="0"
         >
+            <AppBar
+                path=file_path.get()
+                open_visual_rules=Callback::new(move |_| set_visual_rules_open.set(true))
+                visual_rules_button_ref=visual_rules_button_ref
+            />
             <div
                 class=move || {
                     if active_pane.get() == SelectionSource::Main {
@@ -235,7 +301,7 @@ pub fn LogView() -> impl IntoView {
                     format!("flex: {main_height_percent} {main_height_percent} 0;")
                 }
             >
-                <MainPane />
+                <MainPane refresh_generation=visual_rules_refresh_generation />
             </div>
             <div class="divider" on:pointerdown=move |_| set_is_resizing.set(true)></div>
             <div
@@ -251,16 +317,29 @@ pub fn LogView() -> impl IntoView {
                     format!("flex: {filter_height_percent} {filter_height_percent} 0;")
                 }
             >
-                <FilterPane />
+                <FilterPane refresh_generation=visual_rules_refresh_generation />
             </div>
             <SearchPanel />
+            <VisualRules
+                open=visual_rules_open
+                set_open=set_visual_rules_open
+                invoker_ref=visual_rules_button_ref
+                on_saved=Callback::new(move |_| {
+                    set_visual_rules_refresh_generation.update(|generation| {
+                        *generation = next_refresh_generation(*generation);
+                    });
+                })
+            />
         </div>
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_editable_element;
+    use super::{
+        app_bar_path, is_editable_element, next_refresh_generation, should_handle_viewer_shortcut,
+    };
+    use logmancer_core::FileInfo;
 
     #[test]
     fn editable_detection_matches_form_controls_and_contenteditable() {
@@ -268,5 +347,37 @@ mod tests {
         assert!(is_editable_element("TEXTAREA", None));
         assert!(is_editable_element("DIV", Some("true")));
         assert!(!is_editable_element("DIV", None));
+    }
+
+    #[test]
+    fn viewer_shortcuts_ignore_the_visual_rules_surface_and_editable_targets() {
+        assert!(!should_handle_viewer_shortcut(false, true, false));
+        assert!(!should_handle_viewer_shortcut(false, true, true));
+        assert!(should_handle_viewer_shortcut(false, false, false));
+        assert!(should_handle_viewer_shortcut(false, false, true));
+        assert!(!should_handle_viewer_shortcut(true, false, false));
+        assert!(should_handle_viewer_shortcut(true, false, true));
+    }
+
+    #[test]
+    fn app_bar_path_uses_the_open_file_path_when_file_info_is_available() {
+        let file_info = FileInfo {
+            path: "/var/log/service.log".to_string(),
+            total_lines: 12,
+            indexing_progress: 1.0,
+        };
+
+        assert_eq!(
+            app_bar_path(Some(&file_info), "file-id"),
+            "/var/log/service.log"
+        );
+        assert_eq!(app_bar_path(None, "file-id"), "file-id");
+    }
+
+    #[test]
+    fn page_refresh_generation_advances_for_each_accepted_save() {
+        assert_eq!(next_refresh_generation(0), 1);
+        assert_eq!(next_refresh_generation(1), 2);
+        assert_eq!(next_refresh_generation(u64::MAX), 0);
     }
 }

--- a/logmancer-web/src/components/main_pane.rs
+++ b/logmancer-web/src/components/main_pane.rs
@@ -79,7 +79,7 @@ fn apply_search_page_result(
 }
 
 #[component]
-pub fn MainPane() -> impl IntoView {
+pub fn MainPane(refresh_generation: ReadSignal<u64>) -> impl IntoView {
     let LogFileContext {
         file_id,
         tail,
@@ -129,6 +129,7 @@ pub fn MainPane() -> impl IntoView {
     let (handled_next_request, set_handled_next_request) = signal(0_u64);
     let (handled_previous_request, set_handled_previous_request) = signal(0_u64);
     let log_page = LocalResource::new(move || {
+        refresh_generation.track();
         fetch_page(
             file_id.get(),
             start_line.get(),

--- a/logmancer-web/src/components/mod.rs
+++ b/logmancer-web/src/components/mod.rs
@@ -1,4 +1,5 @@
 mod app;
+mod app_bar;
 mod auto_scroll_status;
 mod content_lines;
 mod content_scroll;
@@ -15,10 +16,14 @@ mod progress_bar;
 mod search_panel;
 mod search_status;
 mod server_file_spotlight;
+mod visual_rule_editor;
+mod visual_rules;
 
 pub use app::App;
+pub use app_bar::AppBar;
 pub use context::Port;
 pub use filter_pane::FilterPane;
 pub use home::Home;
 pub use log_view::LogView;
 pub use server_file_spotlight::ServerFileSpotlight;
+pub use visual_rules::VisualRules;

--- a/logmancer-web/src/components/visual_rule_editor.rs
+++ b/logmancer-web/src/components/visual_rule_editor.rs
@@ -1,0 +1,180 @@
+use leptos::prelude::*;
+use logmancer_core::{LineStyleIntent, ManagedVisualRule, VisualColor, VisualMatcher};
+
+const VISUAL_COLOR_PALETTE: [(&str, &str); 9] = [
+    ("default", "Default"),
+    ("red", "Red"),
+    ("orange", "Orange"),
+    ("yellow", "Yellow"),
+    ("green", "Green"),
+    ("cyan", "Cyan"),
+    ("blue", "Blue"),
+    ("purple", "Purple"),
+    ("gray", "Gray"),
+];
+
+#[derive(Clone, Copy)]
+enum VisualColorRole {
+    Foreground,
+    Background,
+}
+
+pub fn new_rule() -> ManagedVisualRule {
+    ManagedVisualRule {
+        name: Some("New rule".to_string()),
+        enabled: true,
+        matcher: VisualMatcher::Text(String::new()),
+        case_sensitive: false,
+        style: LineStyleIntent {
+            foreground: None,
+            background: None,
+        },
+    }
+}
+
+fn updated_matcher_pattern(matcher: VisualMatcher, value: String) -> VisualMatcher {
+    match matcher {
+        VisualMatcher::Text(_) => VisualMatcher::Text(value),
+        VisualMatcher::Regex(_) => VisualMatcher::Regex(value),
+    }
+}
+
+fn color_selection(color: Option<&VisualColor>) -> &str {
+    color
+        .map(|color| color.0.as_str())
+        .filter(|token| VISUAL_COLOR_PALETTE.iter().any(|(value, _)| value == token))
+        .unwrap_or("default")
+}
+
+fn visual_color_from_selection(value: &str) -> Option<VisualColor> {
+    (value != "default"
+        && VISUAL_COLOR_PALETTE
+            .iter()
+            .any(|(token, _)| *token == value))
+    .then(|| VisualColor(value.to_string()))
+}
+
+fn update_rule_color(rule: &mut ManagedVisualRule, role: VisualColorRole, value: &str) {
+    let color = visual_color_from_selection(value);
+    match role {
+        VisualColorRole::Foreground => rule.style.foreground = color,
+        VisualColorRole::Background => rule.style.background = color,
+    }
+}
+
+#[component]
+pub fn VisualRuleEditor(
+    rule: ManagedVisualRule,
+    save: Callback<ManagedVisualRule>,
+    close: Callback<()>,
+) -> impl IntoView {
+    let (draft, set_draft) = signal(rule);
+    let save_draft = move |_| save.run(draft.get());
+    view! {
+        <div class="visual-rules-modal-backdrop" role="presentation" on:keydown=move |event| {
+            if event.key() == "Escape" { close.run(()); }
+        }>
+            <section class="visual-rules-modal" role="dialog" aria-modal="true" aria-label="Edit visual rule">
+                <label>"Name"
+                    <input value=move || draft.get().name.unwrap_or_default() on:input=move |event| {
+                        let value = event_target_value(&event);
+                        set_draft.update(|rule| rule.name = (!value.trim().is_empty()).then_some(value));
+                    } />
+                </label>
+                <label>"Pattern"
+                    <input value=move || match draft.get().matcher { VisualMatcher::Text(value) | VisualMatcher::Regex(value) => value } on:input=move |event| {
+                        let value = event_target_value(&event);
+                        set_draft.update(|rule| rule.matcher = updated_matcher_pattern(rule.matcher.clone(), value));
+                    } />
+                </label>
+                <label><input type="checkbox" checked=move || draft.get().enabled on:change=move |event| set_draft.update(|rule| rule.enabled = event_target_checked(&event)) />"Enabled"</label>
+                <label>"Foreground color"
+                    <select prop:value=move || color_selection(draft.get().style.foreground.as_ref()).to_string() on:change=move |event| {
+                        let value = event_target_value(&event);
+                        set_draft.update(|rule| update_rule_color(rule, VisualColorRole::Foreground, &value));
+                    }>
+                        {VISUAL_COLOR_PALETTE.into_iter().map(|(value, label)| view! {
+                            <option value=value>{label}</option>
+                        }).collect_view()}
+                    </select>
+                </label>
+                <label>"Background color"
+                    <select prop:value=move || color_selection(draft.get().style.background.as_ref()).to_string() on:change=move |event| {
+                        let value = event_target_value(&event);
+                        set_draft.update(|rule| update_rule_color(rule, VisualColorRole::Background, &value));
+                    }>
+                        {VISUAL_COLOR_PALETTE.into_iter().map(|(value, label)| view! {
+                            <option value=value>{label}</option>
+                        }).collect_view()}
+                    </select>
+                </label>
+                <div><button type="button" on:click=save_draft>"Apply to List"</button><button type="button" on:click=move |_| close.run(())>"Cancel"</button></div>
+            </section>
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn regex_rule() -> ManagedVisualRule {
+        ManagedVisualRule {
+            name: Some("Errors".to_string()),
+            enabled: false,
+            matcher: VisualMatcher::Regex("^ERROR".to_string()),
+            case_sensitive: true,
+            style: LineStyleIntent {
+                foreground: Some(VisualColor("purple".to_string())),
+                background: Some(VisualColor("default".to_string())),
+            },
+        }
+    }
+
+    #[test]
+    fn pattern_edit_preserves_matcher_variant() {
+        assert_eq!(
+            updated_matcher_pattern(VisualMatcher::Regex("old".into()), "new".into()),
+            VisualMatcher::Regex("new".into())
+        );
+        assert_eq!(
+            updated_matcher_pattern(VisualMatcher::Text("old".into()), "new".into()),
+            VisualMatcher::Text("new".into())
+        );
+    }
+
+    #[test]
+    fn loaded_colors_convert_to_palette_selections_and_default_means_no_color() {
+        let rule = regex_rule();
+
+        assert_eq!(color_selection(rule.style.foreground.as_ref()), "purple");
+        assert_eq!(color_selection(rule.style.background.as_ref()), "default");
+        assert_eq!(visual_color_from_selection("default"), None);
+        assert_eq!(
+            visual_color_from_selection("cyan"),
+            Some(VisualColor("cyan".to_string()))
+        );
+    }
+
+    #[test]
+    fn color_edits_preserve_matcher_variant_and_unrelated_rule_fields() {
+        let original = regex_rule();
+        let mut edited = original.clone();
+
+        update_rule_color(&mut edited, VisualColorRole::Foreground, "orange");
+        update_rule_color(&mut edited, VisualColorRole::Background, "blue");
+
+        assert_eq!(edited.name, original.name);
+        assert_eq!(edited.enabled, original.enabled);
+        assert_eq!(edited.matcher, original.matcher);
+        assert_eq!(edited.case_sensitive, original.case_sensitive);
+        assert_eq!(
+            edited.style.foreground,
+            Some(VisualColor("orange".to_string()))
+        );
+        assert_eq!(
+            edited.style.background,
+            Some(VisualColor("blue".to_string()))
+        );
+    }
+}

--- a/logmancer-web/src/components/visual_rules.rs
+++ b/logmancer-web/src/components/visual_rules.rs
@@ -1,0 +1,213 @@
+#[cfg(target_arch = "wasm32")]
+use crate::browser_api_client::{fetch_visual_rules, retry_visual_rules, save_visual_rules};
+use crate::components::visual_rule_editor::{new_rule, VisualRuleEditor};
+#[cfg(target_arch = "wasm32")]
+use crate::visual_rules_state::operation_status;
+use crate::visual_rules_state::VisualRulesEditorState;
+use leptos::html;
+use leptos::prelude::*;
+use logmancer_core::{ManagedVisualRule, VisualRulesEnvelope};
+
+fn drawer_should_handle_escape(key: &str) -> bool {
+    key == "Escape"
+}
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn notify_after_accepted_save(accepted: bool, notify: impl FnOnce()) {
+    if accepted {
+        notify();
+    }
+}
+
+#[component]
+pub fn VisualRules(
+    open: ReadSignal<bool>,
+    set_open: WriteSignal<bool>,
+    invoker_ref: NodeRef<html::Button>,
+    on_saved: Callback<()>,
+) -> impl IntoView {
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = on_saved;
+    let (editor, set_editor) = signal(None::<usize>);
+    let (state, set_state) = signal(VisualRulesEditorState::new(
+        0,
+        VisualRulesEnvelope::new(Vec::new()),
+    ));
+
+    #[cfg(target_arch = "wasm32")]
+    Effect::new(move |_| {
+        if open.get() {
+            set_state.update(VisualRulesEditorState::open_drawer);
+            leptos::task::spawn_local(async move {
+                match fetch_visual_rules().await {
+                    Ok(response) => set_state.update(|state| {
+                        let message =
+                            operation_status("Loaded visual rules.", &response.diagnostics);
+                        if state.load_saved_once(response.revision, response.envelope) {
+                            state.save_failed(message);
+                        }
+                    }),
+                    Err(error) => set_state.update(|state| state.save_failed(error)),
+                }
+            });
+        }
+    });
+
+    let discard = move |_| set_state.update(VisualRulesEditorState::discard);
+    let persist = move |_replace: bool| {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let current = state.get();
+            if !_replace && !current.ordinary_save_allowed() {
+                set_state.update(|state| {
+                    state.save_failed(
+                    "Reload preserved a conflicting draft. Use Replace or Discard before saving.",
+                )
+                });
+                return;
+            }
+            let operation = set_state
+                .try_update(VisualRulesEditorState::begin_operation)
+                .expect("visual rules state");
+            leptos::task::spawn_local(async move {
+                match save_visual_rules(current.revision(), current.envelope().clone(), _replace)
+                    .await
+                {
+                    Ok(response) => set_state.update(|state| {
+                        let action = if _replace { "Replaced" } else { "Saved" };
+                        let message = operation_status(
+                            &format!("{action} visual rules."),
+                            &response.diagnostics,
+                        );
+                        let accepted = state.save_succeeded_for(
+                            operation,
+                            response.revision,
+                            response.envelope,
+                            message,
+                        );
+                        notify_after_accepted_save(accepted, || on_saved.run(()));
+                    }),
+                    Err(error) => set_state.update(|state| state.save_failed(error)),
+                }
+            });
+        }
+    };
+    let reload = move |_| {
+        #[cfg(target_arch = "wasm32")]
+        {
+            let operation = set_state
+                .try_update(VisualRulesEditorState::begin_operation)
+                .expect("visual rules state");
+            leptos::task::spawn_local(async move {
+                match retry_visual_rules().await {
+                    Ok(response) => set_state.update(|state| {
+                        let message =
+                            operation_status("Loaded visual rules.", &response.diagnostics);
+                        state.reload_saved_for(
+                            operation,
+                            response.revision,
+                            response.envelope,
+                            message,
+                        );
+                    }),
+                    Err(error) => set_state.update(|state| state.save_failed(error)),
+                }
+            });
+        }
+    };
+    let apply_editor = move |rule: ManagedVisualRule| {
+        set_state.update(|state| match editor.get_untracked() {
+            Some(index) if index < state.envelope().rules.len() => state.replace_rule(index, rule),
+            _ => state.add(rule),
+        });
+        set_state.update(VisualRulesEditorState::close_editor_with_escape);
+        set_editor.set(None);
+    };
+    view! {
+        <div data-viewer-shortcuts="ignore" style="display: contents">
+            <aside class=move || if open.get() { "visual-rules-drawer" } else { "visual-rules-drawer visual-rules-drawer--closed" } aria-label="Visual rules" on:keydown=move |event: leptos::ev::KeyboardEvent| {
+                if drawer_should_handle_escape(&event.key()) {
+                    event.prevent_default();
+                    set_state.update(VisualRulesEditorState::collapse);
+                    set_state.update(|state| {
+                        let _ = state.close_drawer_with_escape();
+                    });
+                    set_open.set(false);
+                    if let Some(invoker) = invoker_ref.get() {
+                        request_animation_frame(move || {
+                            _ = invoker.focus();
+                        });
+                    }
+                }
+            }>
+                <header><h2>"Visual Rules"</h2><button type="button" on:click=move |_| {
+                    set_state.update(VisualRulesEditorState::collapse);
+                    set_state.update(|state| {
+                        let _ = state.close_drawer_with_escape();
+                    });
+                    set_open.set(false);
+                    if let Some(invoker) = invoker_ref.get() {
+                        request_animation_frame(move || {
+                            _ = invoker.focus();
+                        });
+                    }
+                }>"Close"</button></header>
+                <p role="status">{move || state.get().status().to_string()}</p>
+                <button type="button" on:click=move |_| {
+                    let index = state.get_untracked().envelope().rules.len();
+                    set_state.update(|state| state.add(new_rule()));
+                    set_state.update(|state| state.open_editor(index));
+                    set_editor.set(Some(index));
+                }>"Add"</button>
+                <ol>{move || state.get().envelope().rules.clone().into_iter().enumerate().map(|(index, rule)| view! {
+                    <li><button type="button" on:click=move |_| {
+                        set_state.update(|state| state.open_editor(index));
+                        set_editor.set(Some(index));
+                    }>{rule.name.unwrap_or_else(|| "Unnamed rule".to_string())}</button>
+                        <button type="button" on:click=move |_| set_state.update(|state| state.move_rule(index, -1))>"Move up"</button>
+                        <button type="button" on:click=move |_| set_state.update(|state| state.move_rule(index, 1))>"Move down"</button>
+                        <button type="button" on:click=move |_| set_state.update(|state| state.remove(index))>"Remove"</button></li>
+                }).collect_view()}</ol>
+                <footer><button type="button" on:click=discard>"Discard"</button><button type="button" on:click=reload>"Reload latest"</button><button type="button" disabled=move || !state.get().ordinary_save_allowed() on:click=move |_| persist(false)>"Save"</button><button type="button" on:click=move |_| persist(true)>"Replace"</button></footer>
+            </aside>
+            {move || editor.get().map(|index| {
+                let rule = state.get().envelope().rules.get(index).cloned().unwrap_or_else(new_rule);
+                view! { <VisualRuleEditor rule save=Callback::new(apply_editor) close=Callback::new(move |_| {
+                    set_state.update(VisualRulesEditorState::close_editor_with_escape);
+                    set_editor.set(None);
+                }) /> }
+            })}
+        </div>
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::visual_rules_state::VisualRulesFocusRequest;
+
+    #[test]
+    fn drawer_escape_is_handled_locally_and_restores_the_invoker_focus() {
+        assert!(drawer_should_handle_escape("Escape"));
+        assert!(!drawer_should_handle_escape("ArrowDown"));
+
+        let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
+        state.open_drawer();
+
+        assert_eq!(
+            state.close_drawer_with_escape(),
+            VisualRulesFocusRequest::Invoker
+        );
+    }
+
+    #[test]
+    fn page_refresh_is_notified_only_for_an_accepted_save_response() {
+        let mut notifications = 0;
+
+        notify_after_accepted_save(false, || notifications += 1);
+        assert_eq!(notifications, 0);
+
+        notify_after_accepted_save(true, || notifications += 1);
+        assert_eq!(notifications, 1);
+    }
+}

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -5,6 +5,170 @@ pub mod app;
 pub(crate) mod browser_api_client;
 pub mod components;
 pub mod file_opening;
+mod visual_rules_state;
+
+#[cfg(feature = "ssr")]
+pub fn visual_rules_path_from_env() -> std::path::PathBuf {
+    visual_rules_path(
+        std::env::var_os("LOGMANCER_CONFIG_DIR").map(std::path::PathBuf::from),
+        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn visual_rules_path(
+    config_dir: Option<std::path::PathBuf>,
+    working_dir: std::path::PathBuf,
+) -> std::path::PathBuf {
+    let base = config_dir
+        .filter(|value| !value.as_os_str().is_empty())
+        .unwrap_or_else(|| working_dir.join("config"));
+    base.join("visual-rules.json")
+}
+
+#[cfg(all(test, feature = "ssr"))]
+mod tests {
+    use super::{visual_rules_path, visual_rules_runtime, visual_rules_runtime_with_initial_file};
+    use logmancer_core::{
+        LineStyleIntent, ManagedVisualRule, VisualColor, VisualMatcher, VisualRulesEnvelope,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn config_directory_takes_precedence_over_default_visual_rules_location() {
+        let path = visual_rules_path(
+            Some(PathBuf::from("/temporary/config")),
+            PathBuf::from("/working-directory"),
+        );
+
+        assert_eq!(path, PathBuf::from("/temporary/config/visual-rules.json"));
+    }
+
+    #[test]
+    fn missing_config_directory_uses_the_working_directory_default() {
+        let path = visual_rules_path(None, PathBuf::from("/working-directory"));
+
+        assert_eq!(
+            path,
+            PathBuf::from("/working-directory/config/visual-rules.json")
+        );
+    }
+
+    #[test]
+    fn visual_rules_runtime_creates_parent_and_shares_persisted_rules_with_readers() {
+        let directory = tempfile::tempdir().unwrap();
+        let store_path = directory.path().join("config/visual-rules.json");
+        let log_path = directory.path().join("application.log");
+        std::fs::write(&log_path, "ERROR disk\n").unwrap();
+
+        let (registry, manager) = visual_rules_runtime(store_path.clone());
+        let revision = manager.state().revision;
+        manager
+            .save(
+                revision,
+                VisualRulesEnvelope::new(vec![ManagedVisualRule {
+                    name: None,
+                    enabled: true,
+                    matcher: VisualMatcher::Text("ERROR".to_string()),
+                    case_sensitive: true,
+                    style: LineStyleIntent {
+                        foreground: Some(VisualColor("red".to_string())),
+                        background: None,
+                    },
+                }]),
+            )
+            .unwrap();
+        let file_id = registry.open_file(log_path.to_str().unwrap()).unwrap();
+
+        let mut highlighted = false;
+        for _ in 0..100 {
+            let page = registry
+                .get_reader(&file_id)
+                .unwrap()
+                .read_page(0, 1)
+                .unwrap();
+            highlighted = page.lines.first().is_some_and(|line| line.style.is_some());
+            if highlighted {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+
+        assert!(store_path.is_file());
+        assert!(highlighted);
+    }
+
+    #[test]
+    fn visual_rules_runtime_survives_load_failure_without_claiming_save_success() {
+        let directory = tempfile::tempdir().unwrap();
+        let (_, manager) = visual_rules_runtime(directory.path().to_path_buf());
+
+        assert!(manager
+            .save(
+                manager.state().revision,
+                VisualRulesEnvelope::new(Vec::new())
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn shared_runtime_reopens_the_standard_web_initial_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let log_path = directory.path().join("initial.log");
+        std::fs::write(&log_path, "INFO ready\n").unwrap();
+
+        let (registry, _, file_id) = visual_rules_runtime_with_initial_file(
+            directory.path().join("config/visual-rules.json"),
+            log_path.to_str(),
+        );
+
+        assert!(registry.get_reader(&file_id.unwrap()).is_some());
+    }
+}
+
+#[cfg(feature = "ssr")]
+pub fn visual_rules_runtime(
+    path: std::path::PathBuf,
+) -> (
+    std::sync::Arc<logmancer_core::LogRegistry>,
+    std::sync::Arc<logmancer_core::VisualRulesManager>,
+) {
+    use logmancer_core::{LogRegistry, NativeVisualRulesStore, VisualRulesManager};
+    use std::sync::Arc;
+    use tracing::warn;
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            warn!(path = %parent.display(), %error, "Could not create visual rules directory");
+        }
+    }
+    let manager =
+        VisualRulesManager::with_store(Arc::new(NativeVisualRulesStore::new(path.clone())));
+    if let Err(error) = manager.load() {
+        warn!(path = %path.display(), %error, "Could not load optional visual rules configuration");
+    }
+    (
+        Arc::new(LogRegistry::with_manager(manager.clone())),
+        manager,
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn visual_rules_runtime_with_initial_file(
+    path: std::path::PathBuf,
+    initial_path: Option<&str>,
+) -> (
+    std::sync::Arc<logmancer_core::LogRegistry>,
+    std::sync::Arc<logmancer_core::VisualRulesManager>,
+    Option<String>,
+) {
+    let (registry, manager) = visual_rules_runtime(path);
+    let file_id = try_open_initial_file(&registry, initial_path);
+    (registry, manager, file_id)
+}
 
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]
@@ -16,18 +180,32 @@ pub fn hydrate() {
 
 #[cfg(feature = "ssr")]
 pub async fn start_leptos(port: u16) {
-    use logmancer_core::LogRegistry;
-    use std::sync::Arc;
-
-    start_leptos_with_registry(port, Arc::new(LogRegistry::new())).await;
+    let (registry, manager) = visual_rules_runtime(visual_rules_path_from_env());
+    start_leptos_with_registry_and_manager(port, registry, manager).await;
 }
 
 #[cfg(feature = "ssr")]
 pub async fn start_leptos_with_registry(
     port: u16,
-    registry: std::sync::Arc<logmancer_core::LogRegistry>,
+    _registry: std::sync::Arc<logmancer_core::LogRegistry>,
 ) {
-    use crate::api::config::api_routes_with_registry;
+    let initial_path = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
+    let (registry, manager, _) = visual_rules_runtime_with_initial_file(
+        visual_rules_path_from_env(),
+        initial_path.as_deref(),
+    );
+    start_leptos_with_registry_and_manager(port, registry, manager).await;
+}
+
+#[cfg(feature = "ssr")]
+pub async fn start_leptos_with_registry_and_manager(
+    port: u16,
+    registry: std::sync::Arc<logmancer_core::LogRegistry>,
+    visual_rules_manager: std::sync::Arc<logmancer_core::VisualRulesManager>,
+) {
+    use crate::api::config::api_routes_with_registry_and_manager;
     use crate::app::shell;
     use crate::components::App;
     use axum::Router;
@@ -50,7 +228,10 @@ pub async fn start_leptos_with_registry(
     let routes = generate_route_list(App);
 
     let app = Router::new()
-        .nest("/api", api_routes_with_registry(registry))
+        .nest(
+            "/api",
+            api_routes_with_registry_and_manager(registry.clone(), visual_rules_manager),
+        )
         .leptos_routes(&leptos_options, routes, {
             let leptos_options = leptos_options.clone();
             move || shell(leptos_options.clone())
@@ -69,10 +250,8 @@ pub async fn start_leptos_with_registry(
 
 #[cfg(feature = "ssr")]
 pub async fn start_axum(port: u16) {
-    use crate::api::config::api_routes_with_registry;
-    use logmancer_core::LogRegistry;
+    use crate::api::config::api_routes_with_registry_and_manager;
     use std::net::SocketAddr;
-    use std::sync::Arc;
     use tracing::info;
 
     init_backend_logging();
@@ -83,10 +262,10 @@ pub async fn start_axum(port: u16) {
     // `axum::Server` is a re-export of `hyper::Server`
     info!("Starting API server on http://{}", &addr);
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    axum::serve(
-        listener,
-        api_routes_with_registry(Arc::new(LogRegistry::new())).into_make_service(),
-    )
+    axum::serve(listener, {
+        let (registry, manager) = visual_rules_runtime(visual_rules_path_from_env());
+        api_routes_with_registry_and_manager(registry, manager).into_make_service()
+    })
     .await
     .unwrap();
 }

--- a/logmancer-web/src/visual_rules_state.rs
+++ b/logmancer-web/src/visual_rules_state.rs
@@ -1,0 +1,410 @@
+use logmancer_core::{ManagedVisualRule, VisualRulesEnvelope};
+
+#[derive(Clone, Debug)]
+pub struct VisualRulesEditorState {
+    baseline_revision: u64,
+    baseline: VisualRulesEnvelope,
+    envelope: VisualRulesEnvelope,
+    status: String,
+    drawer_is_open: bool,
+    editor_index: Option<usize>,
+    focus_target: VisualRulesFocusTarget,
+    loaded_from_server: bool,
+    operation_generation: u64,
+    requires_replace: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisualRulesFocusTarget {
+    Invoker,
+    Drawer,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisualRulesFocusRequest {
+    Invoker,
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+impl VisualRulesEditorState {
+    pub fn new(revision: u64, envelope: VisualRulesEnvelope) -> Self {
+        Self {
+            baseline_revision: revision,
+            baseline: envelope.clone(),
+            envelope,
+            status: String::new(),
+            drawer_is_open: false,
+            editor_index: None,
+            focus_target: VisualRulesFocusTarget::Invoker,
+            loaded_from_server: false,
+            operation_generation: 0,
+            requires_replace: false,
+        }
+    }
+
+    pub fn revision(&self) -> u64 {
+        self.baseline_revision
+    }
+
+    pub fn envelope(&self) -> &VisualRulesEnvelope {
+        &self.envelope
+    }
+
+    pub fn status(&self) -> &str {
+        &self.status
+    }
+
+    pub fn begin_operation(&mut self) -> u64 {
+        self.operation_generation = self.operation_generation.wrapping_add(1);
+        self.operation_generation
+    }
+
+    pub fn ordinary_save_allowed(&self) -> bool {
+        !self.requires_replace
+    }
+
+    pub fn open_drawer(&mut self) {
+        self.drawer_is_open = true;
+        self.focus_target = VisualRulesFocusTarget::Drawer;
+    }
+
+    #[allow(dead_code)]
+    pub fn drawer_is_open(&self) -> bool {
+        self.drawer_is_open
+    }
+
+    pub fn open_editor(&mut self, index: usize) {
+        self.editor_index = Some(index);
+    }
+
+    #[allow(dead_code)]
+    pub fn editor_index(&self) -> Option<usize> {
+        self.editor_index
+    }
+
+    pub fn close_editor_with_escape(&mut self) {
+        self.editor_index = None;
+        self.focus_target = VisualRulesFocusTarget::Drawer;
+    }
+
+    pub fn close_drawer_with_escape(&mut self) -> VisualRulesFocusRequest {
+        self.drawer_is_open = false;
+        self.editor_index = None;
+        self.focus_target = VisualRulesFocusTarget::Invoker;
+        VisualRulesFocusRequest::Invoker
+    }
+
+    #[allow(dead_code)]
+    pub fn focus_target(&self) -> VisualRulesFocusTarget {
+        self.focus_target
+    }
+
+    pub fn load_saved_once(&mut self, revision: u64, envelope: VisualRulesEnvelope) -> bool {
+        if self.loaded_from_server {
+            return false;
+        }
+
+        let has_local_edits = self.envelope != self.baseline;
+        self.baseline_revision = revision;
+        self.baseline = envelope.clone();
+        if !has_local_edits {
+            self.envelope = envelope;
+        } else {
+            self.requires_replace = true;
+            self.status = "Draft preserved; use Replace or Discard before saving.".to_string();
+        }
+        self.loaded_from_server = true;
+        true
+    }
+
+    pub fn reload_saved_for(
+        &mut self,
+        operation: u64,
+        revision: u64,
+        envelope: VisualRulesEnvelope,
+        message: impl Into<String>,
+    ) -> bool {
+        if operation != self.operation_generation {
+            return false;
+        }
+        let has_local_edits = self.envelope != self.baseline;
+        self.baseline_revision = revision;
+        self.baseline = envelope.clone();
+        if !has_local_edits {
+            self.envelope = envelope;
+        }
+        self.requires_replace = has_local_edits;
+        self.status = message.into();
+        if has_local_edits {
+            self.status
+                .push_str(" Draft preserved; use Replace or Discard before saving.");
+        }
+        self.loaded_from_server = true;
+        true
+    }
+
+    pub fn add(&mut self, rule: ManagedVisualRule) {
+        self.envelope.rules.push(rule);
+    }
+
+    pub fn replace_rule(&mut self, index: usize, rule: ManagedVisualRule) {
+        if let Some(existing) = self.envelope.rules.get_mut(index) {
+            *existing = rule;
+        }
+    }
+
+    pub fn remove(&mut self, index: usize) {
+        if index < self.envelope.rules.len() {
+            self.envelope.rules.remove(index);
+        }
+    }
+
+    pub fn move_rule(&mut self, index: usize, direction: isize) {
+        let target = index.checked_add_signed(direction);
+        if let Some(target) = target.filter(|target| *target < self.envelope.rules.len()) {
+            self.envelope.rules.swap(index, target);
+        }
+    }
+
+    pub fn collapse(&mut self) {}
+
+    pub fn discard(&mut self) {
+        self.begin_operation();
+        self.envelope = self.baseline.clone();
+        self.requires_replace = false;
+        self.status = "Discarded unsaved visual rule changes.".to_string();
+    }
+
+    pub fn save_failed(&mut self, message: impl Into<String>) {
+        self.status = message.into();
+    }
+
+    pub fn save_succeeded(
+        &mut self,
+        revision: u64,
+        envelope: VisualRulesEnvelope,
+        message: impl Into<String>,
+    ) {
+        let operation = self.operation_generation;
+        self.save_succeeded_for(operation, revision, envelope, message);
+    }
+
+    pub fn save_succeeded_for(
+        &mut self,
+        operation: u64,
+        revision: u64,
+        envelope: VisualRulesEnvelope,
+        message: impl Into<String>,
+    ) -> bool {
+        if operation != self.operation_generation {
+            return false;
+        }
+        let has_later_edits = self.envelope != envelope;
+        self.baseline_revision = revision;
+        self.baseline = envelope.clone();
+        if !has_later_edits {
+            self.envelope = envelope;
+        }
+        self.status = message.into();
+        self.loaded_from_server = true;
+        self.requires_replace = false;
+        true
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub fn operation_status(success: &str, diagnostics: &[String]) -> String {
+    if diagnostics.is_empty() {
+        success.to_string()
+    } else {
+        format!("Persistence warning: {}", diagnostics.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use logmancer_core::{
+        LineStyleIntent, ManagedVisualRule, VisualColor, VisualMatcher, VisualRulesEnvelope,
+    };
+
+    fn rule(name: &str, pattern: &str) -> ManagedVisualRule {
+        ManagedVisualRule {
+            name: Some(name.to_string()),
+            enabled: true,
+            matcher: VisualMatcher::Text(pattern.to_string()),
+            case_sensitive: false,
+            style: LineStyleIntent {
+                foreground: Some(VisualColor("red".to_string())),
+                background: None,
+            },
+        }
+    }
+
+    #[test]
+    fn local_edits_survive_collapse_and_discard_restores_baseline() {
+        let baseline = VisualRulesEnvelope::new(vec![rule("Errors", "ERROR")]);
+        let mut state = VisualRulesEditorState::new(7, baseline.clone());
+
+        state.add(rule("Warnings", "WARN"));
+        state.collapse();
+
+        assert_eq!(state.envelope().rules.len(), 2);
+        assert_eq!(state.envelope().rules[1].name.as_deref(), Some("Warnings"));
+
+        state.discard();
+
+        assert_eq!(state.revision(), 7);
+        assert_eq!(state.envelope().rules, baseline.rules);
+    }
+
+    #[test]
+    fn failed_save_retains_ordered_local_edits_and_success_updates_baseline() {
+        let baseline = VisualRulesEnvelope::new(vec![rule("Errors", "ERROR")]);
+        let mut state = VisualRulesEditorState::new(2, baseline);
+        state.add(rule("Warnings", "WARN"));
+
+        state.save_failed("Configuration changed elsewhere.");
+        assert_eq!(state.envelope().rules.len(), 2);
+        assert_eq!(state.status(), "Configuration changed elsewhere.");
+
+        let saved = state.envelope().clone();
+        state.save_succeeded(3, saved.clone(), "Saved visual rules.");
+        state.add(rule("Debug", "DEBUG"));
+        state.discard();
+
+        assert_eq!(state.revision(), 3);
+        assert_eq!(state.envelope().rules, saved.rules);
+    }
+
+    #[test]
+    fn drawer_and_editor_escape_preserve_local_edits_and_restore_invoker() {
+        let baseline = VisualRulesEnvelope::new(vec![rule("Errors", "ERROR")]);
+        let mut state = VisualRulesEditorState::new(4, baseline);
+
+        state.open_drawer();
+        state.add(rule("Warnings", "WARN"));
+        state.open_editor(1);
+        state.close_editor_with_escape();
+
+        assert_eq!(state.editor_index(), None);
+        assert_eq!(state.focus_target(), VisualRulesFocusTarget::Drawer);
+        assert_eq!(state.envelope().rules.len(), 2);
+
+        state.close_drawer_with_escape();
+
+        assert!(!state.drawer_is_open());
+        assert_eq!(state.focus_target(), VisualRulesFocusTarget::Invoker);
+        assert_eq!(state.envelope().rules[1].name.as_deref(), Some("Warnings"));
+    }
+
+    #[test]
+    fn invalid_recovery_status_does_not_discard_the_editable_copy() {
+        let baseline = VisualRulesEnvelope::new(vec![rule("Errors", "ERROR")]);
+        let mut state = VisualRulesEditorState::new(1, baseline);
+        state.add(rule("Broken draft", "["));
+
+        state.save_failed("rule 2: invalid regex");
+
+        assert_eq!(state.status(), "rule 2: invalid regex");
+        assert_eq!(state.envelope().rules.len(), 2);
+        assert_eq!(
+            state.envelope().rules[1].name.as_deref(),
+            Some("Broken draft")
+        );
+    }
+
+    #[test]
+    fn reopening_drawer_does_not_replace_an_unsaved_local_copy() {
+        let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
+        let saved = VisualRulesEnvelope::new(vec![rule("Errors", "ERROR")]);
+
+        assert!(state.load_saved_once(1, saved));
+        state.add(rule("Warnings", "WARN"));
+        state.close_drawer_with_escape();
+        state.open_drawer();
+
+        assert!(!state.load_saved_once(2, VisualRulesEnvelope::new(vec![rule("Other", "OTHER")])));
+        assert_eq!(state.envelope().rules.len(), 2);
+        assert_eq!(state.envelope().rules[1].name.as_deref(), Some("Warnings"));
+    }
+
+    #[test]
+    fn delayed_initial_load_updates_baseline_without_replacing_local_edits() {
+        let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
+        state.add(rule("Local", "LOCAL"));
+        let saved = VisualRulesEnvelope::new(vec![rule("Saved", "SAVED")]);
+        assert!(state.load_saved_once(5, saved.clone()));
+        assert_eq!(state.revision(), 5);
+        assert_eq!(state.envelope().rules[0].name.as_deref(), Some("Local"));
+        assert!(!state.ordinary_save_allowed());
+        assert!(state.status().contains("Replace or Discard"));
+        state.discard();
+        assert_eq!(state.envelope().rules, saved.rules);
+        assert!(state.ordinary_save_allowed());
+    }
+
+    #[test]
+    fn save_success_preserves_edits_made_after_submission() {
+        let mut state = VisualRulesEditorState::new(1, VisualRulesEnvelope::new(Vec::new()));
+        state.add(rule("Submitted", "ONE"));
+        let submitted = state.envelope().clone();
+        state.add(rule("Later", "TWO"));
+        state.save_succeeded(2, submitted.clone(), "Saved visual rules.");
+        assert_eq!(state.revision(), 2);
+        assert_eq!(state.envelope().rules.len(), 2);
+        state.discard();
+        assert_eq!(state.envelope().rules, submitted.rules);
+    }
+
+    #[test]
+    fn reload_rebases_revision_without_discarding_conflicting_draft() {
+        let mut state = VisualRulesEditorState::new(1, VisualRulesEnvelope::new(Vec::new()));
+        state.add(rule("Draft", "DRAFT"));
+        let latest = VisualRulesEnvelope::new(vec![rule("Latest", "LATEST")]);
+        let operation = state.begin_operation();
+        state.reload_saved_for(operation, 4, latest.clone(), "Loaded visual rules.");
+        assert_eq!(state.revision(), 4);
+        assert_eq!(state.envelope().rules[0].name.as_deref(), Some("Draft"));
+        assert!(!state.ordinary_save_allowed());
+        assert!(state.status().contains("Replace or Discard"));
+        state.discard();
+        assert_eq!(state.envelope().rules, latest.rules);
+        assert!(state.ordinary_save_allowed());
+    }
+
+    #[test]
+    fn older_save_response_cannot_rollback_a_newer_reload() {
+        let mut state = VisualRulesEditorState::new(1, VisualRulesEnvelope::new(Vec::new()));
+        state.add(rule("Draft", "DRAFT"));
+        let save_operation = state.begin_operation();
+        let submitted = state.envelope().clone();
+        let reload_operation = state.begin_operation();
+        let latest = VisualRulesEnvelope::new(vec![rule("Latest", "LATEST")]);
+        assert!(state.reload_saved_for(reload_operation, 4, latest, "Loaded visual rules.",));
+        assert!(!state.save_succeeded_for(save_operation, 2, submitted, "Saved visual rules.",));
+        assert_eq!(state.revision(), 4);
+        assert!(!state.ordinary_save_allowed());
+    }
+
+    #[test]
+    fn operation_status_surfaces_persistence_diagnostics() {
+        assert_eq!(
+            operation_status(
+                "Saved visual rules.",
+                &["directory sync failed".to_string()]
+            ),
+            "Persistence warning: directory sync failed"
+        );
+    }
+
+    #[test]
+    fn drawer_close_requests_focus_for_the_visual_rules_invoker() {
+        let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
+        state.open_drawer();
+
+        let focus_request = state.close_drawer_with_escape();
+
+        assert_eq!(focus_request, VisualRulesFocusRequest::Invoker);
+    }
+}

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -549,6 +549,30 @@ body {
   }
 }
 
+.app-bar {
+  display: grid;
+  grid-template-columns: 1fr minmax(0, 2fr) 1fr;
+  align-items: center;
+  min-height: 38px;
+  padding: 4px 8px;
+  border-bottom: 1px solid #dbe2ef;
+  background: #f8fafc;
+  font-family: system-ui, sans-serif;
+}
+
+.app-bar__filename { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: center; color: #334155; }
+.app-bar__actions { display: flex; justify-content: flex-end; gap: 6px; }
+.app-bar button, .visual-rules-drawer button, .visual-rules-modal button { border: 1px solid #cbd5e1; border-radius: 6px; background: #fff; color: #1e293b; cursor: pointer; padding: 5px 8px; }
+.visual-rules-drawer { position: fixed; right: 0; top: 0; z-index: 10000; width: min(390px, 94vw); height: 100vh; overflow: auto; padding: 16px; background: #fff; box-shadow: -12px 0 30px rgba(15, 23, 42, .18); font-family: system-ui, sans-serif; }
+.visual-rules-drawer--closed { display: none; }
+.visual-rules-drawer header, .visual-rules-drawer footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.visual-rules-drawer ol { margin: 12px 0; padding-left: 22px; }
+.visual-rules-drawer li { margin: 8px 0; display: flex; flex-wrap: wrap; gap: 4px; }
+.visual-rules-modal-backdrop { position: fixed; inset: 0; z-index: 10001; display: grid; place-items: center; background: rgba(15, 23, 42, .45); }
+.visual-rules-modal { width: min(420px, 92vw); display: grid; gap: 12px; padding: 18px; border-radius: 10px; background: #fff; font-family: system-ui, sans-serif; }
+.visual-rules-modal label { display: grid; gap: 4px; }
+.visual-rules-modal input { border: 1px solid #cbd5e1; border-radius: 6px; padding: 7px; }
+
 .main-pane-container {
   flex: 0 0 70%;
   min-width: 0;


### PR DESCRIPTION
Closes #69

## PR Type
- [x] New feature

## Summary
- Add the Visual Rules app-bar action, drawer, editor, ordering, Save/Replace/Discard workflow, and persistence diagnostics.
- Add accessible foreground/background palette controls and safe canonical color rendering.
- Wire one shared persisted manager across web and desktop runtimes and refresh visible pages after accepted changes.

## Changes
| Area | Change |
|---|---|
| Web API/client | GET, Save, retry, and Replace flows with revision/source conflict handling. |
| UI/state | Local draft lifecycle, async generation guards, drawer/editor focus, canonical palette controls. |
| Viewer | Safe foreground/background rendering and immediate main/filter refresh. |
| Runtime | Shared persisted manager, fresh config-directory creation, non-fatal observable initial load failures. |
| Desktop | Tauri config-path injection and shared runtime wiring. |
| Docs/fixture | Changelog entry and development JSON example. |

## Test Plan
- [x] `cargo test -p logmancer-web --features ssr --lib` — 114 passed.
- [x] `cargo test -p logmancer-core --features native-persistence` — 44 passed, 1 ignored.
- [x] Hydrate WASM check, formatting, and workspace Clippy passed.
- [x] Manual color editor, persistence, reload, and visible rendering tested.
- [x] Native pre-push and pre-PR receipt validation passed (`review-5de35c636177bbe3`).
- [x] Desktop/Tauri runtime explicitly waived; static workspace-Clippy coverage only.
- [x] Shellcheck N/A — no shell scripts changed.

## Review Size Exception

Maintainer-approved `size:exception`: 1,733 authored changed lines. This reviewed work unit keeps API, local state, accessible UI, runtime wiring, viewer refresh, tests, fixture, and changelog together as one functional/rollback boundary. It passed full 4R native review plus a bounded correction.

## Chain Context

```text
#79 Visual Rules Core Foundation
  └─ #80 Visual Rule Highlights
       └─ #81 Management Persistence
            └─ 📍 This PR: Management UI
```

- **Start:** #81 provides validated global persistence and shared snapshots.
- **End:** users can manage, persist, reload, and immediately see visual rules in web/desktop flows.
- **Depends on:** #81.
- **Follow-up:** behavior documentation in #70.
- **Out of scope:** browser E2E harness and desktop runtime automation.
- **Rollback:** revert the web/desktop management integration; core persistence and highlighting remain intact.

## Contributor Checklist
- [x] Linked approved issue #69.
- [x] Exactly one `type:*` label will be applied.
- [x] Tests, manual validation, and reviewed receipt are present.
- [x] Changelog updated.
- [x] Conventional commit format used.
- [x] No AI attribution trailers.