### PR TITLE
refactor(registry): centralize leased reader access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,12 @@ cargo clean --profile dev
 - Keep changelog entries concise and grouped under `[Unreleased]` during development or the active release section when preparing a tag.
 - If a change is purely internal and not release-note-worthy, leave `CHANGELOG.md` unchanged and call that out in the commit/PR summary.
 
+### Architecture Decisions
+- Accepted architectural decisions are documented in `docs/adr/`.
+- Before changing cross-cutting behavior, identify and read the relevant ADRs. This includes registry lifecycle, file opening and authorization, persistence, concurrency and workers, server resource policies, and platform-wide behavior.
+- Do not read every ADR by default. List or search `docs/adr/` by topic, then read only the relevant decision records.
+- Do not rewrite an accepted ADR to change its historical decision. Create a new ADR that references or supersedes it when making a new architectural decision.
+
 ---
 
 ## Dependencies

--- a/docs/adr/0007-bounded-registry-reader-lifecycle.md
+++ b/docs/adr/0007-bounded-registry-reader-lifecycle.md
@@ -1,0 +1,83 @@
+# ADR 0007: Bounded registry reader lifecycle
+
+## Status
+
+Accepted
+
+## Decision
+
+`LogRegistry` owns the complete lifecycle of its readers. Every reader
+operation acquires an internal lease, and removal waits for active leases to
+finish before shutting down the reader workers and releasing its resources.
+
+For long-running SSR services, the registry acts as a shared anonymous cache.
+On each file-open attempt, it applies a lazy retention policy based on an idle
+TTL and a soft budget for in-process index memory. It never evicts a reader
+with an active lease.
+
+## Context
+
+The registry currently retains each opened `LogReader` for the process
+lifetime. A reader owns a memory map, line-offset index, filter state, search
+state, and reload, filter, and search workers. There is no removal operation
+or resource bound.
+
+The web service can be used by multiple anonymous clients. Browser tabs cannot
+safely own server readers: closing one tab must not release a reader another
+client may still use. Browser lifecycle notifications are also best effort.
+
+ADR 0006 preserves stable IDs and canonical paths for recent persistent files.
+That history can restore an evicted reader when a subsequent operation uses its
+ID, provided the path still exists and passes the registry file-open policy
+defined by ADR 0005.
+
+## Decisions
+
+| Area | Decision |
+|---|---|
+| Lifecycle owner | `LogRegistry` owns reader acquisition, recency, removal, and restoration. API handlers do not manage lifecycle counters. |
+| Leased access | Every reader operation acquires a lease before use and releases it on every completion path, including errors. A closing reader rejects new leases. |
+| Resource release | Removal waits for active leases, signals all reader workers to stop, joins them, then releases the reader and its memory map and in-memory state. |
+| Cache ownership | SSR readers are shared anonymous server-cache entries, not resources owned by browser tabs or clients. There is no public close endpoint in this phase. |
+| Retention trigger | Retention runs only when opening a file. No periodic reaper is introduced. Entries can remain beyond their TTL when no later file is opened. |
+| Idle retention | Entries older than the configured idle TTL are eligible for removal only when they have no active lease. |
+| Memory budget | One configurable, soft index-memory budget governs estimated line-offset, filter, and search-index memory. The mapped-file size is observed separately and is not part of the budget. |
+| Eviction policy | When over budget, remove least-recently-used idle readers until an internal target below the configured budget is reached. If every candidate is active, opening succeeds and the budget may remain exceeded until a later opening. |
+| Restoration | An evicted persistent reader is restored silently on its next operation when its historical path is still available and authorized. Unavailable or unauthorized paths return an actionable error. |
+
+## Consequences
+
+- A long-running service can reclaim reader resources without relying on
+  browser-tab shutdown.
+- Active operations cannot be interrupted by TTL or LRU eviction.
+- The configured budget is not a hard memory guarantee: it deliberately favors
+  successful file opening over evicting active readers or rejecting admission.
+- Persisted recent routes continue to work after a reader is evicted or a
+  process restarts, subject to ADR 0005 authorization.
+- Index-memory metrics and mapped-file-size metrics must remain distinct so
+  operators understand what the retention budget controls.
+
+## Out of scope
+
+- Browser-upload cleanup or persistent upload storage.
+- A periodic retention process.
+- Hard admission rejection or eviction of active readers.
+- User authentication, client ownership, or per-user resource quotas.
+- Web or Desktop multi-file workspace UI.
+
+## Related work
+
+- #95 centralizes leased reader access.
+- #96 implements deterministic inactive-reader release.
+- #94 implements lazy idle retention during file opening.
+
+## Verification checklist
+
+- [ ] Reader operations cannot run after their reader begins closing.
+- [ ] Leases are released after successful and failed operations.
+- [ ] Removal waits for active operations and joins every reader worker.
+- [ ] Idle readers are selected by TTL and LRU only when a file is opened.
+- [ ] Active readers are never evicted.
+- [ ] Index memory, mapped-file size, and eviction outcomes are observable.
+- [ ] A valid evicted persistent route restores transparently.
+- [ ] Missing or unauthorized persisted routes return an actionable error.

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -5,18 +5,74 @@ use crate::{
     VisualRulesState,
 };
 use dashmap::DashMap;
-use dashmap::mapref::one::RefMut;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use uuid::Uuid;
 
 pub trait FileOpenPolicy: Send + Sync {
     fn validate(&self, path: &Path) -> io::Result<PathBuf>;
 }
 
+struct ReaderEntry {
+    reader: Mutex<LogReader>,
+    state: Arc<Mutex<ReaderState>>,
+}
+
+struct ReaderState {
+    active_leases: usize,
+    closing: bool,
+    last_access: Instant,
+}
+
+struct ReaderLease {
+    state: Arc<Mutex<ReaderState>>,
+}
+
+impl ReaderEntry {
+    fn new(reader: LogReader) -> Self {
+        Self {
+            reader: Mutex::new(reader),
+            state: Arc::new(Mutex::new(ReaderState {
+                active_leases: 0,
+                closing: false,
+                last_access: Instant::now(),
+            })),
+        }
+    }
+
+    fn acquire(&self) -> Option<ReaderLease> {
+        let mut state = self.state.lock().unwrap();
+        if state.closing {
+            return None;
+        }
+        state.active_leases += 1;
+        state.last_access = Instant::now();
+        Some(ReaderLease {
+            state: self.state.clone(),
+        })
+    }
+
+    #[cfg(test)]
+    fn mark_closing(&self) {
+        self.state.lock().unwrap().closing = true;
+    }
+
+    #[cfg(test)]
+    fn active_leases(&self) -> usize {
+        self.state.lock().unwrap().active_leases
+    }
+}
+
+impl Drop for ReaderLease {
+    fn drop(&mut self) {
+        self.state.lock().unwrap().active_leases -= 1;
+    }
+}
+
 pub struct LogRegistry {
-    open_files: Arc<DashMap<Uuid, LogReader>>,
+    open_files: Arc<DashMap<Uuid, Arc<ReaderEntry>>>,
     visual_rules_manager: Arc<VisualRulesManager>,
     file_open_policy: Option<Arc<dyn FileOpenPolicy>>,
     #[cfg(feature = "native-persistence")]
@@ -108,11 +164,20 @@ impl LogRegistry {
         Ok(uuid.to_string())
     }
 
-    /// Gets a LogReader by UUID
-    pub fn get_reader(&self, file_id: &str) -> Option<RefMut<'_, Uuid, LogReader>> {
+    pub fn with_reader<T>(
+        &self,
+        file_id: &str,
+        operation: impl FnOnce(&mut LogReader) -> T,
+    ) -> Option<T> {
+        let entry = self.reader_entry(file_id)?;
+        let _lease = entry.acquire()?;
+        Some(operation(&mut entry.reader.lock().unwrap()))
+    }
+
+    fn reader_entry(&self, file_id: &str) -> Option<Arc<ReaderEntry>> {
         let uuid = Uuid::parse_str(file_id).ok()?;
-        if self.open_files.contains_key(&uuid) {
-            return self.open_files.get_mut(&uuid);
+        if let Some(entry) = self.open_files.get(&uuid) {
+            return Some(entry.clone());
         }
         #[cfg(feature = "native-persistence")]
         if let Some(manager) = &self.recent_files_manager {
@@ -123,7 +188,20 @@ impl LogRegistry {
                 .record(file_id.to_string(), path.to_string_lossy().into_owned())
                 .ok()?;
         }
-        self.open_files.get_mut(&uuid)
+        self.open_files.get(&uuid).map(|entry| entry.clone())
+    }
+
+    #[cfg(test)]
+    fn mark_closing(&self, file_id: &str) -> Option<()> {
+        let uuid = Uuid::parse_str(file_id).ok()?;
+        self.open_files.get(&uuid)?.mark_closing();
+        Some(())
+    }
+
+    #[cfg(test)]
+    fn active_leases(&self, file_id: &str) -> Option<usize> {
+        let uuid = Uuid::parse_str(file_id).ok()?;
+        Some(self.open_files.get(&uuid)?.active_leases())
     }
 
     fn resolve_path(&self, path: &str) -> io::Result<PathBuf> {
@@ -141,7 +219,8 @@ impl LogRegistry {
             path.to_string_lossy().into_owned(),
             self.visual_rules_manager.clone(),
         )?;
-        self.open_files.insert(uuid, reader);
+        self.open_files
+            .insert(uuid, Arc::new(ReaderEntry::new(reader)));
         Ok(())
     }
 
@@ -213,7 +292,10 @@ mod tests {
             .build();
 
         let file_id = registry.open_file("untrusted.log").unwrap();
-        let file_info = registry.get_reader(&file_id).unwrap().file_info().unwrap();
+        let file_info = registry
+            .with_reader(&file_id, |reader| reader.file_info())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(file_info.path, allowed_path.to_string_lossy());
         drop(registry);
@@ -229,6 +311,50 @@ mod tests {
         let error = registry.open_file("blocked.log").unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn leased_access_releases_the_lease_after_an_operation_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = LogRegistry::new();
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+
+        let result = registry.with_reader(&file_id, |_| {
+            Err::<(), _>(io::Error::other("operation failed"))
+        });
+
+        assert!(result.expect("reader is available").is_err());
+        assert_eq!(registry.active_leases(&file_id), Some(0));
+    }
+
+    #[test]
+    fn closing_reader_rejects_new_access_while_an_operation_is_active() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = Arc::new(LogRegistry::new());
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let active_registry = registry.clone();
+        let active_file_id = file_id.clone();
+
+        let active_operation = std::thread::spawn(move || {
+            active_registry.with_reader(&active_file_id, |_| {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })
+        });
+        started_rx.recv().unwrap();
+
+        registry.mark_closing(&file_id).unwrap();
+
+        assert!(registry.with_reader(&file_id, |_| ()).is_none());
+        release_tx.send(()).unwrap();
+        active_operation.join().unwrap();
+        assert_eq!(registry.active_leases(&file_id), Some(0));
     }
 
     #[cfg(feature = "native-persistence")]

--- a/logmancer-core/tests/recent_files.rs
+++ b/logmancer-core/tests/recent_files.rs
@@ -19,7 +19,7 @@ fn reopening_a_file_reuses_its_persisted_id_after_restart() {
     drop(first);
 
     let restarted = registry(&directory.path().join("config"));
-    assert!(restarted.get_reader(&id).is_some());
+    assert!(restarted.with_reader(&id, |_| ()).is_some());
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn ephemeral_opening_is_not_restored_after_restart() {
     drop(first);
 
     let restarted = registry(&directory.path().join("config"));
-    assert!(restarted.get_reader(&id).is_none());
+    assert!(restarted.with_reader(&id, |_| ()).is_none());
 }
 
 #[test]
@@ -49,8 +49,8 @@ fn persistent_history_keeps_only_the_ten_most_recent_files() {
     drop(open_registry);
 
     let restarted = registry(&directory.path().join("config"));
-    assert!(restarted.get_reader(&ids[0]).is_none());
-    assert!(restarted.get_reader(&ids[10]).is_some());
+    assert!(restarted.with_reader(&ids[0], |_| ()).is_none());
+    assert!(restarted.with_reader(&ids[10], |_| ()).is_some());
 }
 
 #[test]
@@ -73,8 +73,8 @@ fn concurrent_registries_merge_recent_file_updates() {
     drop((first_registry, second_registry));
 
     let restarted = registry(&config);
-    assert!(restarted.get_reader(&first_id).is_some());
-    assert!(restarted.get_reader(&second_id).is_some());
+    assert!(restarted.with_reader(&first_id, |_| ()).is_some());
+    assert!(restarted.with_reader(&second_id, |_| ()).is_some());
 }
 
 #[test]

--- a/logmancer-core/tests/visual_rules_management.rs
+++ b/logmancer-core/tests/visual_rules_management.rs
@@ -149,9 +149,8 @@ fn temp_log_path(name: &str) -> std::path::PathBuf {
 fn wait_for_indexed_lines(registry: &LogRegistry, file_id: &str, expected: usize) {
     for _ in 0..20 {
         if registry
-            .get_reader(file_id)
+            .with_reader(file_id, |reader| reader.file_info())
             .expect("reader")
-            .file_info()
             .expect("file info")
             .total_lines
             >= expected
@@ -183,9 +182,8 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
     wait_for_indexed_lines(&registry, &first_id, 3);
 
     let first_page = registry
-        .get_reader(&first_id)
+        .with_reader(&first_id, |reader| reader.read_page(0, 3))
         .expect("first reader")
-        .read_page(0, 3)
         .expect("read page");
     assert_eq!(
         first_page
@@ -208,9 +206,8 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
         .expect("open second");
     wait_for_indexed_lines(&registry, &second_id, 3);
     let second_page = registry
-        .get_reader(&second_id)
+        .with_reader(&second_id, |reader| reader.read_page(0, 3))
         .expect("second reader")
-        .read_page(0, 3)
         .expect("read future reader");
     assert_eq!(second_page.lines[1].style, None);
     assert_eq!(
@@ -218,9 +215,16 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
         Some(style(Some("red"), Some("default")))
     );
 
-    let mut reader = registry.get_reader(&first_id).expect("first reader");
-    reader.filter("ERROR|WARN".to_string());
-    let filtered = reader.read_filter(0, 3).expect("filtered read");
+    let (filtered, searched, status) = registry
+        .with_reader(&first_id, |reader| {
+            reader.filter("ERROR|WARN".to_string());
+            let filtered = reader.read_filter(0, 3);
+            let searched = reader.apply_search("WARN".to_string(), 3);
+            let status = reader.search_status();
+            (filtered, searched, status)
+        })
+        .expect("first reader");
+    let filtered = filtered.expect("filtered read");
     assert_eq!(
         filtered
             .lines
@@ -229,7 +233,7 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
             .collect::<Vec<_>>(),
         vec![2, 3]
     );
-    let searched = reader.apply_search("WARN".to_string(), 3).expect("search");
+    let searched = searched.expect("search");
     assert_eq!(
         searched
             .lines
@@ -238,7 +242,7 @@ fn registry_readers_capture_global_snapshot_without_changing_filter_search_or_na
             .collect::<Vec<_>>(),
         vec![2, 3, 4]
     );
-    assert_eq!(reader.search_status().query.as_deref(), Some("WARN"));
+    assert_eq!(status.query.as_deref(), Some("WARN"));
 
     std::fs::remove_file(path).expect("remove log");
 }

--- a/logmancer-desktop/src/lib.rs
+++ b/logmancer-desktop/src/lib.rs
@@ -223,16 +223,23 @@ mod tests {
         let file_id = open_selected_log_file(&registry, Some(path), "test")
             .unwrap()
             .unwrap();
-        let reader = registry.get_reader(&file_id).unwrap();
-
         for _ in 0..10 {
-            if reader.file_info().unwrap().total_lines >= 2 {
+            if registry
+                .with_reader(&file_id, |reader| reader.file_info())
+                .unwrap()
+                .unwrap()
+                .total_lines
+                >= 2
+            {
                 break;
             }
             sleep(Duration::from_millis(50));
         }
 
-        let info = reader.file_info().unwrap();
+        let info = registry
+            .with_reader(&file_id, |reader| reader.file_info())
+            .unwrap()
+            .unwrap();
 
         assert_eq!(info.total_lines, 2);
     }
@@ -260,7 +267,7 @@ mod tests {
 
         let file_id = open_dropped_log_path(&registry, path).unwrap();
 
-        assert!(registry.get_reader(&file_id).is_some());
+        assert!(registry.with_reader(&file_id, |_| ()).is_some());
     }
 
     #[test]
@@ -275,7 +282,10 @@ mod tests {
         let file_id = open_first_dropped_log_path(&registry, vec![first_path, second_path])
             .unwrap()
             .unwrap();
-        let info = registry.get_reader(&file_id).unwrap().file_info().unwrap();
+        let info = registry
+            .with_reader(&file_id, |reader| reader.file_info())
+            .unwrap()
+            .unwrap();
 
         assert!(info.path.ends_with("first.log"));
     }

--- a/logmancer-web/src/api/file_info.rs
+++ b/logmancer-web/src/api/file_info.rs
@@ -11,8 +11,11 @@ pub async fn file_info(
     query: Query<FileInfoRequest>,
 ) -> impl IntoResponse {
     debug!("Getting info about: {:?}", query);
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(reader) => match reader.file_info() {
+    match app_state
+        .registry
+        .with_reader(&query.file_id, |reader| reader.file_info())
+    {
+        Some(result) => match result {
             Ok(file_info) => (StatusCode::OK, Json(file_info)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/logmancer-web/src/api/filter.rs
+++ b/logmancer-web/src/api/filter.rs
@@ -15,11 +15,11 @@ pub async fn apply_filter(
         payload.file_id, payload.filter
     );
 
-    match app_state.registry.get_reader(&payload.file_id) {
-        Some(mut reader) => {
-            reader.filter(payload.filter);
-            (StatusCode::OK, Json("Filter applied")).into_response()
-        }
+    match app_state
+        .registry
+        .with_reader(&payload.file_id, |reader| reader.filter(payload.filter))
+    {
+        Some(()) => (StatusCode::OK, Json("Filter applied")).into_response(),
         None => (StatusCode::NOT_FOUND, Json("File not opened")).into_response(),
     }
 }
@@ -30,8 +30,10 @@ pub async fn read_filter_page(
 ) -> impl IntoResponse {
     debug!("read_filter_page: {:?}", query);
 
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(mut reader) => match reader.read_filter(query.start_line, query.max_lines) {
+    match app_state.registry.with_reader(&query.file_id, |reader| {
+        reader.read_filter(query.start_line, query.max_lines)
+    }) {
+        Some(result) => match result {
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/logmancer-web/src/api/read_page.rs
+++ b/logmancer-web/src/api/read_page.rs
@@ -12,8 +12,10 @@ pub async fn read_page(
 ) -> impl IntoResponse {
     debug!("payload.path: {:?}", query);
 
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(mut reader) => match reader.read_page(query.start_line, query.max_lines) {
+    match app_state.registry.with_reader(&query.file_id, |reader| {
+        reader.read_page(query.start_line, query.max_lines)
+    }) {
+        Some(result) => match result {
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -31,8 +33,10 @@ pub async fn tail(
 ) -> impl IntoResponse {
     debug!("payload.path: {:?}", query);
 
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(mut reader) => match reader.tail(query.max_lines, query.follow) {
+    match app_state.registry.with_reader(&query.file_id, |reader| {
+        reader.tail(query.max_lines, query.follow)
+    }) {
+        Some(result) => match result {
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/logmancer-web/src/api/search.rs
+++ b/logmancer-web/src/api/search.rs
@@ -9,8 +9,10 @@ pub async fn apply_search(
     State(app_state): State<AppState>,
     Json(payload): Json<ApplySearchRequest>,
 ) -> impl IntoResponse {
-    match app_state.registry.get_reader(&payload.file_id) {
-        Some(mut reader) => match reader.apply_search(payload.query, payload.max_lines) {
+    match app_state.registry.with_reader(&payload.file_id, |reader| {
+        reader.apply_search(payload.query, payload.max_lines)
+    }) {
+        Some(result) => match result {
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::BAD_REQUEST,
@@ -26,11 +28,11 @@ pub async fn clear_search(
     State(app_state): State<AppState>,
     query: Query<SearchStatusRequest>,
 ) -> impl IntoResponse {
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(mut reader) => {
-            reader.clear_search();
-            (StatusCode::OK, Json("Search cleared")).into_response()
-        }
+    match app_state
+        .registry
+        .with_reader(&query.file_id, |reader| reader.clear_search())
+    {
+        Some(()) => (StatusCode::OK, Json("Search cleared")).into_response(),
         None => (StatusCode::NOT_FOUND, Json("File not opened")).into_response(),
     }
 }
@@ -39,8 +41,11 @@ pub async fn search_status(
     State(app_state): State<AppState>,
     query: Query<SearchStatusRequest>,
 ) -> impl IntoResponse {
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(reader) => (StatusCode::OK, Json(reader.search_status())).into_response(),
+    match app_state
+        .registry
+        .with_reader(&query.file_id, |reader| reader.search_status())
+    {
+        Some(status) => (StatusCode::OK, Json(status)).into_response(),
         None => (StatusCode::NOT_FOUND, Json("File not opened")).into_response(),
     }
 }
@@ -49,8 +54,11 @@ pub async fn search_next(
     State(app_state): State<AppState>,
     query: Query<SearchNavigateRequest>,
 ) -> impl IntoResponse {
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(mut reader) => match reader.search_next(query.max_lines) {
+    match app_state
+        .registry
+        .with_reader(&query.file_id, |reader| reader.search_next(query.max_lines))
+    {
+        Some(result) => match result {
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -66,8 +74,10 @@ pub async fn search_previous(
     State(app_state): State<AppState>,
     query: Query<SearchNavigateRequest>,
 ) -> impl IntoResponse {
-    match app_state.registry.get_reader(&query.file_id) {
-        Some(mut reader) => match reader.search_previous(query.max_lines) {
+    match app_state.registry.with_reader(&query.file_id, |reader| {
+        reader.search_previous(query.max_lines)
+    }) {
+        Some(result) => match result {
             Ok(page_result) => (StatusCode::OK, Json(page_result)).into_response(),
             Err(e) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/logmancer-web/src/lib.rs
+++ b/logmancer-web/src/lib.rs
@@ -125,9 +125,8 @@ mod tests {
         let mut highlighted = false;
         for _ in 0..100 {
             let page = registry
-                .get_reader(&file_id)
+                .with_reader(&file_id, |reader| reader.read_page(0, 1))
                 .unwrap()
-                .read_page(0, 1)
                 .unwrap();
             highlighted = page.lines.first().is_some_and(|line| line.style.is_some());
             if highlighted {
@@ -164,7 +163,7 @@ mod tests {
         let registry = registry_runtime(directory.path().join("config"), None);
         let file_id = try_open_initial_file(&registry, log_path.to_str());
 
-        assert!(registry.get_reader(&file_id.unwrap()).is_some());
+        assert!(registry.with_reader(&file_id.unwrap(), |_| ()).is_some());
     }
 }
 


### PR DESCRIPTION
Closes #95

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [x] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Centralizes mutable reader operations behind registry-owned leased access.
- Tracks active leases and recency while rejecting acquisitions for closing readers.
- Migrates web, desktop, persistence, and visual-rule consumers off direct reader guards.

## Changes
| File | Change |
|---|---|
| `logmancer-core/src/registry.rs` | Adds reader entries, lifecycle state, RAII leases, and `with_reader`. |
| `logmancer-web/src/api/*.rs` | Runs API reader operations through the registry lease boundary. |
| `logmancer-core/tests/*`, `logmancer-web/src/lib.rs`, `logmancer-desktop/src/lib.rs` | Migrates consumers and covers error release and closing concurrency. |

## Test Plan
- [x] `cargo test -p logmancer-core registry::tests:: --lib`
- [x] `cargo test -p logmancer-core --test recent_files --features native-persistence`
- [x] `cargo test -p logmancer-web --features ssr --lib`
- [x] `cargo test -p logmancer-desktop`
- [x] `cargo test`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] Shellcheck: N/A, no shell scripts changed.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Shellcheck is not applicable.
- [x] No runtime script boundary changed.
- [x] Documentation was updated in the preceding ADR commit.
- [x] Conventional Commit format.
- [x] No `Co-Authored-By` trailers.