### PR TITLE
fix(build): raise release recursion limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- Release packaging now sets the required Rust recursion limit on the web binary and desktop library crate roots.
 - Desktop external-server mode now preserves desktop runtime detection across hydration and log navigation, so native file opening and drag/drop continue to work while avoiding duplicate Home file buttons.
 - Server-root file opening now accepts native-picker absolute paths only after canonicalizing them inside `LOGMANCER_SERVER_FILE_ROOT`.
 

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use logmancer_core::LogRegistry;
 use std::net::{TcpStream, ToSocketAddrs};
 #[cfg(any(feature = "embedded-server", test))]

--- a/logmancer-web/src/main.rs
+++ b/logmancer-web/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 #[cfg(feature = "ssr")]
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Closes #83

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Set Rust query recursion limits on the web binary and desktop library crate roots.
- Allow release packaging to compile the visual-rules UI on Linux and Windows.

## Changes
| File | Change |
| --- | --- |
| `logmancer-web/src/main.rs` | Add the web binary crate recursion limit. |
| `logmancer-desktop/src/lib.rs` | Add the desktop library crate recursion limit. |
| `CHANGELOG.md` | Document the release-packaging correction. |

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo build --release`
- [x] No shell scripts changed.

## Contributor Checklist
- [x] Linked approved issue #83
- [x] Added exactly one `type:*` label
- [x] Updated changelog for packaging behavior
- [x] Used a conventional commit
- [x] No `Co-Authored-By` trailer