### PR TITLE
feat(web): allow configurable server binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added
+
+- The standalone web server can be deliberately exposed on a configured interface and port through `LOGMANCER_BIND_ADDR`; desktop remains loopback-only.
+
 ## [0.4.0] - 2026-08-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ Run the development web server with Leptos:
 cargo leptos watch --project logmancer-web
 ```
 
+The web server listens on `127.0.0.1:3000` by default. To intentionally expose it on another interface or port, set `LOGMANCER_BIND_ADDR` to a full socket address:
+
+```sh
+LOGMANCER_BIND_ADDR=0.0.0.0:8080 cargo leptos watch --project logmancer-web
+```
+
+This setting applies only to the standalone web server. Desktop always uses loopback; its embedded server selects a loopback port automatically and its development mode connects to `localhost:3000`. When exposing the web server, set `LOGMANCER_SERVER_FILE_ROOT` to limit the server-side files it can open.
+
 ### logmancer-desktop
 
 Launch the desktop app using Tauri:
@@ -125,7 +133,10 @@ cargo tauri dev
 
 ## Configuration
 
-No additional configuration is required at this time. Future modules may introduce config files or environment variables.
+No additional configuration is required. The web server supports these optional environment variables:
+
+* `LOGMANCER_BIND_ADDR`: Full bind address for the standalone web server, such as `0.0.0.0:8080`. Defaults to `127.0.0.1:3000`.
+* `LOGMANCER_SERVER_FILE_ROOT`: Directory containing files that the web server may open.
 
 ---
 

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -1,6 +1,8 @@
 #![recursion_limit = "256"]
 
 use logmancer_core::LogRegistry;
+#[cfg(any(feature = "embedded-server", test))]
+use std::net::SocketAddr;
 use std::net::{TcpStream, ToSocketAddrs};
 #[cfg(any(feature = "embedded-server", test))]
 use std::path::{Path, PathBuf};
@@ -58,6 +60,11 @@ where
     }
 
     false
+}
+
+#[cfg(any(feature = "embedded-server", test))]
+fn embedded_server_bind_addr() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], 0))
 }
 
 #[cfg(not(feature = "embedded-server"))]
@@ -283,6 +290,11 @@ mod tests {
     }
 
     #[test]
+    fn embedded_server_bind_address_is_always_loopback() {
+        assert_eq!(embedded_server_bind_addr(), "127.0.0.1:0".parse().unwrap());
+    }
+
+    #[test]
     fn default_capability_keeps_native_open_inside_tauri_boundary() {
         let capability = include_str!("../capabilities/default.json");
 
@@ -363,15 +375,15 @@ pub fn run() {
         let registry = registry_runtime(config_directory, None);
         *state.registry.write().expect("desktop registry lock") = registry.clone();
         let initial_file_id = try_open_initial_file(&registry, initial_path.as_deref());
-        let port = std::net::TcpListener::bind("127.0.0.1:0")
+        let addr = std::net::TcpListener::bind(embedded_server_bind_addr())
             .expect("Could not open a socket")
             .local_addr()
-            .expect("The address could not be obtained")
-            .port();
+            .expect("The address could not be obtained");
+        let port = addr.port();
         info!("Spawning embedded SSR server on port={}", port);
         tauri::async_runtime::spawn(async move {
             info!("Embedded SSR server task started");
-            start_leptos_with_registry(port, registry).await
+            start_leptos_with_registry(addr, registry).await
         });
         wait_for_embedded_server(port);
         let window = app.get_webview_window("main").unwrap();

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -16,6 +16,30 @@ pub fn config_directory_from_env() -> std::path::PathBuf {
 }
 
 #[cfg(feature = "ssr")]
+pub fn web_bind_addr(default_port: u16) -> Result<std::net::SocketAddr, String> {
+    resolve_bind_addr(
+        std::env::var("LOGMANCER_BIND_ADDR").ok().as_deref(),
+        default_port,
+    )
+}
+
+#[cfg(feature = "ssr")]
+fn resolve_bind_addr(
+    configured_addr: Option<&str>,
+    default_port: u16,
+) -> Result<std::net::SocketAddr, String> {
+    match configured_addr
+        .map(str::trim)
+        .filter(|addr| !addr.is_empty())
+    {
+        Some(addr) => addr.parse().map_err(|error| {
+            format!("LOGMANCER_BIND_ADDR must be a socket address such as 0.0.0.0:3000: {error}")
+        }),
+        None => Ok(std::net::SocketAddr::from(([127, 0, 0, 1], default_port))),
+    }
+}
+
+#[cfg(feature = "ssr")]
 fn config_directory(
     config_dir: Option<std::path::PathBuf>,
     working_dir: std::path::PathBuf,
@@ -27,7 +51,7 @@ fn config_directory(
 
 #[cfg(all(test, feature = "ssr"))]
 mod tests {
-    use super::{config_directory, registry_runtime, try_open_initial_file};
+    use super::{config_directory, registry_runtime, resolve_bind_addr, try_open_initial_file};
     use logmancer_core::{
         LineStyleIntent, ManagedVisualRule, VisualColor, VisualMatcher, VisualRulesEnvelope,
     };
@@ -48,6 +72,27 @@ mod tests {
         let path = config_directory(None, PathBuf::from("/working-directory"));
 
         assert_eq!(path, PathBuf::from("/working-directory/config"));
+    }
+
+    #[test]
+    fn missing_bind_address_uses_loopback_with_the_configured_port() {
+        let addr = resolve_bind_addr(None, 43123).unwrap();
+
+        assert_eq!(addr, "127.0.0.1:43123".parse().unwrap());
+    }
+
+    #[test]
+    fn configured_bind_address_overrides_interface_and_port() {
+        let addr = resolve_bind_addr(Some("0.0.0.0:8080"), 3000).unwrap();
+
+        assert_eq!(addr, "0.0.0.0:8080".parse().unwrap());
+    }
+
+    #[test]
+    fn invalid_bind_address_returns_configuration_error() {
+        let error = resolve_bind_addr(Some("not-an-address"), 3000).unwrap_err();
+
+        assert!(error.contains("LOGMANCER_BIND_ADDR"));
     }
 
     #[test]
@@ -156,7 +201,7 @@ pub fn hydrate() {
 }
 
 #[cfg(feature = "ssr")]
-pub async fn start_leptos(port: u16) {
+pub async fn start_leptos(addr: std::net::SocketAddr) {
     use crate::api::server_browser::{ServerFileRoot, SsrFileOpenPolicy};
     use logmancer_core::FileOpenPolicy;
     use std::sync::Arc;
@@ -168,20 +213,20 @@ pub async fn start_leptos(port: u16) {
         .nth(1)
         .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
     let _ = try_open_initial_file(&registry, initial_path.as_deref());
-    start_leptos_with_registry(port, registry).await;
+    start_leptos_with_registry(addr, registry).await;
 }
 
 #[cfg(feature = "ssr")]
 pub async fn start_leptos_with_registry(
-    port: u16,
+    addr: std::net::SocketAddr,
     registry: std::sync::Arc<logmancer_core::LogRegistry>,
 ) {
-    start_leptos_with_registry_inner(port, registry).await;
+    start_leptos_with_registry_inner(addr, registry).await;
 }
 
 #[cfg(feature = "ssr")]
 async fn start_leptos_with_registry_inner(
-    port: u16,
+    addr: std::net::SocketAddr,
     registry: std::sync::Arc<logmancer_core::LogRegistry>,
 ) {
     use crate::api::config::api_routes_with_registry;
@@ -190,13 +235,11 @@ async fn start_leptos_with_registry_inner(
     use axum::Router;
     use leptos::prelude::*;
     use leptos_axum::{generate_route_list, LeptosRoutes};
-    use std::net::SocketAddr;
     use tracing::info;
 
     init_backend_logging();
 
     let conf = get_configuration(None).unwrap();
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let leptos_options = conf.leptos_options;
     info!(
         "Resolved Leptos runtime config LEPTOS_SITE_ROOT={:?} LEPTOS_OUTPUT_NAME={:?}",
@@ -227,12 +270,11 @@ async fn start_leptos_with_registry_inner(
 #[cfg(feature = "ssr")]
 pub async fn start_axum(port: u16) {
     use crate::api::config::api_routes_with_registry;
-    use std::net::SocketAddr;
     use tracing::info;
 
     init_backend_logging();
-
-    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = web_bind_addr(port)
+        .unwrap_or_else(|error| panic!("Invalid web server configuration: {error}"));
 
     // run our app with hyper
     // `axum::Server` is a re-export of `hyper::Server`

--- a/logmancer-web/src/main.rs
+++ b/logmancer-web/src/main.rs
@@ -5,20 +5,21 @@
 async fn main() {
     use leptos::prelude::*;
     use logmancer_web::init_backend_logging;
-    use logmancer_web::start_leptos;
+    use logmancer_web::{start_leptos, web_bind_addr};
     use tracing::info;
 
     init_backend_logging();
 
     let conf = get_configuration(None).unwrap();
-    let addr = conf.leptos_options.site_addr;
+    let addr = web_bind_addr(conf.leptos_options.site_addr.port())
+        .unwrap_or_else(|error| panic!("Invalid web server configuration: {error}"));
     info!(
         "Launching logmancer-web SSR on {} with LEPTOS_SITE_ROOT={:?} LEPTOS_OUTPUT_NAME={:?}",
         addr,
         std::env::var("LEPTOS_SITE_ROOT").ok(),
         std::env::var("LEPTOS_OUTPUT_NAME").ok()
     );
-    start_leptos(addr.port()).await;
+    start_leptos(addr).await;
 }
 
 #[cfg(not(feature = "ssr"))]

--- a/packaging/portable/linux/run-web.sh
+++ b/packaging/portable/linux/run-web.sh
@@ -5,6 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 export LEPTOS_OUTPUT_NAME=logmancer-web
 export LEPTOS_SITE_ROOT="$SCRIPT_DIR/site"
+# Restricts server-side file browsing to the user's home directory; prefer a narrower directory when possible.
+# export LOGMANCER_SERVER_FILE_ROOT=~/
+# Exposes the standalone web server on all network interfaces at port 3000.
+# export LOGMANCER_BIND_ADDR=0.0.0.0:3000
 mkdir -p "$SCRIPT_DIR/logs"
 export LOGMANCER_LOG_FILE="$SCRIPT_DIR/logs/logmancer-web.log"
 

--- a/packaging/portable/windows/run-web.cmd
+++ b/packaging/portable/windows/run-web.cmd
@@ -1,6 +1,10 @@
 @echo off
 set LEPTOS_OUTPUT_NAME=logmancer-web
 set LEPTOS_SITE_ROOT=%~dp0site
+rem Restricts server-side file browsing to the user's home directory; prefer a narrower directory when possible.
+rem set "LOGMANCER_SERVER_FILE_ROOT=%USERPROFILE%"
+rem Exposes the standalone web server on all network interfaces at port 3000.
+rem set "LOGMANCER_BIND_ADDR=0.0.0.0:3000"
 if not exist "%~dp0logs" mkdir "%~dp0logs"
 set LOGMANCER_LOG_FILE=%~dp0logs\logmancer-web.log
 "%~dp0logmancer-web.exe" %*


### PR DESCRIPTION
Closes #88

## Summary
- Add an opt-in `LOGMANCER_BIND_ADDR` for standalone Web interface and port configuration.
- Preserve loopback-only Desktop embedded and external-development modes.
- Document the setting and add commented portable launcher examples.

## Changes
| File | Change |
|---|---|
| `logmancer-web/src/lib.rs` | Resolve the bind address and pass it through SSR startup. |
| `logmancer-web/src/main.rs` | Apply standalone Web configuration at startup. |
| `logmancer-desktop/src/lib.rs` | Enforce loopback for the embedded server. |
| `packaging/portable/*/run-web.*` | Add commented opt-in environment examples. |
| `README.md`, `CHANGELOG.md` | Document configuration and Unreleased behavior. |

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo test -p logmancer-web --features ssr --lib`
- [x] `cargo test -p logmancer-desktop --features embedded-server --lib`
- [x] `cargo check -p logmancer-web --features ssr --bin logmancer-web`
- [x] `bash -n packaging/portable/linux/run-web.sh`
- [ ] `shellcheck packaging/portable/linux/run-web.sh` (unavailable: `shellcheck` is not installed in this environment)