### PR TITLE
feat(registry): centralize configuration and file authorization

### DIFF
--- a/docs/adr/0004-core-configuration-store.md
+++ b/docs/adr/0004-core-configuration-store.md
@@ -1,0 +1,67 @@
+# ADR 0004: Core configuration store
+
+## Status
+
+Accepted
+
+## Decision
+
+Core owns persisted configuration files through `ConfigStore`.
+
+Web and desktop resolve only the platform-specific configuration directory.
+`ConfigStore` receives that directory and owns configuration document names,
+native filesystem operations, atomic writes, locks, backups, and recovery.
+
+`LogRegistry` receives a `ConfigStore` and creates its internal
+`VisualRulesManager` from the visual-rules store supplied by that configuration
+store. The registry exposes semantic visual-rules operations without exposing
+the manager itself.
+
+## Context
+
+Visual-rules persistence currently receives a path assembled separately by web
+and desktop. This distributes configuration-file naming and native persistence
+concerns across platform layers.
+
+`LogRegistry` currently receives a pre-built `VisualRulesManager`, making its
+lifecycle external and requiring runtimes to carry registry and manager as
+parallel dependencies.
+
+Future persisted recent-file history will use another JSON document in the
+same configuration directory. It has different domain behavior from visual
+rules, but should use the same core-owned persistence infrastructure.
+
+## Decisions
+
+| Area | Decision |
+|---|---|
+| Configuration directory | Web and desktop resolve the platform-specific directory. |
+| Configuration files | `ConfigStore` owns file names and native persistence infrastructure. |
+| File names | Configuration document names are private core details, including `visual-rules.json` and the future `recent-files.json`. |
+| Visual rules | `LogRegistry` creates its `VisualRulesManager` from `ConfigStore`. |
+| Registry API | The registry exposes semantic visual-rules operations rather than its internal manager. |
+| Document semantics | Each manager owns validation, revisions, limits, and lifecycle behavior for its document. |
+
+## Consequences
+
+- Web and desktop no longer assemble individual configuration file paths.
+- One registry owns the one visual-rules manager used by all of its readers.
+- Visual rules and recent-file history can share persistence infrastructure
+  without sharing domain semantics.
+- Tests can inject document-specific stores without depending on platform
+  configuration directories.
+
+## Out of scope
+
+- Persisted recent-file history and stable route IDs.
+- Persistent upload storage and cleanup.
+- File-open authorization policies.
+
+## Verification checklist
+
+- [ ] Web and desktop resolve configuration directories without naming
+  individual configuration files.
+- [ ] Registry readers and visual-rules operations use one internal manager.
+- [ ] Configuration document names are defined only in core.
+- [ ] Visual-rules persistence retains its current atomic-write, conflict, and
+  recovery behavior.

--- a/docs/adr/0005-registry-file-open-policy.md
+++ b/docs/adr/0005-registry-file-open-policy.md
@@ -1,0 +1,68 @@
+# ADR 0005: Registry-level file-open policy
+
+## Status
+
+Accepted
+
+## Decision
+
+`LogRegistry` accepts an optional `FileOpenPolicy` and validates every file
+open through that policy before creating a `LogReader`.
+
+The policy receives an input path and returns the authorized, canonical path
+that the reader consumes. A rejected path prevents reader creation.
+
+Registries without a policy preserve the current unrestricted native-file
+behavior.
+
+## Context
+
+SSR server-file browsing already constrains paths to
+`LOGMANCER_SERVER_FILE_ROOT`. That validation currently lives in individual
+HTTP handlers.
+
+Future persisted recent-file history must restore paths without bypassing the
+active authorization boundary. Applying authorization at the registry is the
+only way to ensure every caller of `open_file` follows the same rule.
+
+This ADR complements ADR 0001. ADR 0001 defines the SSR server-browser
+capability; this ADR defines the registry-level enforcement point used by that
+capability and future restoration flows.
+
+## Decisions
+
+| Area | Decision |
+|---|---|
+| Enforcement point | `LogRegistry` applies the policy before every reader is created. |
+| Policy contract | The policy validates and canonicalizes a path, returning the path that may be opened. |
+| Policy ownership | Core defines the policy contract; platform layers construct policies from deployment-specific authorization rules. |
+| SSR authorization | SSR supplies roots authorized by the deployment, including the configured server root. |
+| Current uploads | SSR also allows direct children of the system temporary directory whose names start with `logmancer-upload-`, preserving the current upload flow. |
+| Future uploads | The temporary upload exception will be replaced with a persistent Logmancer-managed upload directory when uploads are implemented. |
+| HTTP behavior | Handlers retain request validation, text-readability checks, and HTTP error mapping. |
+
+## Consequences
+
+- Server-browser openings, future history restoration, and other registry
+  callers cannot bypass an installed policy.
+- The core does not depend on `LOGMANCER_SERVER_FILE_ROOT`, HTTP, or SSR.
+- Desktop and TUI can use the registry without a policy.
+- Existing SSR root validation remains useful for safe request-specific errors,
+  while the registry provides the final authorization boundary.
+
+## Out of scope
+
+- Persisted recent-file history and stable route IDs.
+- Persistent upload storage and cleanup.
+- Reader close or eviction APIs.
+- User authentication and authorization.
+
+## Verification checklist
+
+- [ ] A registry with a policy opens only the canonical path returned by that
+  policy.
+- [ ] A rejected policy prevents reader creation.
+- [ ] A registry without a policy continues to open native files as before.
+- [ ] SSR server-root restrictions remain enforced.
+- [ ] Future path restoration uses the registry and cannot bypass an installed
+  policy.

--- a/logmancer-core/src/config_store.rs
+++ b/logmancer-core/src/config_store.rs
@@ -1,0 +1,49 @@
+use crate::{NativeVisualRulesStore, VisualRulesStore};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+const VISUAL_RULES_FILE: &str = "visual-rules.json";
+
+#[derive(Clone)]
+pub struct ConfigStore {
+    directory: PathBuf,
+}
+
+impl ConfigStore {
+    pub fn new(directory: PathBuf) -> Self {
+        Self { directory }
+    }
+
+    pub fn prepare(&self) -> io::Result<()> {
+        std::fs::create_dir_all(&self.directory)
+    }
+
+    pub fn visual_rules(&self) -> Arc<dyn VisualRulesStore> {
+        Arc::new(NativeVisualRulesStore::new(
+            self.directory.join(VISUAL_RULES_FILE),
+        ))
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prepares_its_directory_and_owns_visual_rules_file_name() {
+        let directory =
+            std::env::temp_dir().join(format!("logmancer-config-store-{}", uuid::Uuid::new_v4()));
+        let store = ConfigStore::new(directory.clone());
+
+        store.prepare().unwrap();
+        store.visual_rules().save_new(b"{}").unwrap();
+
+        assert!(directory.join(VISUAL_RULES_FILE).is_file());
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/logmancer-core/src/lib.rs
+++ b/logmancer-core/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "native-persistence")]
+mod config_store;
 mod file_ops;
 mod handler;
 mod models;
@@ -10,6 +12,8 @@ mod visual_rules_manager;
 mod visual_rules_store;
 mod workers;
 
+#[cfg(feature = "native-persistence")]
+pub use config_store::ConfigStore;
 pub use models::file_info::FileInfo;
 pub use models::page_result::{PageLine, PageResult};
 pub use models::search::{PageSearchResult, SearchDisplayStatus, SearchMatch, SearchStatus};
@@ -18,7 +22,7 @@ pub use models::visual_rules::{
     ValidationSeverity, VisualColor, VisualMatcher, VisualRule, VisualRulesEnvelope,
 };
 pub use reader::LogReader;
-pub use registry::LogRegistry;
+pub use registry::{FileOpenPolicy, LogRegistry, LogRegistryBuilder};
 pub use visual_rules::VisualRuleEvaluator;
 pub use visual_rules_manager::{
     SaveOutcome, SaveResult, VisualRulesError, VisualRulesManager, VisualRulesState,

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -1,34 +1,83 @@
-use crate::{LogReader, VisualRulesManager};
+use crate::{
+    LogReader, SaveResult, VisualRulesEnvelope, VisualRulesError, VisualRulesManager,
+    VisualRulesState,
+};
 use dashmap::DashMap;
 use dashmap::mapref::one::RefMut;
 use std::io;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use uuid::Uuid;
+
+pub trait FileOpenPolicy: Send + Sync {
+    fn validate(&self, path: &Path) -> io::Result<PathBuf>;
+}
 
 pub struct LogRegistry {
     open_files: Arc<DashMap<Uuid, LogReader>>,
     visual_rules_manager: Arc<VisualRulesManager>,
+    file_open_policy: Option<Arc<dyn FileOpenPolicy>>,
+}
+
+pub struct LogRegistryBuilder {
+    #[cfg(feature = "native-persistence")]
+    config_store: Option<crate::ConfigStore>,
+    file_open_policy: Option<Arc<dyn FileOpenPolicy>>,
+}
+
+impl LogRegistryBuilder {
+    #[cfg(feature = "native-persistence")]
+    pub fn config_store(mut self, config_store: crate::ConfigStore) -> Self {
+        self.config_store = Some(config_store);
+        self
+    }
+
+    pub fn file_open_policy(mut self, file_open_policy: Arc<dyn FileOpenPolicy>) -> Self {
+        self.file_open_policy = Some(file_open_policy);
+        self
+    }
+
+    pub fn build(self) -> LogRegistry {
+        #[cfg(feature = "native-persistence")]
+        let visual_rules_manager = self
+            .config_store
+            .map(|config_store| VisualRulesManager::with_store(config_store.visual_rules()))
+            .unwrap_or_else(VisualRulesManager::in_memory);
+        #[cfg(not(feature = "native-persistence"))]
+        let visual_rules_manager = VisualRulesManager::in_memory();
+
+        LogRegistry {
+            open_files: Arc::new(DashMap::new()),
+            visual_rules_manager,
+            file_open_policy: self.file_open_policy,
+        }
+    }
 }
 
 impl LogRegistry {
-    pub fn new() -> Self {
-        LogRegistry {
-            open_files: Arc::new(DashMap::new()),
-            visual_rules_manager: VisualRulesManager::in_memory(),
+    pub fn builder() -> LogRegistryBuilder {
+        LogRegistryBuilder {
+            #[cfg(feature = "native-persistence")]
+            config_store: None,
+            file_open_policy: None,
         }
     }
 
-    pub fn with_manager(visual_rules_manager: Arc<VisualRulesManager>) -> Self {
-        Self {
-            open_files: Arc::new(DashMap::new()),
-            visual_rules_manager,
-        }
+    pub fn new() -> Self {
+        Self::builder().build()
     }
 
     /// Opens a new file and register with a UUID
     pub fn open_file(&self, path: &str) -> io::Result<String> {
         let uuid = Uuid::new_v4();
-        let reader = LogReader::with_manager(path.to_string(), self.visual_rules_manager.clone());
+        let path = match &self.file_open_policy {
+            Some(policy) => policy.validate(Path::new(path))?,
+            None => PathBuf::from(path),
+        };
+        let reader = LogReader::with_manager(
+            path.to_string_lossy().into_owned(),
+            self.visual_rules_manager.clone(),
+        );
         self.open_files.insert(uuid, reader?);
         Ok(uuid.to_string())
     }
@@ -41,10 +90,107 @@ impl LogRegistry {
             None
         }
     }
+
+    pub fn visual_rules_state(&self) -> VisualRulesState {
+        self.visual_rules_manager.state()
+    }
+
+    pub fn apply_visual_rules_memory(
+        &self,
+        envelope: VisualRulesEnvelope,
+    ) -> Result<SaveResult, VisualRulesError> {
+        self.visual_rules_manager.apply_memory(envelope)
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn reload_visual_rules(&self) -> Result<VisualRulesState, VisualRulesError> {
+        self.visual_rules_manager.load()
+    }
+
+    #[cfg(feature = "native-persistence")]
+    pub fn upsert_visual_rules(
+        &self,
+        base_revision: u64,
+        envelope: VisualRulesEnvelope,
+    ) -> Result<SaveResult, VisualRulesError> {
+        self.visual_rules_manager.upsert(base_revision, envelope)
+    }
 }
 
 impl Default for LogRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct RedirectPolicy {
+        path: PathBuf,
+    }
+
+    impl FileOpenPolicy for RedirectPolicy {
+        fn validate(&self, _path: &Path) -> io::Result<PathBuf> {
+            Ok(self.path.clone())
+        }
+    }
+
+    struct RejectPolicy;
+
+    impl FileOpenPolicy for RejectPolicy {
+        fn validate(&self, _path: &Path) -> io::Result<PathBuf> {
+            Err(io::Error::new(io::ErrorKind::PermissionDenied, "rejected"))
+        }
+    }
+
+    #[test]
+    fn policy_path_is_used_to_open_the_reader() {
+        let directory =
+            std::env::temp_dir().join(format!("logmancer-registry-policy-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let allowed_path = directory.join("allowed.log");
+        std::fs::write(&allowed_path, "ready\n").unwrap();
+        let registry = LogRegistry::builder()
+            .file_open_policy(Arc::new(RedirectPolicy {
+                path: allowed_path.clone(),
+            }))
+            .build();
+
+        let file_id = registry.open_file("untrusted.log").unwrap();
+        let file_info = registry.get_reader(&file_id).unwrap().file_info().unwrap();
+
+        assert_eq!(file_info.path, allowed_path.to_string_lossy());
+        drop(registry);
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejected_policy_prevents_reader_creation() {
+        let registry = LogRegistry::builder()
+            .file_open_policy(Arc::new(RejectPolicy))
+            .build();
+
+        let error = registry.open_file("blocked.log").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(feature = "native-persistence")]
+    #[test]
+    fn config_store_creates_the_registry_visual_rules_manager() {
+        let directory =
+            std::env::temp_dir().join(format!("logmancer-registry-config-{}", Uuid::new_v4()));
+        let store = crate::ConfigStore::new(directory.join("config"));
+        store.prepare().unwrap();
+        let registry = LogRegistry::builder().config_store(store).build();
+
+        registry
+            .upsert_visual_rules(0, VisualRulesEnvelope::new(Vec::new()))
+            .unwrap();
+
+        assert!(directory.join("config/visual-rules.json").is_file());
+        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/logmancer-core/tests/visual_rules_management.rs
+++ b/logmancer-core/tests/visual_rules_management.rs
@@ -172,13 +172,12 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
     writeln!(file, "WARN cache").expect("write");
     drop(file);
 
-    let manager = VisualRulesManager::in_memory();
-    let registry = LogRegistry::with_manager(manager.clone());
+    let registry = LogRegistry::new();
     let first_id = registry
         .open_file(path.to_str().expect("path"))
         .expect("open first");
-    manager
-        .apply_memory(VisualRulesEnvelope::new(vec![rule("ERROR")]))
+    registry
+        .apply_visual_rules_memory(VisualRulesEnvelope::new(vec![rule("ERROR")]))
         .expect("apply first snapshot");
 
     wait_for_indexed_lines(&registry, &first_id, 3);
@@ -201,8 +200,8 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
         Some(style(Some("red"), Some("default")))
     );
 
-    manager
-        .apply_memory(VisualRulesEnvelope::new(vec![rule("WARN")]))
+    registry
+        .apply_visual_rules_memory(VisualRulesEnvelope::new(vec![rule("WARN")]))
         .expect("swap snapshot");
     let second_id = registry
         .open_file(path.to_str().expect("path"))

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -15,8 +15,8 @@ use tracing::{info, warn};
 #[cfg(feature = "embedded-server")]
 use {
     logmancer_web::{
-        file_opening::enable_desktop_ssr_runtime, start_leptos_with_registry_and_manager,
-        try_open_initial_file, visual_rules_runtime,
+        file_opening::enable_desktop_ssr_runtime, registry_runtime, start_leptos_with_registry,
+        try_open_initial_file,
     },
     tauri::WindowEvent,
 };
@@ -40,12 +40,10 @@ impl DesktopState {
 }
 
 #[cfg(any(feature = "embedded-server", test))]
-fn visual_rules_store_path(config_dir: Option<PathBuf>) -> Result<PathBuf, String> {
+fn config_directory(config_dir: Option<PathBuf>) -> Result<PathBuf, String> {
     config_dir
-        .map(|directory| directory.join("visual-rules.json"))
-        .ok_or_else(|| {
-            "Could not resolve the Tauri app configuration directory for visual rules.".to_string()
-        })
+        .filter(|directory| !directory.as_os_str().is_empty())
+        .ok_or_else(|| "Could not resolve the Tauri app configuration directory.".to_string())
 }
 
 fn wait_for_tcp_server<A>(addr: A, attempts: u32, delay: Duration) -> bool
@@ -193,8 +191,8 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn visual_rules_path_resolution_failure_writes_nowhere() {
-        let error = visual_rules_store_path(None).unwrap_err();
+    fn config_directory_resolution_failure_writes_nowhere() {
+        let error = config_directory(None).unwrap_err();
 
         assert!(error.contains("app configuration directory"));
     }
@@ -360,9 +358,9 @@ pub fn run() {
         info!("Desktop runtime configured for embedded SSR rendering");
 
         let state = app.state::<DesktopState>();
-        let visual_rules_path = visual_rules_store_path(app.path().app_config_dir().ok())
-            .map_err(std::io::Error::other)?;
-        let (registry, visual_rules_manager) = visual_rules_runtime(visual_rules_path);
+        let config_directory =
+            config_directory(app.path().app_config_dir().ok()).map_err(std::io::Error::other)?;
+        let registry = registry_runtime(config_directory, None);
         *state.registry.write().expect("desktop registry lock") = registry.clone();
         let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
         let port = std::net::TcpListener::bind("127.0.0.1:0")
@@ -373,7 +371,7 @@ pub fn run() {
         info!("Spawning embedded SSR server on port={}", port);
         tauri::async_runtime::spawn(async move {
             info!("Embedded SSR server task started");
-            start_leptos_with_registry_and_manager(port, registry, visual_rules_manager).await
+            start_leptos_with_registry(port, registry).await
         });
         wait_for_embedded_server(port);
         let window = app.get_webview_window("main").unwrap();

--- a/logmancer-web/src/api/config.rs
+++ b/logmancer-web/src/api/config.rs
@@ -10,7 +10,7 @@ use crate::api::visual_rules::{get_visual_rules, retry_visual_rules, save_visual
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, post};
 use axum::Router;
-use logmancer_core::{LogRegistry, VisualRulesManager};
+use logmancer_core::LogRegistry;
 use std::sync::Arc;
 
 const LOG_UPLOAD_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
@@ -18,14 +18,10 @@ const LOG_UPLOAD_BODY_LIMIT_BYTES: usize = 512 * 1024 * 1024;
 #[derive(Clone)]
 pub struct AppState {
     pub registry: Arc<LogRegistry>,
-    pub visual_rules_manager: Arc<VisualRulesManager>,
     pub server_file_root: Option<ServerFileRoot>,
 }
 
-pub fn api_routes_with_registry_and_manager<T>(
-    registry: Arc<LogRegistry>,
-    visual_rules_manager: Arc<VisualRulesManager>,
-) -> Router<T> {
+pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
     let server_file_root = ServerFileRoot::from_env();
 
     Router::new()
@@ -49,13 +45,8 @@ pub fn api_routes_with_registry_and_manager<T>(
         .layer(DefaultBodyLimit::max(LOG_UPLOAD_BODY_LIMIT_BYTES))
         .with_state(AppState {
             registry,
-            visual_rules_manager,
             server_file_root,
         })
-}
-
-pub fn api_routes_with_registry<T>(registry: Arc<LogRegistry>) -> Router<T> {
-    api_routes_with_registry_and_manager(registry, VisualRulesManager::in_memory())
 }
 
 pub fn api_routes<T>() -> Router<T> {
@@ -67,20 +58,17 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::{Method, Request, StatusCode};
-    use logmancer_core::{NativeVisualRulesStore, VisualRulesEnvelope, VisualRulesManager};
+    use logmancer_core::{ConfigStore, VisualRulesEnvelope};
     use std::sync::Arc;
     use tower::ServiceExt;
 
     fn visual_rules_router() -> Router {
         let directory = tempfile::tempdir().unwrap().keep();
-        let manager = VisualRulesManager::with_store(Arc::new(NativeVisualRulesStore::new(
-            directory.join("visual-rules.json"),
-        )));
-        manager.load().unwrap();
-        api_routes_with_registry_and_manager(
-            Arc::new(LogRegistry::with_manager(manager.clone())),
-            manager,
-        )
+        let config_store = ConfigStore::new(directory);
+        config_store.prepare().unwrap();
+        let registry = Arc::new(LogRegistry::builder().config_store(config_store).build());
+        registry.reload_visual_rules().unwrap();
+        api_routes_with_registry(registry)
     }
 
     #[tokio::test]

--- a/logmancer-web/src/api/server_browser.rs
+++ b/logmancer-web/src/api/server_browser.rs
@@ -7,6 +7,8 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use logmancer_core::FileOpenPolicy;
+use std::io;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::time::UNIX_EPOCH;
@@ -14,6 +16,12 @@ use std::time::UNIX_EPOCH;
 #[derive(Clone)]
 pub struct ServerFileRoot {
     pub canonical_path: PathBuf,
+}
+
+#[derive(Clone)]
+pub struct SsrFileOpenPolicy {
+    server_file_root: ServerFileRoot,
+    temporary_directory: Option<PathBuf>,
 }
 
 impl ServerFileRoot {
@@ -30,6 +38,38 @@ impl ServerFileRoot {
         }
 
         Some(Self { canonical_path })
+    }
+}
+
+impl SsrFileOpenPolicy {
+    pub fn new(server_file_root: ServerFileRoot) -> Self {
+        Self {
+            server_file_root,
+            temporary_directory: std::env::temp_dir().canonicalize().ok(),
+        }
+    }
+}
+
+impl FileOpenPolicy for SsrFileOpenPolicy {
+    fn validate(&self, path: &Path) -> io::Result<PathBuf> {
+        let canonical_path = path.canonicalize()?;
+        if canonical_path.starts_with(&self.server_file_root.canonical_path)
+            || self
+                .temporary_directory
+                .as_deref()
+                .is_some_and(|directory| canonical_path.parent() == Some(directory))
+                && canonical_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("logmancer-upload-"))
+        {
+            Ok(canonical_path)
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "path is outside the configured server file root",
+            ))
+        }
     }
 }
 
@@ -303,6 +343,14 @@ mod tests {
         (dir, root)
     }
 
+    fn temporary_file_path(prefix: &str) -> PathBuf {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("{prefix}-{}-{timestamp}", std::process::id()))
+    }
+
     #[test]
     fn rejects_parent_traversal() {
         let (_dir, root) = mk_root();
@@ -343,6 +391,44 @@ mod tests {
         let result = resolve_root_bound_path(&root, &path.to_string_lossy());
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn file_open_policy_allows_server_files_and_managed_temporary_uploads() {
+        let (_dir, root) = mk_root();
+        let allowed = root.canonical_path.join("allowed.log");
+        std::fs::write(&allowed, "hello").unwrap();
+        let temporary_upload = temporary_file_path("logmancer-upload");
+        std::fs::write(&temporary_upload, "hello").unwrap();
+        let policy = SsrFileOpenPolicy::new(root);
+        let outside = tempfile::tempdir().unwrap();
+        let blocked = outside.path().join("blocked.log");
+        std::fs::write(&blocked, "hello").unwrap();
+
+        assert_eq!(policy.validate(&allowed).unwrap(), allowed);
+        assert_eq!(
+            policy.validate(&temporary_upload).unwrap(),
+            temporary_upload
+        );
+        assert_eq!(
+            policy.validate(&blocked).unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        std::fs::remove_file(temporary_upload).unwrap();
+    }
+
+    #[test]
+    fn file_open_policy_rejects_unmanaged_temporary_files() {
+        let (_dir, root) = mk_root();
+        let temporary_file = temporary_file_path("unmanaged");
+        std::fs::write(&temporary_file, "hello").unwrap();
+        let policy = SsrFileOpenPolicy::new(root);
+
+        assert_eq!(
+            policy.validate(&temporary_file).unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        std::fs::remove_file(temporary_file).unwrap();
     }
 
     #[test]

--- a/logmancer-web/src/api/visual_rules.rs
+++ b/logmancer-web/src/api/visual_rules.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use logmancer_core::{SaveOutcome, SaveResult, VisualRulesEnvelope, VisualRulesError};
 
 pub async fn get_visual_rules(State(app_state): State<AppState>) -> impl IntoResponse {
-    let state = app_state.visual_rules_manager.state();
+    let state = app_state.registry.visual_rules_state();
     (
         StatusCode::OK,
         Json(VisualRulesResponse {
@@ -28,8 +28,8 @@ pub async fn save_visual_rules(
 ) -> Response {
     let envelope = request.envelope.clone();
     match app_state
-        .visual_rules_manager
-        .upsert(request.base_revision, request.envelope)
+        .registry
+        .upsert_visual_rules(request.base_revision, request.envelope)
     {
         Ok(result) => {
             (StatusCode::OK, Json(visual_rules_success(result, envelope))).into_response()
@@ -39,7 +39,7 @@ pub async fn save_visual_rules(
 }
 
 pub async fn retry_visual_rules(State(app_state): State<AppState>) -> Response {
-    match app_state.visual_rules_manager.load() {
+    match app_state.registry.reload_visual_rules() {
         Ok(state) => (
             StatusCode::OK,
             Json(VisualRulesResponse {

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -8,63 +8,60 @@ pub mod file_opening;
 mod visual_rules_state;
 
 #[cfg(feature = "ssr")]
-pub fn visual_rules_path_from_env() -> std::path::PathBuf {
-    visual_rules_path(
+pub fn config_directory_from_env() -> std::path::PathBuf {
+    config_directory(
         std::env::var_os("LOGMANCER_CONFIG_DIR").map(std::path::PathBuf::from),
         std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
     )
 }
 
 #[cfg(feature = "ssr")]
-fn visual_rules_path(
+fn config_directory(
     config_dir: Option<std::path::PathBuf>,
     working_dir: std::path::PathBuf,
 ) -> std::path::PathBuf {
-    let base = config_dir
+    config_dir
         .filter(|value| !value.as_os_str().is_empty())
-        .unwrap_or_else(|| working_dir.join("config"));
-    base.join("visual-rules.json")
+        .unwrap_or_else(|| working_dir.join("config"))
 }
 
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
-    use super::{visual_rules_path, visual_rules_runtime, visual_rules_runtime_with_initial_file};
+    use super::{config_directory, registry_runtime, try_open_initial_file};
     use logmancer_core::{
         LineStyleIntent, ManagedVisualRule, VisualColor, VisualMatcher, VisualRulesEnvelope,
     };
     use std::path::PathBuf;
 
     #[test]
-    fn config_directory_takes_precedence_over_default_visual_rules_location() {
-        let path = visual_rules_path(
+    fn config_directory_takes_precedence_over_default_location() {
+        let path = config_directory(
             Some(PathBuf::from("/temporary/config")),
             PathBuf::from("/working-directory"),
         );
 
-        assert_eq!(path, PathBuf::from("/temporary/config/visual-rules.json"));
+        assert_eq!(path, PathBuf::from("/temporary/config"));
     }
 
     #[test]
     fn missing_config_directory_uses_the_working_directory_default() {
-        let path = visual_rules_path(None, PathBuf::from("/working-directory"));
+        let path = config_directory(None, PathBuf::from("/working-directory"));
 
-        assert_eq!(
-            path,
-            PathBuf::from("/working-directory/config/visual-rules.json")
-        );
+        assert_eq!(path, PathBuf::from("/working-directory/config"));
     }
 
     #[test]
     fn visual_rules_runtime_creates_parent_and_shares_persisted_rules_with_readers() {
         let directory = tempfile::tempdir().unwrap();
-        let store_path = directory.path().join("config/visual-rules.json");
+        let config_directory = directory.path().join("config");
+        let store_path = config_directory.join("visual-rules.json");
         let log_path = directory.path().join("application.log");
         std::fs::write(&log_path, "ERROR disk\n").unwrap();
 
-        let (registry, manager) = visual_rules_runtime(store_path.clone());
-        let revision = manager.state().revision;
-        manager
-            .save(
+        let registry = registry_runtime(config_directory, None);
+        let revision = registry.visual_rules_state().revision;
+        registry
+            .upsert_visual_rules(
                 revision,
                 VisualRulesEnvelope::new(vec![ManagedVisualRule {
                     name: None,
@@ -101,11 +98,13 @@ mod tests {
     #[test]
     fn visual_rules_runtime_survives_load_failure_without_claiming_save_success() {
         let directory = tempfile::tempdir().unwrap();
-        let (_, manager) = visual_rules_runtime(directory.path().to_path_buf());
+        let blocked_config_directory = directory.path().join("not-a-directory");
+        std::fs::write(&blocked_config_directory, "blocked").unwrap();
+        let registry = registry_runtime(blocked_config_directory, None);
 
-        assert!(manager
-            .save(
-                manager.state().revision,
+        assert!(registry
+            .upsert_visual_rules(
+                registry.visual_rules_state().revision,
                 VisualRulesEnvelope::new(Vec::new())
             )
             .is_err());
@@ -117,57 +116,35 @@ mod tests {
         let log_path = directory.path().join("initial.log");
         std::fs::write(&log_path, "INFO ready\n").unwrap();
 
-        let (registry, _, file_id) = visual_rules_runtime_with_initial_file(
-            directory.path().join("config/visual-rules.json"),
-            log_path.to_str(),
-        );
+        let registry = registry_runtime(directory.path().join("config"), None);
+        let file_id = try_open_initial_file(&registry, log_path.to_str());
 
         assert!(registry.get_reader(&file_id.unwrap()).is_some());
     }
 }
 
 #[cfg(feature = "ssr")]
-pub fn visual_rules_runtime(
-    path: std::path::PathBuf,
-) -> (
-    std::sync::Arc<logmancer_core::LogRegistry>,
-    std::sync::Arc<logmancer_core::VisualRulesManager>,
-) {
-    use logmancer_core::{LogRegistry, NativeVisualRulesStore, VisualRulesManager};
+pub fn registry_runtime(
+    config_directory: std::path::PathBuf,
+    file_open_policy: Option<std::sync::Arc<dyn logmancer_core::FileOpenPolicy>>,
+) -> std::sync::Arc<logmancer_core::LogRegistry> {
+    use logmancer_core::{ConfigStore, LogRegistry};
     use std::sync::Arc;
     use tracing::warn;
 
-    if let Some(parent) = path
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-    {
-        if let Err(error) = std::fs::create_dir_all(parent) {
-            warn!(path = %parent.display(), %error, "Could not create visual rules directory");
-        }
+    let config_store = ConfigStore::new(config_directory);
+    if let Err(error) = config_store.prepare() {
+        warn!(path = %config_store.directory().display(), %error, "Could not prepare configuration directory");
     }
-    let manager =
-        VisualRulesManager::with_store(Arc::new(NativeVisualRulesStore::new(path.clone())));
-    if let Err(error) = manager.load() {
-        warn!(path = %path.display(), %error, "Could not load optional visual rules configuration");
+    let mut builder = LogRegistry::builder().config_store(config_store);
+    if let Some(file_open_policy) = file_open_policy {
+        builder = builder.file_open_policy(file_open_policy);
     }
-    (
-        Arc::new(LogRegistry::with_manager(manager.clone())),
-        manager,
-    )
-}
-
-#[cfg(feature = "ssr")]
-fn visual_rules_runtime_with_initial_file(
-    path: std::path::PathBuf,
-    initial_path: Option<&str>,
-) -> (
-    std::sync::Arc<logmancer_core::LogRegistry>,
-    std::sync::Arc<logmancer_core::VisualRulesManager>,
-    Option<String>,
-) {
-    let (registry, manager) = visual_rules_runtime(path);
-    let file_id = try_open_initial_file(&registry, initial_path);
-    (registry, manager, file_id)
+    let registry = Arc::new(builder.build());
+    if let Err(error) = registry.reload_visual_rules() {
+        warn!(%error, "Could not load optional visual rules configuration");
+    }
+    registry
 }
 
 #[cfg(feature = "hydrate")]
@@ -180,32 +157,34 @@ pub fn hydrate() {
 
 #[cfg(feature = "ssr")]
 pub async fn start_leptos(port: u16) {
-    let (registry, manager) = visual_rules_runtime(visual_rules_path_from_env());
-    start_leptos_with_registry_and_manager(port, registry, manager).await;
+    use crate::api::server_browser::{ServerFileRoot, SsrFileOpenPolicy};
+    use logmancer_core::FileOpenPolicy;
+    use std::sync::Arc;
+
+    let file_open_policy = ServerFileRoot::from_env()
+        .map(|root| Arc::new(SsrFileOpenPolicy::new(root)) as Arc<dyn FileOpenPolicy>);
+    let registry = registry_runtime(config_directory_from_env(), file_open_policy);
+    let initial_path = std::env::args()
+        .nth(1)
+        .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
+    let _ = try_open_initial_file(&registry, initial_path.as_deref());
+    start_leptos_with_registry(port, registry).await;
 }
 
 #[cfg(feature = "ssr")]
 pub async fn start_leptos_with_registry(
     port: u16,
-    _registry: std::sync::Arc<logmancer_core::LogRegistry>,
+    registry: std::sync::Arc<logmancer_core::LogRegistry>,
 ) {
-    let initial_path = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
-    let (registry, manager, _) = visual_rules_runtime_with_initial_file(
-        visual_rules_path_from_env(),
-        initial_path.as_deref(),
-    );
-    start_leptos_with_registry_and_manager(port, registry, manager).await;
+    start_leptos_with_registry_inner(port, registry).await;
 }
 
 #[cfg(feature = "ssr")]
-pub async fn start_leptos_with_registry_and_manager(
+async fn start_leptos_with_registry_inner(
     port: u16,
     registry: std::sync::Arc<logmancer_core::LogRegistry>,
-    visual_rules_manager: std::sync::Arc<logmancer_core::VisualRulesManager>,
 ) {
-    use crate::api::config::api_routes_with_registry_and_manager;
+    use crate::api::config::api_routes_with_registry;
     use crate::app::shell;
     use crate::components::App;
     use axum::Router;
@@ -228,10 +207,7 @@ pub async fn start_leptos_with_registry_and_manager(
     let routes = generate_route_list(App);
 
     let app = Router::new()
-        .nest(
-            "/api",
-            api_routes_with_registry_and_manager(registry.clone(), visual_rules_manager),
-        )
+        .nest("/api", api_routes_with_registry(registry.clone()))
         .leptos_routes(&leptos_options, routes, {
             let leptos_options = leptos_options.clone();
             move || shell(leptos_options.clone())
@@ -250,7 +226,7 @@ pub async fn start_leptos_with_registry_and_manager(
 
 #[cfg(feature = "ssr")]
 pub async fn start_axum(port: u16) {
-    use crate::api::config::api_routes_with_registry_and_manager;
+    use crate::api::config::api_routes_with_registry;
     use std::net::SocketAddr;
     use tracing::info;
 
@@ -263,8 +239,14 @@ pub async fn start_axum(port: u16) {
     info!("Starting API server on http://{}", &addr);
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     axum::serve(listener, {
-        let (registry, manager) = visual_rules_runtime(visual_rules_path_from_env());
-        api_routes_with_registry_and_manager(registry, manager).into_make_service()
+        use crate::api::server_browser::{ServerFileRoot, SsrFileOpenPolicy};
+        use logmancer_core::FileOpenPolicy;
+        use std::sync::Arc;
+
+        let file_open_policy = ServerFileRoot::from_env()
+            .map(|root| Arc::new(SsrFileOpenPolicy::new(root)) as Arc<dyn FileOpenPolicy>);
+        let registry = registry_runtime(config_directory_from_env(), file_open_policy);
+        api_routes_with_registry(registry).into_make_service()
     })
     .await
     .unwrap();

--- a/logmancer-web/src/main.rs
+++ b/logmancer-web/src/main.rs
@@ -4,35 +4,21 @@
 #[tokio::main]
 async fn main() {
     use leptos::prelude::*;
-    use logmancer_core::LogRegistry;
     use logmancer_web::init_backend_logging;
-    use logmancer_web::start_leptos_with_registry;
-    use logmancer_web::try_open_initial_file;
-    use std::sync::Arc;
+    use logmancer_web::start_leptos;
     use tracing::info;
 
     init_backend_logging();
 
     let conf = get_configuration(None).unwrap();
     let addr = conf.leptos_options.site_addr;
-    let registry = Arc::new(LogRegistry::new());
-    let initial_path = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
-    let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
-    let startup_url = match initial_file_id.as_deref() {
-        Some(file_id) => format!("http://{addr}/log/{file_id}"),
-        None => format!("http://{addr}"),
-    };
-
     info!(
         "Launching logmancer-web SSR on {} with LEPTOS_SITE_ROOT={:?} LEPTOS_OUTPUT_NAME={:?}",
         addr,
         std::env::var("LEPTOS_SITE_ROOT").ok(),
         std::env::var("LEPTOS_OUTPUT_NAME").ok()
     );
-    info!("Initial navigation URL: {}", startup_url);
-    start_leptos_with_registry(addr.port(), registry).await;
+    start_leptos(addr.port()).await;
 }
 
 #[cfg(not(feature = "ssr"))]


### PR DESCRIPTION
Closes #86

## PR Type
- [x] New feature

## Summary
- Centralizes persisted visual-rules configuration behind core ConfigStore and registry-owned operations.
- Adds registry-wide FileOpenPolicy enforcement with SSR root validation and the narrowly scoped temporary upload exception.
- Adds and accepts ADRs 0004 and 0005.

## Changes
| Area | Change |
|---|---|
| logmancer-core | Adds ConfigStore, LogRegistryBuilder, semantic visual-rules methods, and FileOpenPolicy. |
| logmancer-web | Removes parallel manager wiring and installs SSR authorization policy. |
| logmancer-desktop | Passes only the platform configuration directory to the shared runtime. |
| docs/adr | Documents the accepted ownership and authorization decisions. |

## Size Exception
This PR changes 681 lines. ConfigStore ownership and FileOpenPolicy enforcement cross core, web, desktop, tests, and ADRs; splitting them would leave an intermediate branch with either duplicated manager ownership or an uninstalled security boundary.

## Verification
- [x] cargo fmt
- [x] cargo check -p logmancer-web --features ssr --tests
- [x] cargo test -p logmancer-core --features native-persistence
- [x] cargo clippy --workspace -- -D warnings
- [x] git diff --check
- [ ] cargo test --workspace exceeded the ten-minute Tauri/Leptos test-link window without reporting a test failure.

## Runtime Check
N/A: this change is infrastructure wiring; targeted core tests exercise persistence construction and policy acceptance/rejection.

## Rollback
Revert c540b18 to remove ConfigStore, registry policy enforcement, runtime wiring, and both ADRs as one unit.

## Checklist
- [x] Linked an approved issue.
- [x] Docs updated.
- [x] Conventional commit format used.
- [x] No Co-Authored-By trailers.