### PR TITLE
feat(registry): persist recent file routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 
+- Desktop and SSR server-root log routes now restore the 10 most recently opened files across restarts.
 - Core visual rules foundation with UI-neutral rule models, text/regex matching, array-order priority, per-rule case sensitivity, safe invalid-rule handling, and optional line style metadata for foreground/background colors (#63, #64, #65, #66).
 - The shared web viewer used by browser and desktop shells now renders safe whole-line visual-rule foreground/background styles, with an opt-in debug fixture for end-to-end development testing (#68).
 - Web and desktop visual-rules management now loads and saves one revision-checked global configuration through the shared core persistence manager.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "uuid",
  "windows-sys 0.61.2",
 ]

--- a/docs/adr/0006-persisted-recent-files.md
+++ b/docs/adr/0006-persisted-recent-files.md
@@ -1,0 +1,96 @@
+# ADR 0006: Persisted recent files
+
+## Status
+
+Accepted
+
+## Decision
+
+`LogRegistry` owns persisted recent-file history through an internal
+`RecentFilesManager` created from `ConfigStore`.
+
+The history preserves stable route IDs for the ten most recently opened native
+desktop or SSR server-root files. An unavailable or unauthorized persisted
+route resolves as not found; the web client returns to the home route.
+
+## Context
+
+`LogRegistry` currently maps generated UUIDs to readers in memory. Restarting
+the process loses that mapping, so a previously valid `/log/<id>` route cannot
+be reopened.
+
+ADR 0004 assigns configuration document naming and persistence infrastructure
+to core through `ConfigStore`. ADR 0005 makes `LogRegistry` the final file-open
+authorization boundary through `FileOpenPolicy`.
+
+Recent-file restoration must use both decisions: core owns the document and
+registry owns the authorization check before recreating a reader.
+
+## Decisions
+
+| Area | Decision |
+|---|---|
+| Ownership | `LogRegistry` owns one `RecentFilesManager`, alongside its internal visual-rules manager. |
+| Configuration | `ConfigStore` owns the private `recent-files.json` document name. Web SSR and desktop supply only their configuration directory. |
+| Stored record | Each entry contains a stable UUID, a canonical absolute path, and its last-opened timestamp. |
+| Capacity | History retains at most 10 entries, ordered by most recent opening. |
+| Deduplication | The canonical full path is the identity. Reopening it reuses its UUID and moves it to the front. Basenames are never matched. |
+| Cache and durability | History loads once at registry construction and is kept in memory. Each mutation is merged and atomically persisted under a file lock. |
+| Normal opening | Persistent opening validates and canonicalizes the path, reuses an existing history UUID when present, otherwise creates a new UUID and records it after the reader opens. |
+| Restoration | `get_reader(id)` first checks open readers. If absent, it resolves the ID in history and recreates the reader with that same UUID. |
+| Authorization | Every recreated reader passes through `FileOpenPolicy`; SSR restoration therefore cannot bypass the active `LOGMANCER_SERVER_FILE_ROOT`. |
+| Uploads | Browser uploads are ephemeral: they create an in-memory reader but never enter history. |
+| Missing records | Missing, unreadable, moved, or unauthorized paths result in not found. `LogView` redirects to `/` only for that response. |
+| Startup files | Desktop positional command-line files are persistent openings. The future TUI follows the same rule. `LOGMANCER_INITIAL_FILE` and SSR initial-file startup are removed. |
+| User interface | This change adds no recent-files UI. |
+
+## Persistence model
+
+The document is readable JSON with a versioned envelope:
+
+```json
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "id": "0cc4fad3-e0a0-440a-a857-5b809c1af57a",
+      "path": "/var/log/application.log",
+      "openedAt": "2026-08-26T12:00:00Z"
+    }
+  ]
+}
+```
+
+The document records paths, not file content or file identity. Replacing a
+file at the same path opens its current contents. Moving a configuration
+directory to another machine can leave entries invalid; those entries are
+treated as not found.
+
+## Consequences
+
+- Direct log routes survive application restart when their file remains valid.
+- Desktop and SSR histories remain separate because their configuration
+  directories are separate.
+- TUI can use the same registry behavior without duplicating persistence or
+  restoration logic.
+- The configuration file contains filesystem paths and must remain in the
+  private, ignored configuration directory.
+- Concurrent processes do not silently overwrite each other's history updates.
+
+## Out of scope
+
+- A UI for viewing, selecting, or clearing recent files.
+- Persistent browser uploads or upload cleanup.
+- Detecting that a file at a stable path was replaced.
+- Cross-machine path portability.
+
+## Verification checklist
+
+- [ ] Opening a new persistent file creates a record with a canonical path and UUID.
+- [ ] Reopening the same canonical path reuses its UUID and updates its recency.
+- [ ] The eleventh entry removes the least recently opened entry.
+- [ ] Restart restoration recreates a reader with the persisted UUID.
+- [ ] SSR restoration rejects paths outside the configured server root.
+- [ ] Uploads never appear in `recent-files.json`.
+- [ ] A missing or rejected route redirects the web client to `/`.
+- [ ] Desktop positional startup records and opens its file; SSR does not use `LOGMANCER_INITIAL_FILE`.

--- a/docs/adr/0006-persisted-recent-files.md
+++ b/docs/adr/0006-persisted-recent-files.md
@@ -36,6 +36,7 @@ registry owns the authorization check before recreating a reader.
 | Capacity | History retains at most 10 entries, ordered by most recent opening. |
 | Deduplication | The canonical full path is the identity. Reopening it reuses its UUID and moves it to the front. Basenames are never matched. |
 | Cache and durability | History loads once at registry construction and is kept in memory. Each mutation is merged and atomically persisted under a file lock. |
+| Corrupt history | Invalid JSON is copied to a timestamped `.corrupt.json` backup, replaced with an empty valid history, and reported through the application log. |
 | Normal opening | Persistent opening validates and canonicalizes the path, reuses an existing history UUID when present, otherwise creates a new UUID and records it after the reader opens. |
 | Restoration | `get_reader(id)` first checks open readers. If absent, it resolves the ID in history and recreates the reader with that same UUID. |
 | Authorization | Every recreated reader passes through `FileOpenPolicy`; SSR restoration therefore cannot bypass the active `LOGMANCER_SERVER_FILE_ROOT`. |

--- a/logmancer-core/Cargo.toml
+++ b/logmancer-core/Cargo.toml
@@ -19,5 +19,8 @@ sha2 = { version = "0.10.9", optional = true }
 wasm = ["uuid/js"]
 native-persistence = ["dep:atomic-write-file", "dep:serde_json", "dep:sha2", "dep:windows-sys"]
 
+[dev-dependencies]
+tempfile = "3"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"], optional = true }

--- a/logmancer-core/src/config_lock.rs
+++ b/logmancer-core/src/config_lock.rs
@@ -1,0 +1,29 @@
+use std::fs::OpenOptions;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+static COMMIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+pub fn with_config_file_lock<T>(
+    path: &Path,
+    operation: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    let _commit = COMMIT_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| io::Error::other("configuration commit lock poisoned"))?;
+    let mut lock_path = path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(PathBuf::from(lock_path))?;
+    lock_file.lock()?;
+    match (operation(), lock_file.unlock()) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), _) | (_, Err(error)) => Err(error),
+    }
+}

--- a/logmancer-core/src/config_store.rs
+++ b/logmancer-core/src/config_store.rs
@@ -1,9 +1,11 @@
+use crate::recent_files::RecentFilesManager;
 use crate::{NativeVisualRulesStore, VisualRulesStore};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 const VISUAL_RULES_FILE: &str = "visual-rules.json";
+const RECENT_FILES_FILE: &str = "recent-files.json";
 
 #[derive(Clone)]
 pub struct ConfigStore {
@@ -23,6 +25,10 @@ impl ConfigStore {
         Arc::new(NativeVisualRulesStore::new(
             self.directory.join(VISUAL_RULES_FILE),
         ))
+    }
+
+    pub fn recent_files(&self) -> io::Result<RecentFilesManager> {
+        RecentFilesManager::load(self.directory.join(RECENT_FILES_FILE))
     }
 
     pub fn directory(&self) -> &Path {

--- a/logmancer-core/src/lib.rs
+++ b/logmancer-core/src/lib.rs
@@ -4,6 +4,8 @@ mod file_ops;
 mod handler;
 mod models;
 mod reader;
+#[cfg(feature = "native-persistence")]
+mod recent_files;
 mod registry;
 mod timing;
 mod visual_rules;
@@ -22,6 +24,8 @@ pub use models::visual_rules::{
     ValidationSeverity, VisualColor, VisualMatcher, VisualRule, VisualRulesEnvelope,
 };
 pub use reader::LogReader;
+#[cfg(feature = "native-persistence")]
+pub use recent_files::{MAX_RECENT_FILES, RecentFile, RecentFilesEnvelope, RecentFilesManager};
 pub use registry::{FileOpenPolicy, LogRegistry, LogRegistryBuilder};
 pub use visual_rules::VisualRuleEvaluator;
 pub use visual_rules_manager::{

--- a/logmancer-core/src/lib.rs
+++ b/logmancer-core/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "native-persistence")]
+mod config_lock;
+#[cfg(feature = "native-persistence")]
 mod config_store;
 mod file_ops;
 mod handler;

--- a/logmancer-core/src/recent_files.rs
+++ b/logmancer-core/src/recent_files.rs
@@ -1,8 +1,10 @@
+use crate::config_lock::with_config_file_lock;
 use atomic_write_file::AtomicWriteFile;
+use log::warn;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -39,11 +41,7 @@ pub struct RecentFilesManager {
 
 impl RecentFilesManager {
     pub fn load(path: PathBuf) -> io::Result<Self> {
-        let state = match fs::read(&path) {
-            Ok(bytes) => serde_json::from_slice(&bytes).map_err(io::Error::other)?,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => RecentFilesEnvelope::default(),
-            Err(error) => return Err(error),
-        };
+        let state = read_envelope(&path)?;
         Ok(Self {
             path,
             state: Mutex::new(state),
@@ -75,22 +73,65 @@ impl RecentFilesManager {
             .state
             .lock()
             .map_err(|_| io::Error::other("recent file state poisoned"))?;
-        state.entries.retain(|entry| entry.path != path);
-        state.entries.insert(
-            0,
-            RecentFile {
-                id,
-                path,
-                opened_at: SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .map_err(io::Error::other)?
-                    .as_millis(),
-            },
-        );
-        state.entries.truncate(MAX_RECENT_FILES);
-        let bytes = serde_json::to_vec_pretty(&*state).map_err(io::Error::other)?;
-        let mut file = AtomicWriteFile::options().open(&self.path)?;
-        file.write_all(&bytes)?;
-        file.commit()
+        with_config_file_lock(&self.path, || {
+            let mut merged = read_envelope(&self.path)?;
+            apply_record(&mut merged, id, path)?;
+            write_envelope(&self.path, &merged)?;
+            *state = merged;
+            Ok(())
+        })
     }
+}
+
+fn read_envelope(path: &Path) -> io::Result<RecentFilesEnvelope> {
+    match fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice(&bytes) {
+            Ok(envelope) => Ok(envelope),
+            Err(error) => recover_corrupt_file(path, error),
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(RecentFilesEnvelope::default()),
+        Err(error) => Err(error),
+    }
+}
+
+fn recover_corrupt_file(path: &Path, error: serde_json::Error) -> io::Result<RecentFilesEnvelope> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_millis();
+    let backup = path.with_file_name(format!("recent-files.{timestamp}.corrupt.json"));
+    fs::copy(path, &backup)?;
+    let envelope = RecentFilesEnvelope::default();
+    write_envelope(path, &envelope)?;
+    warn!(
+        "Recovered corrupt recent-files history at {} into {}: {}",
+        path.display(),
+        backup.display(),
+        error
+    );
+    Ok(envelope)
+}
+
+fn apply_record(envelope: &mut RecentFilesEnvelope, id: String, path: String) -> io::Result<()> {
+    envelope.entries.retain(|entry| entry.path != path);
+    envelope.entries.insert(
+        0,
+        RecentFile {
+            id,
+            path,
+            opened_at: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(io::Error::other)?
+                .as_millis(),
+        },
+    );
+    envelope.entries.truncate(MAX_RECENT_FILES);
+    Ok(())
+}
+
+fn write_envelope(path: &Path, envelope: &RecentFilesEnvelope) -> io::Result<()> {
+    let bytes = serde_json::to_vec_pretty(envelope).map_err(io::Error::other)?;
+    let mut file = AtomicWriteFile::options().open(path)?;
+    file.write_all(&bytes)?;
+    file.commit()
 }

--- a/logmancer-core/src/recent_files.rs
+++ b/logmancer-core/src/recent_files.rs
@@ -1,0 +1,96 @@
+use atomic_write_file::AtomicWriteFile;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const MAX_RECENT_FILES: usize = 10;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentFile {
+    pub id: String,
+    pub path: String,
+    pub opened_at: u128,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentFilesEnvelope {
+    pub schema_version: u32,
+    pub entries: Vec<RecentFile>,
+}
+
+impl Default for RecentFilesEnvelope {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            entries: Vec::new(),
+        }
+    }
+}
+
+pub struct RecentFilesManager {
+    path: PathBuf,
+    state: Mutex<RecentFilesEnvelope>,
+}
+
+impl RecentFilesManager {
+    pub fn load(path: PathBuf) -> io::Result<Self> {
+        let state = match fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).map_err(io::Error::other)?,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => RecentFilesEnvelope::default(),
+            Err(error) => return Err(error),
+        };
+        Ok(Self {
+            path,
+            state: Mutex::new(state),
+        })
+    }
+
+    pub fn path_for_id(&self, id: &str) -> Option<String> {
+        self.state
+            .lock()
+            .ok()?
+            .entries
+            .iter()
+            .find(|entry| entry.id == id)
+            .map(|entry| entry.path.clone())
+    }
+
+    pub fn id_for_path(&self, path: &str) -> Option<String> {
+        self.state
+            .lock()
+            .ok()?
+            .entries
+            .iter()
+            .find(|entry| entry.path == path)
+            .map(|entry| entry.id.clone())
+    }
+
+    pub fn record(&self, id: String, path: String) -> io::Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("recent file state poisoned"))?;
+        state.entries.retain(|entry| entry.path != path);
+        state.entries.insert(
+            0,
+            RecentFile {
+                id,
+                path,
+                opened_at: SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map_err(io::Error::other)?
+                    .as_millis(),
+            },
+        );
+        state.entries.truncate(MAX_RECENT_FILES);
+        let bytes = serde_json::to_vec_pretty(&*state).map_err(io::Error::other)?;
+        let mut file = AtomicWriteFile::options().open(&self.path)?;
+        file.write_all(&bytes)?;
+        file.commit()
+    }
+}

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "native-persistence")]
+use crate::recent_files::RecentFilesManager;
 use crate::{
     LogReader, SaveResult, VisualRulesEnvelope, VisualRulesError, VisualRulesManager,
     VisualRulesState,
@@ -17,6 +19,8 @@ pub struct LogRegistry {
     open_files: Arc<DashMap<Uuid, LogReader>>,
     visual_rules_manager: Arc<VisualRulesManager>,
     file_open_policy: Option<Arc<dyn FileOpenPolicy>>,
+    #[cfg(feature = "native-persistence")]
+    recent_files_manager: Option<Arc<RecentFilesManager>>,
 }
 
 pub struct LogRegistryBuilder {
@@ -41,15 +45,24 @@ impl LogRegistryBuilder {
         #[cfg(feature = "native-persistence")]
         let visual_rules_manager = self
             .config_store
+            .as_ref()
             .map(|config_store| VisualRulesManager::with_store(config_store.visual_rules()))
             .unwrap_or_else(VisualRulesManager::in_memory);
         #[cfg(not(feature = "native-persistence"))]
         let visual_rules_manager = VisualRulesManager::in_memory();
 
+        #[cfg(feature = "native-persistence")]
+        let recent_files_manager = self
+            .config_store
+            .as_ref()
+            .and_then(|store| store.recent_files().ok())
+            .map(Arc::new);
         LogRegistry {
             open_files: Arc::new(DashMap::new()),
             visual_rules_manager,
             file_open_policy: self.file_open_policy,
+            #[cfg(feature = "native-persistence")]
+            recent_files_manager,
         }
     }
 }
@@ -69,26 +82,67 @@ impl LogRegistry {
 
     /// Opens a new file and register with a UUID
     pub fn open_file(&self, path: &str) -> io::Result<String> {
+        let path = self.resolve_path(path)?;
+        #[cfg(feature = "native-persistence")]
+        if let Some(manager) = &self.recent_files_manager
+            && let Some(id) = manager.id_for_path(&path.to_string_lossy())
+        {
+            let uuid = Uuid::parse_str(&id).map_err(io::Error::other)?;
+            self.open_with_id(uuid, &path)?;
+            manager.record(id.clone(), path.to_string_lossy().into_owned())?;
+            return Ok(id);
+        }
         let uuid = Uuid::new_v4();
-        let path = match &self.file_open_policy {
-            Some(policy) => policy.validate(Path::new(path))?,
-            None => PathBuf::from(path),
-        };
-        let reader = LogReader::with_manager(
-            path.to_string_lossy().into_owned(),
-            self.visual_rules_manager.clone(),
-        );
-        self.open_files.insert(uuid, reader?);
+        self.open_with_id(uuid, &path)?;
+        #[cfg(feature = "native-persistence")]
+        if let Some(manager) = &self.recent_files_manager {
+            manager.record(uuid.to_string(), path.to_string_lossy().into_owned())?;
+        }
+        Ok(uuid.to_string())
+    }
+
+    pub fn open_ephemeral_file(&self, path: &str) -> io::Result<String> {
+        let uuid = Uuid::new_v4();
+        let path = self.resolve_path(path)?;
+        self.open_with_id(uuid, &path)?;
         Ok(uuid.to_string())
     }
 
     /// Gets a LogReader by UUID
     pub fn get_reader(&self, file_id: &str) -> Option<RefMut<'_, Uuid, LogReader>> {
-        if let Ok(uuid) = Uuid::parse_str(file_id) {
-            self.open_files.get_mut(&uuid)
-        } else {
-            None
+        let uuid = Uuid::parse_str(file_id).ok()?;
+        if self.open_files.contains_key(&uuid) {
+            return self.open_files.get_mut(&uuid);
         }
+        #[cfg(feature = "native-persistence")]
+        if let Some(manager) = &self.recent_files_manager {
+            let path = manager.path_for_id(file_id)?;
+            let path = self.resolve_path(&path).ok()?;
+            self.open_with_id(uuid, &path).ok()?;
+            manager
+                .record(file_id.to_string(), path.to_string_lossy().into_owned())
+                .ok()?;
+        }
+        self.open_files.get_mut(&uuid)
+    }
+
+    fn resolve_path(&self, path: &str) -> io::Result<PathBuf> {
+        match &self.file_open_policy {
+            Some(policy) => policy.validate(Path::new(path)),
+            None => Path::new(path).canonicalize(),
+        }
+    }
+
+    fn open_with_id(&self, uuid: Uuid, path: &Path) -> io::Result<()> {
+        if self.open_files.contains_key(&uuid) {
+            return Ok(());
+        }
+        let reader = LogReader::with_manager(
+            path.to_string_lossy().into_owned(),
+            self.visual_rules_manager.clone(),
+        )?;
+        self.open_files.insert(uuid, reader);
+        Ok(())
     }
 
     pub fn visual_rules_state(&self) -> VisualRulesState {

--- a/logmancer-core/src/visual_rules_store.rs
+++ b/logmancer-core/src/visual_rules_store.rs
@@ -1,17 +1,17 @@
 #![cfg(feature = "native-persistence")]
 
+use crate::config_lock::with_config_file_lock;
 use crate::models::visual_rules::VisualRulesEnvelope;
 use atomic_write_file::AtomicWriteFile;
 use sha2::{Digest, Sha256};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 static TEMPORARY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
-static COMMIT_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 const OVERSIZED_TOKEN_DOMAIN: &[u8] = b"logmancer:visual-rules:oversized:sha256:v1\0";
 const MAX_RETAINED_BACKUPS: usize = 10;
 
@@ -113,20 +113,7 @@ impl VisualRulesStore for NativeVisualRulesStore {
         bytes: &[u8],
         replace: bool,
     ) -> io::Result<StoreCommit> {
-        let _commit = COMMIT_LOCK
-            .get_or_init(|| Mutex::new(()))
-            .lock()
-            .map_err(|_| io::Error::other("visual rules commit lock poisoned"))?;
-        let mut lock_path = self.path.as_os_str().to_os_string();
-        lock_path.push(".lock");
-        let lock_file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(PathBuf::from(lock_path))?;
-        lock_file.lock()?;
-        let result = (|| {
+        with_config_file_lock(&self.path, || {
             if self.read()?.as_deref() != expected {
                 return Err(io::Error::new(
                     io::ErrorKind::AlreadyExists,
@@ -138,11 +125,7 @@ impl VisualRulesStore for NativeVisualRulesStore {
             } else {
                 self.save_new(bytes)
             }
-        })();
-        match (result, lock_file.unlock()) {
-            (Ok(commit), Ok(())) => Ok(commit),
-            (Err(error), _) | (_, Err(error)) => Err(error),
-        }
+        })
     }
 }
 

--- a/logmancer-core/tests/recent_files.rs
+++ b/logmancer-core/tests/recent_files.rs
@@ -1,0 +1,52 @@
+use logmancer_core::{ConfigStore, LogRegistry};
+
+fn registry(directory: &std::path::Path) -> LogRegistry {
+    let store = ConfigStore::new(directory.to_path_buf());
+    store.prepare().unwrap();
+    LogRegistry::builder().config_store(store).build()
+}
+
+#[test]
+fn reopening_a_file_reuses_its_persisted_id_after_restart() {
+    let directory = tempfile::tempdir().unwrap();
+    let file = directory.path().join("application.log");
+    std::fs::write(&file, "INFO ready\n").unwrap();
+
+    let first = registry(&directory.path().join("config"));
+    let id = first.open_file(file.to_str().unwrap()).unwrap();
+    drop(first);
+
+    let restarted = registry(&directory.path().join("config"));
+    assert!(restarted.get_reader(&id).is_some());
+}
+
+#[test]
+fn ephemeral_opening_is_not_restored_after_restart() {
+    let directory = tempfile::tempdir().unwrap();
+    let file = directory.path().join("upload.log");
+    std::fs::write(&file, "INFO uploaded\n").unwrap();
+
+    let first = registry(&directory.path().join("config"));
+    let id = first.open_ephemeral_file(file.to_str().unwrap()).unwrap();
+    drop(first);
+
+    let restarted = registry(&directory.path().join("config"));
+    assert!(restarted.get_reader(&id).is_none());
+}
+
+#[test]
+fn persistent_history_keeps_only_the_ten_most_recent_files() {
+    let directory = tempfile::tempdir().unwrap();
+    let open_registry = registry(&directory.path().join("config"));
+    let mut ids = Vec::new();
+    for index in 0..11 {
+        let file = directory.path().join(format!("{index}.log"));
+        std::fs::write(&file, "INFO ready\n").unwrap();
+        ids.push(open_registry.open_file(file.to_str().unwrap()).unwrap());
+    }
+    drop(open_registry);
+
+    let restarted = registry(&directory.path().join("config"));
+    assert!(restarted.get_reader(&ids[0]).is_none());
+    assert!(restarted.get_reader(&ids[10]).is_some());
+}

--- a/logmancer-core/tests/recent_files.rs
+++ b/logmancer-core/tests/recent_files.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "native-persistence")]
+
 use logmancer_core::{ConfigStore, LogRegistry};
 
 fn registry(directory: &std::path::Path) -> LogRegistry {

--- a/logmancer-core/tests/recent_files.rs
+++ b/logmancer-core/tests/recent_files.rs
@@ -50,3 +50,54 @@ fn persistent_history_keeps_only_the_ten_most_recent_files() {
     assert!(restarted.get_reader(&ids[0]).is_none());
     assert!(restarted.get_reader(&ids[10]).is_some());
 }
+
+#[test]
+fn concurrent_registries_merge_recent_file_updates() {
+    let directory = tempfile::tempdir().unwrap();
+    let first_file = directory.path().join("first.log");
+    let second_file = directory.path().join("second.log");
+    std::fs::write(&first_file, "INFO first\n").unwrap();
+    std::fs::write(&second_file, "INFO second\n").unwrap();
+
+    let config = directory.path().join("config");
+    let first_registry = registry(&config);
+    let second_registry = registry(&config);
+    let first_id = first_registry
+        .open_file(first_file.to_str().unwrap())
+        .unwrap();
+    let second_id = second_registry
+        .open_file(second_file.to_str().unwrap())
+        .unwrap();
+    drop((first_registry, second_registry));
+
+    let restarted = registry(&config);
+    assert!(restarted.get_reader(&first_id).is_some());
+    assert!(restarted.get_reader(&second_id).is_some());
+}
+
+#[test]
+fn corrupt_history_is_backed_up_and_reinitialized() {
+    let directory = tempfile::tempdir().unwrap();
+    let config = directory.path().join("config");
+    std::fs::create_dir_all(&config).unwrap();
+    std::fs::write(config.join("recent-files.json"), "not json").unwrap();
+    let file = directory.path().join("application.log");
+    std::fs::write(&file, "INFO ready\n").unwrap();
+
+    let registry = registry(&config);
+    let id = registry.open_file(file.to_str().unwrap()).unwrap();
+    drop(registry);
+
+    let history = std::fs::read_to_string(config.join("recent-files.json")).unwrap();
+    assert!(history.contains(&id));
+    assert!(std::fs::read_dir(&config).unwrap().flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_string_lossy()
+            .starts_with("recent-files.")
+            && entry
+                .file_name()
+                .to_string_lossy()
+                .ends_with(".corrupt.json")
+    }));
+}

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -348,9 +348,7 @@ fn wait_for_embedded_server(port: u16) {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     init_desktop_logging();
-    let initial_path = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
+    let initial_path = std::env::args().nth(1);
     info!(
         initial_file_provided = initial_path.is_some(),
         "Resolved desktop initial file argument"

--- a/logmancer-web/src/api/upload_file.rs
+++ b/logmancer-web/src/api/upload_file.rs
@@ -119,7 +119,7 @@ pub async fn upload_file(
     let path_string = path.to_string_lossy().to_string();
     info!("Opening uploaded temp file path={}", path_string);
 
-    match app_state.registry.clone().open_file(&path_string) {
+    match app_state.registry.clone().open_ephemeral_file(&path_string) {
         Ok(file_id) => (
             StatusCode::CREATED,
             Json(OpenServerFileResponse { file_id }),

--- a/logmancer-web/src/browser_api_client.rs
+++ b/logmancer-web/src/browser_api_client.rs
@@ -43,7 +43,7 @@ pub async fn fetch_page(
 #[cfg(target_arch = "wasm32")]
 pub enum FileInfoError {
     NotFound,
-    Message(String),
+    RequestFailed,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -51,25 +51,24 @@ pub async fn fetch_file_info(file_id: String) -> Result<FileInfo, FileInfoError>
     let base = window()
         .location()
         .origin()
-        .map_err(|_| FileInfoError::Message("Could not detect application origin.".to_string()))?;
+        .map_err(|_| FileInfoError::RequestFailed)?;
     let response = reqwest::Client::new()
         .get(format!("{base}/api/file_info"))
         .query(&crate::api::commons::FileInfoRequest { file_id })
         .send()
         .await
-        .map_err(|_| FileInfoError::Message("Could not connect to the server.".to_string()))?;
+        .map_err(|_| FileInfoError::RequestFailed)?;
 
     if response.status().is_success() {
         response
             .json::<FileInfo>()
             .await
-            .map_err(|_| FileInfoError::Message("Could not parse file information.".to_string()))
+            .map_err(|_| FileInfoError::RequestFailed)
     } else if response.status() == reqwest::StatusCode::NOT_FOUND {
         Err(FileInfoError::NotFound)
     } else {
-        Err(FileInfoError::Message(
-            parse_api_error_message(response, "Could not load file information.").await,
-        ))
+        let _ = parse_api_error_message(response, "Could not load file information.").await;
+        Err(FileInfoError::RequestFailed)
     }
 }
 

--- a/logmancer-web/src/browser_api_client.rs
+++ b/logmancer-web/src/browser_api_client.rs
@@ -41,25 +41,35 @@ pub async fn fetch_page(
 }
 
 #[cfg(target_arch = "wasm32")]
-pub async fn fetch_file_info(file_id: String) -> Result<FileInfo, String> {
+pub enum FileInfoError {
+    NotFound,
+    Message(String),
+}
+
+#[cfg(target_arch = "wasm32")]
+pub async fn fetch_file_info(file_id: String) -> Result<FileInfo, FileInfoError> {
     let base = window()
         .location()
         .origin()
-        .map_err(|_| "Could not detect application origin.".to_string())?;
+        .map_err(|_| FileInfoError::Message("Could not detect application origin.".to_string()))?;
     let response = reqwest::Client::new()
         .get(format!("{base}/api/file_info"))
         .query(&crate::api::commons::FileInfoRequest { file_id })
         .send()
         .await
-        .map_err(|_| "Could not connect to the server.".to_string())?;
+        .map_err(|_| FileInfoError::Message("Could not connect to the server.".to_string()))?;
 
     if response.status().is_success() {
         response
             .json::<FileInfo>()
             .await
-            .map_err(|_| "Could not parse file information.".to_string())
+            .map_err(|_| FileInfoError::Message("Could not parse file information.".to_string()))
+    } else if response.status() == reqwest::StatusCode::NOT_FOUND {
+        Err(FileInfoError::NotFound)
     } else {
-        Err(parse_api_error_message(response, "Could not load file information.").await)
+        Err(FileInfoError::Message(
+            parse_api_error_message(response, "Could not load file information.").await,
+        ))
     }
 }
 

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -1,5 +1,5 @@
 #[cfg(target_arch = "wasm32")]
-use crate::browser_api_client::fetch_file_info;
+use crate::browser_api_client::{fetch_file_info, FileInfoError};
 use crate::components::context::{
     ActivePaneContext, LogContentFocusContext, LogFileContext, SearchCommandContext,
     SearchUiContext, SelectionContext, SelectionSource,
@@ -15,6 +15,8 @@ use leptos::prelude::*;
 #[cfg(target_arch = "wasm32")]
 use leptos::wasm_bindgen::JsCast;
 use leptos::{component, view, IntoView};
+#[cfg(target_arch = "wasm32")]
+use leptos_router::hooks::use_navigate;
 use leptos_router::hooks::use_params_map;
 #[cfg(target_arch = "wasm32")]
 use leptos_use::use_event_listener;
@@ -74,6 +76,8 @@ fn next_refresh_generation(current: u64) -> u64 {
 #[component]
 pub fn LogView() -> impl IntoView {
     let file_id = Memo::new(move |_| use_params_map().get().get("id").unwrap_or_default());
+    #[cfg(target_arch = "wasm32")]
+    let navigate = use_navigate();
     let (follow, set_follow) = signal(false);
     let (tail, set_tail) = signal(false);
     let (selected_original_line, set_selected_original_line) = signal(None::<usize>);
@@ -107,8 +111,10 @@ pub fn LogView() -> impl IntoView {
         let current_file_id = file_id.get();
         set_file_path.set(current_file_id.clone());
         leptos::task::spawn_local(async move {
-            if let Ok(info) = fetch_file_info(current_file_id).await {
-                set_file_path.set(app_bar_path(Some(&info), ""));
+            match fetch_file_info(current_file_id).await {
+                Ok(info) => set_file_path.set(app_bar_path(Some(&info), "")),
+                Err(FileInfoError::NotFound) => navigate("/", Default::default()),
+                Err(FileInfoError::Message(_)) => {}
             }
         });
     });

--- a/logmancer-web/src/components/log_view.rs
+++ b/logmancer-web/src/components/log_view.rs
@@ -109,12 +109,13 @@ pub fn LogView() -> impl IntoView {
     #[cfg(target_arch = "wasm32")]
     Effect::new(move |_| {
         let current_file_id = file_id.get();
+        let navigate = navigate.clone();
         set_file_path.set(current_file_id.clone());
         leptos::task::spawn_local(async move {
             match fetch_file_info(current_file_id).await {
                 Ok(info) => set_file_path.set(app_bar_path(Some(&info), "")),
                 Err(FileInfoError::NotFound) => navigate("/", Default::default()),
-                Err(FileInfoError::Message(_)) => {}
+                Err(FileInfoError::RequestFailed) => {}
             }
         });
     });

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -209,10 +209,6 @@ pub async fn start_leptos(addr: std::net::SocketAddr) {
     let file_open_policy = ServerFileRoot::from_env()
         .map(|root| Arc::new(SsrFileOpenPolicy::new(root)) as Arc<dyn FileOpenPolicy>);
     let registry = registry_runtime(config_directory_from_env(), file_open_policy);
-    let initial_path = std::env::args()
-        .nth(1)
-        .or_else(|| std::env::var("LOGMANCER_INITIAL_FILE").ok());
-    let _ = try_open_initial_file(&registry, initial_path.as_deref());
     start_leptos_with_registry(addr, registry).await;
 }
 


### PR DESCRIPTION
Closes #92

## PR Type
- [x] New feature

## Summary
- Persists the ten most recently opened desktop and SSR server-root files with stable route IDs.
- Restores missing readers lazily through the registry and redirects unavailable web routes home.
- Hardens configuration persistence with shared locking, merge-on-write, and corrupt-history recovery.

## Changes
| Area | Change |
|---|---|
| `logmancer-core` | Adds bounded recent-file history, stable-ID restoration, shared config locking, and corrupt JSON recovery. |
| `logmancer-web` | Keeps uploads ephemeral and redirects route metadata 404s to home. |
| `logmancer-desktop` | Retains positional startup while removing `LOGMANCER_INITIAL_FILE`. |
| `docs/adr` | Documents the persisted recent-files contract and recovery behavior. |

## Verification
- [x] `cargo test`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo check -p logmancer-web --features hydrate`
- [x] `git diff --check`

## Runtime Check
N/A: the behavior is covered by core integration tests; no UI surface was added.

## Rollback
Revert `6a55bcf` and `1d297a7` to remove persisted history, restoration, and its resilience hardening.

## Checklist
- [x] Linked approved issue #92
- [x] Added exactly one `type:*` label
- [x] No scripts changed
- [x] Documentation updated
- [x] Conventional commits used
- [x] No Co-Authored-By trailers