### PR TITLE
feat(visual-rules): simplify configuration management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 /.atl/
 
 /openspec/
+/config/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Changed
 
+- Persisted visual-rules configuration is now formatted as readable multi-line JSON.
 - Desktop development mode can now run against an external `cargo leptos watch` server without embedding the Leptos/Axum server in the Tauri crate, reducing `tauri dev --no-default-features` compile work.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Changed
 
+- Visual-rules saving now creates or updates automatically, with clear conflict recovery controls.
 - Visual-rules drawer controls are more compact, with clearer rule editing and action hierarchy.
 - Persisted visual-rules configuration is now formatted as readable multi-line JSON.
 - Desktop development mode can now run against an external `cargo leptos watch` server without embedding the Leptos/Axum server in the Tauri crate, reducing `tauri dev --no-default-features` compile work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Changed
 
+- Visual-rules drawer controls are more compact, with clearer rule editing and action hierarchy.
 - Persisted visual-rules configuration is now formatted as readable multi-line JSON.
 - Desktop development mode can now run against an external `cargo leptos watch` server without embedding the Leptos/Axum server in the Tauri crate, reducing `tauri dev --no-default-features` compile work.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Changed
 
+- Visual-rules configuration retains only the 10 most recent backups after updates.
 - Visual-rules saving now creates or updates automatically, with clear conflict recovery controls.
 - Visual-rules drawer controls are more compact, with clearer rule editing and action hierarchy.
 - Persisted visual-rules configuration is now formatted as readable multi-line JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
+- Web app-bar file labels now update from the route ID to the opened file path after metadata loads.
 - Release packaging now sets the required Rust recursion limit on the web binary and desktop library crate roots.
 - Desktop external-server mode now preserves desktop runtime detection across hydration and log navigation, so native file opening and drag/drop continue to work while avoiding duplicate Home file buttons.
 - Server-root file opening now accepts native-picker absolute paths only after canonicalizing them inside `LOGMANCER_SERVER_FILE_ROOT`.

--- a/logmancer-core/src/visual_rules_manager.rs
+++ b/logmancer-core/src/visual_rules_manager.rs
@@ -200,7 +200,7 @@ impl VisualRulesManager {
         base_revision: u64,
         envelope: VisualRulesEnvelope,
     ) -> Result<SaveResult, VisualRulesError> {
-        self.persist(base_revision, envelope, false)
+        self.persist(base_revision, envelope, Some(false))
     }
 
     #[cfg(feature = "native-persistence")]
@@ -209,7 +209,16 @@ impl VisualRulesManager {
         base_revision: u64,
         envelope: VisualRulesEnvelope,
     ) -> Result<SaveResult, VisualRulesError> {
-        self.persist(base_revision, envelope, true)
+        self.persist(base_revision, envelope, Some(true))
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn upsert(
+        &self,
+        base_revision: u64,
+        envelope: VisualRulesEnvelope,
+    ) -> Result<SaveResult, VisualRulesError> {
+        self.persist(base_revision, envelope, None)
     }
 
     #[cfg(feature = "native-persistence")]
@@ -217,7 +226,7 @@ impl VisualRulesManager {
         &self,
         base_revision: u64,
         envelope: VisualRulesEnvelope,
-        replace: bool,
+        replace: Option<bool>,
     ) -> Result<SaveResult, VisualRulesError> {
         let report = envelope
             .validate_for_save()
@@ -233,6 +242,7 @@ impl VisualRulesManager {
         if state.revision != base_revision {
             return Err(VisualRulesError::RevisionConflict);
         }
+        let replace = replace.unwrap_or(state.source.is_some());
         let store = self.store.as_ref().expect("native store");
         let commit = store
             .compare_and_commit(state.source.as_deref(), &bytes, replace)

--- a/logmancer-core/src/visual_rules_manager.rs
+++ b/logmancer-core/src/visual_rules_manager.rs
@@ -222,7 +222,7 @@ impl VisualRulesManager {
         let report = envelope
             .validate_for_save()
             .map_err(|error| VisualRulesError::Validation(error.message))?;
-        let bytes = serde_json::to_vec(&envelope)
+        let bytes = serde_json::to_vec_pretty(&envelope)
             .map_err(|error| VisualRulesError::Decode(error.to_string()))?;
         if bytes.len() > VisualRulesEnvelope::MAX_PERSISTED_SIZE {
             return Err(VisualRulesError::Validation(
@@ -415,5 +415,16 @@ mod tests {
         assert_eq!(state.envelope, envelope("WARN"));
         assert!(manager.snapshot().evaluate("WARN").is_some());
         assert_eq!(manager.snapshot().evaluate("ERROR"), None);
+        let persisted = store
+            .bytes
+            .lock()
+            .expect("store lock")
+            .clone()
+            .expect("persisted rules");
+        assert!(
+            std::str::from_utf8(&persisted)
+                .expect("persisted rules are UTF-8 JSON")
+                .contains("\n  \"schemaVersion\"")
+        );
     }
 }

--- a/logmancer-core/src/visual_rules_store.rs
+++ b/logmancer-core/src/visual_rules_store.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 static TEMPORARY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static COMMIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 const OVERSIZED_TOKEN_DOMAIN: &[u8] = b"logmancer:visual-rules:oversized:sha256:v1\0";
+const MAX_RETAINED_BACKUPS: usize = 10;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StoreCommit {
@@ -216,7 +217,10 @@ impl AtomicFileReplacer for NativeAtomicFileReplacer {
         let mut file = AtomicWriteFile::options().open(path)?;
         file.write_all(bytes)?;
         file.commit()?;
-        match sync_parent(path) {
+        let sync_result = sync_parent(path);
+        // Retention is best-effort: a cleanup failure must not undo a committed update.
+        let _ = prune_backups(path);
+        match sync_result {
             Ok(()) => Ok(StoreCommit::Committed),
             Err(error) => Ok(StoreCommit::with_warning(error.to_string())),
         }
@@ -244,6 +248,38 @@ fn timestamped_backup_path(path: &Path) -> io::Result<PathBuf> {
     Ok(path.with_extension(format!("{timestamp}.bak")))
 }
 
+fn prune_backups(path: &Path) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("visual-rules");
+    let prefix = format!("{stem}.");
+    let mut backups = Vec::new();
+
+    for entry in fs::read_dir(parent)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Some(timestamp) = name
+            .strip_prefix(&prefix)
+            .and_then(|name| name.strip_suffix(".bak"))
+            .and_then(|timestamp| timestamp.parse::<u128>().ok())
+        else {
+            continue;
+        };
+        backups.push((timestamp, entry.path()));
+    }
+
+    backups.sort_unstable_by_key(|(timestamp, _)| *timestamp);
+    let expired = backups.len().saturating_sub(MAX_RETAINED_BACKUPS);
+    for (_, backup) in backups.into_iter().take(expired) {
+        fs::remove_file(backup)?;
+    }
+    Ok(())
+}
+
 #[cfg(unix)]
 fn sync_parent(path: &Path) -> io::Result<()> {
     File::open(path.parent().unwrap_or_else(|| Path::new(".")))?.sync_all()
@@ -252,4 +288,39 @@ fn sync_parent(path: &Path) -> io::Result<()> {
 #[cfg(not(unix))]
 fn sync_parent(_path: &Path) -> io::Result<()> {
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pruning_retains_recent_backups_without_touching_unrelated_files() {
+        let directory = std::env::temp_dir().join(format!(
+            "logmancer-visual-rules-backups-{}-{}",
+            std::process::id(),
+            TEMPORARY_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir(&directory).expect("create temporary directory");
+        let config = directory.join("visual-rules.json");
+        let unrelated = directory.join("other.1.bak");
+        fs::write(&unrelated, "unrelated backup").expect("write unrelated backup");
+
+        for timestamp in 1..=12 {
+            fs::write(config.with_extension(format!("{timestamp}.bak")), "backup")
+                .expect("write visual rules backup");
+        }
+
+        prune_backups(&config).expect("prune backups");
+
+        for timestamp in 1..=2 {
+            assert!(!config.with_extension(format!("{timestamp}.bak")).exists());
+        }
+        for timestamp in 3..=12 {
+            assert!(config.with_extension(format!("{timestamp}.bak")).exists());
+        }
+        assert!(unrelated.exists());
+
+        fs::remove_dir_all(directory).expect("remove temporary directory");
+    }
 }

--- a/logmancer-core/tests/visual_rules_management.rs
+++ b/logmancer-core/tests/visual_rules_management.rs
@@ -405,7 +405,7 @@ fn separate_processes_serialize_native_compare_and_commit() {
 }
 
 #[test]
-fn native_persistence_handles_missing_first_save_replace_and_source_conflicts() {
+fn native_persistence_upsert_creates_updates_and_preserves_source_conflicts() {
     let path = temp_config_path("visual-rules-persistence");
     let store = NativeVisualRulesStore::new(path.clone());
     let manager = VisualRulesManager::with_store(std::sync::Arc::new(store));
@@ -415,17 +415,17 @@ fn native_persistence_handles_missing_first_save_replace_and_source_conflicts() 
     assert!(loaded.envelope.rules.is_empty());
 
     let saved = manager
-        .save(
+        .upsert(
             loaded.revision,
             VisualRulesEnvelope::new(vec![rule("ERROR")]),
         )
-        .expect("first save");
+        .expect("first upsert");
     assert_eq!(saved.outcome, SaveOutcome::Committed);
     assert!(path.exists());
 
     let replaced = manager
-        .replace(saved.revision, VisualRulesEnvelope::new(vec![rule("WARN")]))
-        .expect("replace creates a backup before publication");
+        .upsert(saved.revision, VisualRulesEnvelope::new(vec![rule("WARN")]))
+        .expect("upsert replaces an existing configuration with a backup");
     assert_eq!(replaced.outcome, SaveOutcome::Committed);
     let backup_prefix = path
         .file_stem()
@@ -456,7 +456,7 @@ fn native_persistence_handles_missing_first_save_replace_and_source_conflicts() 
     );
 
     std::fs::write(&path, "{\"schemaVersion\":1,\"rules\":[]}").expect("external write");
-    let conflict = manager.save(
+    let conflict = manager.upsert(
         replaced.revision,
         VisualRulesEnvelope::new(vec![rule("INFO")]),
     );

--- a/logmancer-core/tests/visual_rules_management.rs
+++ b/logmancer-core/tests/visual_rules_management.rs
@@ -60,7 +60,7 @@ fn envelope_with_serialized_size(target: usize) -> VisualRulesEnvelope {
         style: style(Some("red"), Some("default")),
     };
     let mut envelope = VisualRulesEnvelope::new(vec![empty_rule; 100]);
-    let baseline = serde_json::to_vec(&envelope)
+    let baseline = serde_json::to_vec_pretty(&envelope)
         .expect("serialize baseline envelope")
         .len();
     let extra = target
@@ -82,7 +82,7 @@ fn envelope_with_serialized_size(target: usize) -> VisualRulesEnvelope {
     }
     assert_eq!((escaped, ascii), (0, 0));
     assert!(envelope.validate_for_save().is_ok());
-    let size = serde_json::to_vec(&envelope)
+    let size = serde_json::to_vec_pretty(&envelope)
         .expect("serialize boundary envelope")
         .len();
     assert_eq!(size, target);
@@ -814,7 +814,7 @@ fn oversized_tail_change_conflicts_until_the_complete_source_is_reloaded() {
     assert_eq!(repaired.outcome, SaveOutcome::Committed);
     assert_eq!(
         std::fs::read(&path).expect("read repaired source"),
-        serde_json::to_vec(&VisualRulesEnvelope::new(vec![rule("WARN")]))
+        serde_json::to_vec_pretty(&VisualRulesEnvelope::new(vec![rule("WARN")]))
             .expect("serialize repaired source")
     );
     assert_eq!(
@@ -965,7 +965,7 @@ fn separate_native_stores_serialize_concurrent_manager_replacements() {
     );
     assert_eq!(
         std::fs::read(&path).expect("read committed source"),
-        serde_json::to_vec(&VisualRulesEnvelope::new(vec![rule("WARN")]))
+        serde_json::to_vec_pretty(&VisualRulesEnvelope::new(vec![rule("WARN")]))
             .expect("serialize committed replacement")
     );
 

--- a/logmancer-web/src/api/config.rs
+++ b/logmancer-web/src/api/config.rs
@@ -6,9 +6,7 @@ use crate::api::server_browser::{
     server_browser_list, server_browser_open, server_browser_status, ServerFileRoot,
 };
 use crate::api::upload_file::upload_file;
-use crate::api::visual_rules::{
-    get_visual_rules, replace_visual_rules, retry_visual_rules, save_visual_rules,
-};
+use crate::api::visual_rules::{get_visual_rules, retry_visual_rules, save_visual_rules};
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
@@ -48,7 +46,6 @@ pub fn api_routes_with_registry_and_manager<T>(
         .route("/visual-rules", get(get_visual_rules))
         .route("/visual-rules/save", post(save_visual_rules))
         .route("/visual-rules/retry", post(retry_visual_rules))
-        .route("/visual-rules/replace", post(replace_visual_rules))
         .layer(DefaultBodyLimit::max(LOG_UPLOAD_BODY_LIMIT_BYTES))
         .with_state(AppState {
             registry,

--- a/logmancer-web/src/api/visual_rules.rs
+++ b/logmancer-web/src/api/visual_rules.rs
@@ -29,7 +29,7 @@ pub async fn save_visual_rules(
     let envelope = request.envelope.clone();
     match app_state
         .visual_rules_manager
-        .save(request.base_revision, request.envelope)
+        .upsert(request.base_revision, request.envelope)
     {
         Ok(result) => {
             (StatusCode::OK, Json(visual_rules_success(result, envelope))).into_response()
@@ -53,22 +53,6 @@ pub async fn retry_visual_rules(State(app_state): State<AppState>) -> Response {
             }),
         )
             .into_response(),
-        Err(error) => visual_rules_error(error),
-    }
-}
-
-pub async fn replace_visual_rules(
-    State(app_state): State<AppState>,
-    Json(request): Json<VisualRulesSaveRequest>,
-) -> Response {
-    let envelope = request.envelope.clone();
-    match app_state
-        .visual_rules_manager
-        .replace(request.base_revision, request.envelope)
-    {
-        Ok(result) => {
-            (StatusCode::OK, Json(visual_rules_success(result, envelope))).into_response()
-        }
         Err(error) => visual_rules_error(error),
     }
 }

--- a/logmancer-web/src/browser_api_client.rs
+++ b/logmancer-web/src/browser_api_client.rs
@@ -101,32 +101,38 @@ async fn request_visual_rules(
 pub async fn save_visual_rules(
     base_revision: u64,
     envelope: logmancer_core::VisualRulesEnvelope,
-    replace: bool,
-) -> Result<VisualRulesResponse, String> {
-    let base = window()
-        .location()
-        .origin()
-        .map_err(|_| "Could not detect application origin.".to_string())?;
+) -> Result<VisualRulesResponse, VisualRulesSaveError> {
+    let base = window().location().origin().map_err(|_| {
+        VisualRulesSaveError::Message("Could not detect application origin.".to_string())
+    })?;
     let response = reqwest::Client::new()
-        .post(format!(
-            "{base}/api/visual-rules/{}",
-            if replace { "replace" } else { "save" }
-        ))
+        .post(format!("{base}/api/visual-rules/save"))
         .json(&VisualRulesSaveRequest {
             base_revision,
             envelope,
         })
         .send()
         .await
-        .map_err(|_| "Could not connect to the server.".to_string())?;
+        .map_err(|_| {
+            VisualRulesSaveError::Message("Could not connect to the server.".to_string())
+        })?;
     if response.status().is_success() {
-        response
-            .json()
-            .await
-            .map_err(|_| "Could not parse saved visual rules.".to_string())
+        response.json().await.map_err(|_| {
+            VisualRulesSaveError::Message("Could not parse saved visual rules.".to_string())
+        })
+    } else if response.status() == reqwest::StatusCode::CONFLICT {
+        Err(VisualRulesSaveError::Conflict)
     } else {
-        Err(parse_api_error_message(response, "Could not save visual rules.").await)
+        Err(VisualRulesSaveError::Message(
+            parse_api_error_message(response, "Could not save visual rules.").await,
+        ))
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub enum VisualRulesSaveError {
+    Conflict,
+    Message(String),
 }
 
 pub async fn apply_filter(file_id: String, filter: String) -> Result<String, ServerFnError> {

--- a/logmancer-web/src/components/app_bar.rs
+++ b/logmancer-web/src/components/app_bar.rs
@@ -3,14 +3,20 @@ use leptos::prelude::*;
 
 #[component]
 pub fn AppBar(
-    path: String,
+    #[prop(into)] path: Signal<String>,
     open_visual_rules: Callback<()>,
     visual_rules_button_ref: NodeRef<html::Button>,
 ) -> impl IntoView {
     view! {
         <header class="app-bar">
             <span class="app-bar__spacer"></span>
-            <span class="app-bar__filename" title=path.clone() aria-label=format!("Open file: {path}")>{path.clone()}</span>
+            <span
+                class="app-bar__filename"
+                title=move || path.get()
+                aria-label=move || format!("Open file: {}", path.get())
+            >
+                {move || path.get()}
+            </span>
             <div class="app-bar__actions">
                 <button node_ref=visual_rules_button_ref type="button" on:click=move |_| open_visual_rules.run(())>"Visual Rules"</button>
                 <button type="button" aria-label="Future actions" title="Future actions">"…"</button>

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -284,7 +284,7 @@ pub fn LogView() -> impl IntoView {
             tabindex="0"
         >
             <AppBar
-                path=file_path.get()
+                path=file_path
                 open_visual_rules=Callback::new(move |_| set_visual_rules_open.set(true))
                 visual_rules_button_ref=visual_rules_button_ref
             />

--- a/logmancer-web/src/components/visual_rules.rs
+++ b/logmancer-web/src/components/visual_rules.rs
@@ -41,8 +41,7 @@ pub fn VisualRules(
             leptos::task::spawn_local(async move {
                 match fetch_visual_rules().await {
                     Ok(response) => set_state.update(|state| {
-                        let message =
-                            operation_status("Loaded visual rules.", &response.diagnostics);
+                        let message = operation_status("", &response.diagnostics);
                         if state.load_saved_once(response.revision, response.envelope) {
                             state.save_failed(message);
                         }
@@ -140,33 +139,47 @@ pub fn VisualRules(
                     }
                 }
             }>
-                <header><h2>"Visual Rules"</h2><button type="button" on:click=move |_| {
-                    set_state.update(VisualRulesEditorState::collapse);
-                    set_state.update(|state| {
-                        let _ = state.close_drawer_with_escape();
-                    });
-                    set_open.set(false);
-                    if let Some(invoker) = invoker_ref.get() {
-                        request_animation_frame(move || {
-                            _ = invoker.focus();
-                        });
-                    }
-                }>"Close"</button></header>
-                <p role="status">{move || state.get().status().to_string()}</p>
-                <button type="button" on:click=move |_| {
-                    let index = state.get_untracked().envelope().rules.len();
-                    set_state.update(|state| state.add(new_rule()));
-                    set_state.update(|state| state.open_editor(index));
-                    set_editor.set(Some(index));
-                }>"Add"</button>
+                <header>
+                    <h2>"Visual Rules"</h2>
+                    <div class="visual-rules-drawer__header-actions">
+                        <button type="button" on:click=move |_| {
+                            let index = state.get_untracked().envelope().rules.len();
+                            set_state.update(|state| state.add(new_rule()));
+                            set_state.update(|state| state.open_editor(index));
+                            set_editor.set(Some(index));
+                        }>"Add"</button>
+                        <button type="button" on:click=move |_| {
+                            set_state.update(VisualRulesEditorState::collapse);
+                            set_state.update(|state| {
+                                let _ = state.close_drawer_with_escape();
+                            });
+                            set_open.set(false);
+                            if let Some(invoker) = invoker_ref.get() {
+                                request_animation_frame(move || {
+                                    _ = invoker.focus();
+                                });
+                            }
+                        }>"Close"</button>
+                    </div>
+                </header>
+                <Show when=move || !state.get().status().is_empty()>
+                    <p class="visual-rules-drawer__status" role="status">{move || state.get().status().to_string()}</p>
+                </Show>
                 <ol>{move || state.get().envelope().rules.clone().into_iter().enumerate().map(|(index, rule)| view! {
-                    <li><button type="button" on:click=move |_| {
-                        set_state.update(|state| state.open_editor(index));
-                        set_editor.set(Some(index));
-                    }>{rule.name.unwrap_or_else(|| "Unnamed rule".to_string())}</button>
-                        <button type="button" on:click=move |_| set_state.update(|state| state.move_rule(index, -1))>"Move up"</button>
-                        <button type="button" on:click=move |_| set_state.update(|state| state.move_rule(index, 1))>"Move down"</button>
-                        <button type="button" on:click=move |_| set_state.update(|state| state.remove(index))>"Remove"</button></li>
+                    <li class="visual-rules-drawer__rule">
+                        <div class="visual-rules-drawer__rule-title">
+                            <span>{rule.name.unwrap_or_else(|| "Unnamed rule".to_string())}</span>
+                            <button class="visual-rules-drawer__icon-button" type="button" aria-label="Edit rule" title="Edit rule" on:click=move |_| {
+                                set_state.update(|state| state.open_editor(index));
+                                set_editor.set(Some(index));
+                            }>"✎"</button>
+                        </div>
+                        <div class="visual-rules-drawer__rule-actions">
+                            <button class="visual-rules-drawer__icon-button" type="button" aria-label="Move rule up" title="Move rule up" on:click=move |_| set_state.update(|state| state.move_rule(index, -1))>"↑"</button>
+                            <button class="visual-rules-drawer__icon-button" type="button" aria-label="Move rule down" title="Move rule down" on:click=move |_| set_state.update(|state| state.move_rule(index, 1))>"↓"</button>
+                            <button class="visual-rules-drawer__icon-button visual-rules-drawer__icon-button--danger" type="button" aria-label="Remove rule" title="Remove rule" on:click=move |_| set_state.update(|state| state.remove(index))>"×"</button>
+                        </div>
+                    </li>
                 }).collect_view()}</ol>
                 <footer><button type="button" on:click=discard>"Discard"</button><button type="button" on:click=reload>"Reload latest"</button><button type="button" disabled=move || !state.get().ordinary_save_allowed() on:click=move |_| persist(false)>"Save"</button><button type="button" on:click=move |_| persist(true)>"Replace"</button></footer>
             </aside>

--- a/logmancer-web/src/components/visual_rules.rs
+++ b/logmancer-web/src/components/visual_rules.rs
@@ -1,9 +1,13 @@
 #[cfg(target_arch = "wasm32")]
-use crate::browser_api_client::{fetch_visual_rules, retry_visual_rules, save_visual_rules};
+use crate::browser_api_client::{
+    fetch_visual_rules, retry_visual_rules, save_visual_rules, VisualRulesSaveError,
+};
 use crate::components::visual_rule_editor::{new_rule, VisualRuleEditor};
 #[cfg(target_arch = "wasm32")]
 use crate::visual_rules_state::operation_status;
 use crate::visual_rules_state::VisualRulesEditorState;
+#[cfg(target_arch = "wasm32")]
+use crate::visual_rules_state::VisualRulesRecoveryAction;
 use leptos::html;
 use leptos::prelude::*;
 use logmancer_core::{ManagedVisualRule, VisualRulesEnvelope};
@@ -52,32 +56,17 @@ pub fn VisualRules(
         }
     });
 
-    let discard = move |_| set_state.update(VisualRulesEditorState::discard);
-    let persist = move |_replace: bool| {
+    let persist = move |_| {
         #[cfg(target_arch = "wasm32")]
         {
             let current = state.get();
-            if !_replace && !current.ordinary_save_allowed() {
-                set_state.update(|state| {
-                    state.save_failed(
-                    "Reload preserved a conflicting draft. Use Replace or Discard before saving.",
-                )
-                });
-                return;
-            }
             let operation = set_state
                 .try_update(VisualRulesEditorState::begin_operation)
                 .expect("visual rules state");
             leptos::task::spawn_local(async move {
-                match save_visual_rules(current.revision(), current.envelope().clone(), _replace)
-                    .await
-                {
+                match save_visual_rules(current.revision(), current.envelope().clone()).await {
                     Ok(response) => set_state.update(|state| {
-                        let action = if _replace { "Replaced" } else { "Saved" };
-                        let message = operation_status(
-                            &format!("{action} visual rules."),
-                            &response.diagnostics,
-                        );
+                        let message = operation_status("Saved", &response.diagnostics);
                         let accepted = state.save_succeeded_for(
                             operation,
                             response.revision,
@@ -86,22 +75,31 @@ pub fn VisualRules(
                         );
                         notify_after_accepted_save(accepted, || on_saved.run(()));
                     }),
-                    Err(error) => set_state.update(|state| state.save_failed(error)),
+                    Err(VisualRulesSaveError::Conflict) => {
+                        set_state.update(VisualRulesEditorState::save_conflicted)
+                    }
+                    Err(VisualRulesSaveError::Message(error)) => {
+                        set_state.update(|state| state.save_failed(error))
+                    }
                 }
             });
         }
     };
-    let reload = move |_| {
+    let recover = move |_| {
         #[cfg(target_arch = "wasm32")]
         {
+            let action = state.get_untracked().recovery_action();
+            if action == VisualRulesRecoveryAction::Discard {
+                set_state.update(VisualRulesEditorState::discard);
+                return;
+            }
             let operation = set_state
-                .try_update(VisualRulesEditorState::begin_operation)
+                .try_update(VisualRulesEditorState::begin_reload)
                 .expect("visual rules state");
             leptos::task::spawn_local(async move {
                 match retry_visual_rules().await {
                     Ok(response) => set_state.update(|state| {
-                        let message =
-                            operation_status("Loaded visual rules.", &response.diagnostics);
+                        let message = operation_status("", &response.diagnostics);
                         state.reload_saved_for(
                             operation,
                             response.revision,
@@ -129,6 +127,7 @@ pub fn VisualRules(
                     event.prevent_default();
                     set_state.update(VisualRulesEditorState::collapse);
                     set_state.update(|state| {
+                        state.clear_success_status_on_close();
                         let _ = state.close_drawer_with_escape();
                     });
                     set_open.set(false);
@@ -151,6 +150,7 @@ pub fn VisualRules(
                         <button type="button" on:click=move |_| {
                             set_state.update(VisualRulesEditorState::collapse);
                             set_state.update(|state| {
+                                state.clear_success_status_on_close();
                                 let _ = state.close_drawer_with_escape();
                             });
                             set_open.set(false);
@@ -169,19 +169,19 @@ pub fn VisualRules(
                     <li class="visual-rules-drawer__rule">
                         <div class="visual-rules-drawer__rule-title">
                             <span>{rule.name.unwrap_or_else(|| "Unnamed rule".to_string())}</span>
+                        </div>
+                        <div class="visual-rules-drawer__rule-actions">
                             <button class="visual-rules-drawer__icon-button" type="button" aria-label="Edit rule" title="Edit rule" on:click=move |_| {
                                 set_state.update(|state| state.open_editor(index));
                                 set_editor.set(Some(index));
                             }>"✎"</button>
-                        </div>
-                        <div class="visual-rules-drawer__rule-actions">
                             <button class="visual-rules-drawer__icon-button" type="button" aria-label="Move rule up" title="Move rule up" on:click=move |_| set_state.update(|state| state.move_rule(index, -1))>"↑"</button>
                             <button class="visual-rules-drawer__icon-button" type="button" aria-label="Move rule down" title="Move rule down" on:click=move |_| set_state.update(|state| state.move_rule(index, 1))>"↓"</button>
                             <button class="visual-rules-drawer__icon-button visual-rules-drawer__icon-button--danger" type="button" aria-label="Remove rule" title="Remove rule" on:click=move |_| set_state.update(|state| state.remove(index))>"×"</button>
                         </div>
                     </li>
                 }).collect_view()}</ol>
-                <footer><button type="button" on:click=discard>"Discard"</button><button type="button" on:click=reload>"Reload latest"</button><button type="button" disabled=move || !state.get().ordinary_save_allowed() on:click=move |_| persist(false)>"Save"</button><button type="button" on:click=move |_| persist(true)>"Replace"</button></footer>
+                <footer><button type="button" on:click=recover>{move || state.get().recovery_action().label()}</button><button type="button" on:click=persist>"Apply and save"</button></footer>
             </aside>
             {move || editor.get().map(|index| {
                 let rule = state.get().envelope().rules.get(index).cloned().unwrap_or_else(new_rule);

--- a/logmancer-web/src/visual_rules_state.rs
+++ b/logmancer-web/src/visual_rules_state.rs
@@ -11,7 +11,7 @@ pub struct VisualRulesEditorState {
     focus_target: VisualRulesFocusTarget,
     loaded_from_server: bool,
     operation_generation: u64,
-    requires_replace: bool,
+    conflicted: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -23,6 +23,23 @@ pub enum VisualRulesFocusTarget {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VisualRulesFocusRequest {
     Invoker,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisualRulesRecoveryAction {
+    Reload,
+    Discard,
+    DiscardAndReload,
+}
+
+impl VisualRulesRecoveryAction {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Reload => "Reload",
+            Self::Discard => "Discard",
+            Self::DiscardAndReload => "Discard and reload",
+        }
+    }
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
@@ -38,7 +55,7 @@ impl VisualRulesEditorState {
             focus_target: VisualRulesFocusTarget::Invoker,
             loaded_from_server: false,
             operation_generation: 0,
-            requires_replace: false,
+            conflicted: false,
         }
     }
 
@@ -59,8 +76,18 @@ impl VisualRulesEditorState {
         self.operation_generation
     }
 
-    pub fn ordinary_save_allowed(&self) -> bool {
-        !self.requires_replace
+    pub fn has_unsaved_changes(&self) -> bool {
+        self.envelope != self.baseline
+    }
+
+    pub fn recovery_action(&self) -> VisualRulesRecoveryAction {
+        if self.conflicted {
+            VisualRulesRecoveryAction::DiscardAndReload
+        } else if self.has_unsaved_changes() {
+            VisualRulesRecoveryAction::Discard
+        } else {
+            VisualRulesRecoveryAction::Reload
+        }
     }
 
     pub fn open_drawer(&mut self) {
@@ -110,8 +137,7 @@ impl VisualRulesEditorState {
         if !has_local_edits {
             self.envelope = envelope;
         } else {
-            self.requires_replace = true;
-            self.status = "Draft preserved; use Replace or Discard before saving.".to_string();
+            self.status = "Draft preserved.".to_string();
         }
         self.loaded_from_server = true;
         true
@@ -127,18 +153,11 @@ impl VisualRulesEditorState {
         if operation != self.operation_generation {
             return false;
         }
-        let has_local_edits = self.envelope != self.baseline;
         self.baseline_revision = revision;
         self.baseline = envelope.clone();
-        if !has_local_edits {
-            self.envelope = envelope;
-        }
-        self.requires_replace = has_local_edits;
+        self.envelope = envelope;
+        self.conflicted = false;
         self.status = message.into();
-        if has_local_edits {
-            self.status
-                .push_str(" Draft preserved; use Replace or Discard before saving.");
-        }
         self.loaded_from_server = true;
         true
     }
@@ -168,25 +187,34 @@ impl VisualRulesEditorState {
 
     pub fn collapse(&mut self) {}
 
+    pub fn clear_success_status_on_close(&mut self) {
+        if self.status == "Saved" {
+            self.status.clear();
+        }
+    }
+
     pub fn discard(&mut self) {
         self.begin_operation();
         self.envelope = self.baseline.clone();
-        self.requires_replace = false;
-        self.status = "Discarded unsaved visual rule changes.".to_string();
+        self.conflicted = false;
+        self.status.clear();
+    }
+
+    pub fn begin_reload(&mut self) -> u64 {
+        self.envelope = self.baseline.clone();
+        self.conflicted = false;
+        self.status.clear();
+        self.begin_operation()
     }
 
     pub fn save_failed(&mut self, message: impl Into<String>) {
         self.status = message.into();
     }
 
-    pub fn save_succeeded(
-        &mut self,
-        revision: u64,
-        envelope: VisualRulesEnvelope,
-        message: impl Into<String>,
-    ) {
-        let operation = self.operation_generation;
-        self.save_succeeded_for(operation, revision, envelope, message);
+    pub fn save_conflicted(&mut self) {
+        self.conflicted = true;
+        self.status =
+            "Visual rules changed in another instance. Discard and reload to continue.".to_string();
     }
 
     pub fn save_succeeded_for(
@@ -207,7 +235,7 @@ impl VisualRulesEditorState {
         }
         self.status = message.into();
         self.loaded_from_server = true;
-        self.requires_replace = false;
+        self.conflicted = false;
         true
     }
 }
@@ -269,7 +297,8 @@ mod tests {
         assert_eq!(state.status(), "Configuration changed elsewhere.");
 
         let saved = state.envelope().clone();
-        state.save_succeeded(3, saved.clone(), "Saved visual rules.");
+        let operation = state.begin_operation();
+        assert!(state.save_succeeded_for(operation, 3, saved.clone(), "Saved"));
         state.add(rule("Debug", "DEBUG"));
         state.discard();
 
@@ -337,11 +366,11 @@ mod tests {
         assert!(state.load_saved_once(5, saved.clone()));
         assert_eq!(state.revision(), 5);
         assert_eq!(state.envelope().rules[0].name.as_deref(), Some("Local"));
-        assert!(!state.ordinary_save_allowed());
-        assert!(state.status().contains("Replace or Discard"));
+        assert!(state.has_unsaved_changes());
+        assert_eq!(state.recovery_action(), VisualRulesRecoveryAction::Discard);
         state.discard();
         assert_eq!(state.envelope().rules, saved.rules);
-        assert!(state.ordinary_save_allowed());
+        assert_eq!(state.recovery_action(), VisualRulesRecoveryAction::Reload);
     }
 
     #[test]
@@ -349,8 +378,9 @@ mod tests {
         let mut state = VisualRulesEditorState::new(1, VisualRulesEnvelope::new(Vec::new()));
         state.add(rule("Submitted", "ONE"));
         let submitted = state.envelope().clone();
+        let operation = state.begin_operation();
         state.add(rule("Later", "TWO"));
-        state.save_succeeded(2, submitted.clone(), "Saved visual rules.");
+        assert!(state.save_succeeded_for(operation, 2, submitted.clone(), "Saved"));
         assert_eq!(state.revision(), 2);
         assert_eq!(state.envelope().rules.len(), 2);
         state.discard();
@@ -358,19 +388,14 @@ mod tests {
     }
 
     #[test]
-    fn reload_rebases_revision_without_discarding_conflicting_draft() {
+    fn reload_replaces_the_editor_state_with_the_latest_configuration() {
         let mut state = VisualRulesEditorState::new(1, VisualRulesEnvelope::new(Vec::new()));
-        state.add(rule("Draft", "DRAFT"));
         let latest = VisualRulesEnvelope::new(vec![rule("Latest", "LATEST")]);
-        let operation = state.begin_operation();
+        let operation = state.begin_reload();
         state.reload_saved_for(operation, 4, latest.clone(), "Loaded visual rules.");
         assert_eq!(state.revision(), 4);
-        assert_eq!(state.envelope().rules[0].name.as_deref(), Some("Draft"));
-        assert!(!state.ordinary_save_allowed());
-        assert!(state.status().contains("Replace or Discard"));
-        state.discard();
         assert_eq!(state.envelope().rules, latest.rules);
-        assert!(state.ordinary_save_allowed());
+        assert_eq!(state.recovery_action(), VisualRulesRecoveryAction::Reload);
     }
 
     #[test]
@@ -384,7 +409,23 @@ mod tests {
         assert!(state.reload_saved_for(reload_operation, 4, latest, "Loaded visual rules.",));
         assert!(!state.save_succeeded_for(save_operation, 2, submitted, "Saved visual rules.",));
         assert_eq!(state.revision(), 4);
-        assert!(!state.ordinary_save_allowed());
+        assert_eq!(state.recovery_action(), VisualRulesRecoveryAction::Reload);
+    }
+
+    #[test]
+    fn recovery_action_changes_for_drafts_and_conflicts() {
+        let baseline = VisualRulesEnvelope::new(vec![rule("Errors", "ERROR")]);
+        let mut state = VisualRulesEditorState::new(1, baseline);
+
+        assert_eq!(state.recovery_action(), VisualRulesRecoveryAction::Reload);
+        state.add(rule("Warnings", "WARN"));
+        assert_eq!(state.recovery_action(), VisualRulesRecoveryAction::Discard);
+        state.save_conflicted();
+        assert_eq!(
+            state.recovery_action(),
+            VisualRulesRecoveryAction::DiscardAndReload
+        );
+        assert_eq!(state.recovery_action().label(), "Discard and reload");
     }
 
     #[test]
@@ -398,6 +439,23 @@ mod tests {
         let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
         state.save_failed("Could not load visual rules.");
         assert_eq!(state.status(), "Could not load visual rules.");
+    }
+
+    #[test]
+    fn closing_clears_saved_status_but_preserves_warnings_and_errors() {
+        let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
+
+        state.save_failed("Saved");
+        state.clear_success_status_on_close();
+        assert_eq!(state.status(), "");
+
+        state.save_failed("Persistence warning: directory sync failed");
+        state.clear_success_status_on_close();
+        assert_eq!(state.status(), "Persistence warning: directory sync failed");
+
+        state.save_failed("Could not save visual rules.");
+        state.clear_success_status_on_close();
+        assert_eq!(state.status(), "Could not save visual rules.");
     }
 
     #[test]

--- a/logmancer-web/src/visual_rules_state.rs
+++ b/logmancer-web/src/visual_rules_state.rs
@@ -389,13 +389,15 @@ mod tests {
 
     #[test]
     fn operation_status_surfaces_persistence_diagnostics() {
+        assert_eq!(operation_status("", &[]), "");
         assert_eq!(
-            operation_status(
-                "Saved visual rules.",
-                &["directory sync failed".to_string()]
-            ),
+            operation_status("", &["directory sync failed".to_string()]),
             "Persistence warning: directory sync failed"
         );
+
+        let mut state = VisualRulesEditorState::new(0, VisualRulesEnvelope::new(Vec::new()));
+        state.save_failed("Could not load visual rules.");
+        assert_eq!(state.status(), "Could not load visual rules.");
     }
 
     #[test]

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -570,7 +570,7 @@ body {
 .visual-rules-drawer__status { margin: 12px 0; color: #475569; }
 .visual-rules-drawer ol { margin: 12px 0; padding-left: 22px; }
 .visual-rules-drawer__rule { margin: 8px 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
-.visual-rules-drawer__rule-title { display: flex; align-items: center; gap: 4px; min-width: 0; font-weight: 600; }
+.visual-rules-drawer__rule-title { min-width: 0; font-weight: 600; }
 .visual-rules-drawer__rule-title span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .visual-rules-drawer__icon-button { min-width: 30px; padding: 4px 6px; font-size: 16px; line-height: 1; }
 .visual-rules-drawer__icon-button--danger { border-color: #fecaca; color: #b91c1c; }

--- a/logmancer-web/style/main.scss
+++ b/logmancer-web/style/main.scss
@@ -566,8 +566,14 @@ body {
 .visual-rules-drawer { position: fixed; right: 0; top: 0; z-index: 10000; width: min(390px, 94vw); height: 100vh; overflow: auto; padding: 16px; background: #fff; box-shadow: -12px 0 30px rgba(15, 23, 42, .18); font-family: system-ui, sans-serif; }
 .visual-rules-drawer--closed { display: none; }
 .visual-rules-drawer header, .visual-rules-drawer footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.visual-rules-drawer__header-actions, .visual-rules-drawer__rule-actions { display: flex; gap: 4px; }
+.visual-rules-drawer__status { margin: 12px 0; color: #475569; }
 .visual-rules-drawer ol { margin: 12px 0; padding-left: 22px; }
-.visual-rules-drawer li { margin: 8px 0; display: flex; flex-wrap: wrap; gap: 4px; }
+.visual-rules-drawer__rule { margin: 8px 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.visual-rules-drawer__rule-title { display: flex; align-items: center; gap: 4px; min-width: 0; font-weight: 600; }
+.visual-rules-drawer__rule-title span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.visual-rules-drawer__icon-button { min-width: 30px; padding: 4px 6px; font-size: 16px; line-height: 1; }
+.visual-rules-drawer__icon-button--danger { border-color: #fecaca; color: #b91c1c; }
 .visual-rules-modal-backdrop { position: fixed; inset: 0; z-index: 10001; display: grid; place-items: center; background: rgba(15, 23, 42, .45); }
 .visual-rules-modal { width: min(420px, 92vw); display: grid; gap: 12px; padding: 18px; border-radius: 10px; background: #fff; font-family: system-ui, sans-serif; }
 .visual-rules-modal label { display: grid; gap: 4px; }


### PR DESCRIPTION
Closes #70

## PR Type
- [x] New feature

## Summary
- Formats and retains persisted visual-rules configuration safely.
- Simplifies the visual-rules drawer and reacts to resolved file metadata.
- Unifies create/update saving with explicit conflict recovery.

## Changes
| File area | Change |
|---|---|
| `logmancer-core` | Pretty JSON persistence, automatic create/update, and retention of the 10 newest backups. |
| `logmancer-web` | Reactive file label, compact rule controls, unified save/recovery actions, and conflict feedback. |
| `CHANGELOG.md` / `.gitignore` | User-facing release notes and local config exclusion. |

## Verification
- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p logmancer-core --features native-persistence`
- [x] `cargo test -p logmancer-web`
- [x] `cargo check -p logmancer-web --target wasm32-unknown-unknown --features hydrate`

## Review Scope
- Size exception accepted by maintainer: 476 changed lines across five cohesive visual-rules work units.
- Rollback boundary: revert commits `291d0cb`, `97feacb`, `c9be830`, `8597906`, and `063fb1e`; unrelated worktree files are excluded.