### PR TITLE
feat(registry): release inactive reader resources safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed
+
+- The core registry can now remove inactive readers after their active operations finish, releasing their workers, memory map, indexes, filter state, and search state.
+
 ## [0.4.1] - 2026-08-28
 
 ### Added

--- a/logmancer-core/src/file_ops/write.rs
+++ b/logmancer-core/src/file_ops/write.rs
@@ -213,7 +213,14 @@ mod tests {
 
         let worker_ops = FileWriteOps::new(Arc::clone(&log_file));
         let (tx, rx) = unbounded::<SearchCommand>();
-        spawn_search_worker(worker_ops, rx);
+        let (shutdown_tx, shutdown_rx) = unbounded();
+        let worker = spawn_search_worker(
+            worker_ops,
+            rx,
+            shutdown_rx,
+            #[cfg(test)]
+            None,
+        );
 
         let generation = 1u64;
         write_ops.begin_search(generation, "foo".to_string(), 2);
@@ -232,6 +239,8 @@ mod tests {
         assert_eq!(status.total_matches, 3);
         assert_eq!(status.first.unwrap().line_index, 0);
 
+        shutdown_tx.send(()).unwrap();
+        worker.join().unwrap();
         std::fs::remove_file(path).unwrap();
     }
 

--- a/logmancer-core/src/handler.rs
+++ b/logmancer-core/src/handler.rs
@@ -16,15 +16,36 @@ pub struct LogFileHandler {
     reload_sender: Sender<()>,
     filter_sender: Sender<Option<String>>, // New sender for filter thread
     search_sender: Sender<SearchCommand>,
+    shutdown_senders: Vec<Sender<()>>,
+    worker_handles: Vec<thread::JoinHandle<()>>,
+    #[cfg(test)]
+    drop_join_started: Option<Sender<()>>,
     search_generation: u64,
     write_ops: FileWriteOps,
 }
 
 impl LogFileHandler {
     pub fn new(path: String) -> io::Result<Self> {
+        Self::new_with_reload_batch_sync(
+            path,
+            #[cfg(test)]
+            None,
+            #[cfg(test)]
+            None,
+        )
+    }
+
+    fn new_with_reload_batch_sync(
+        path: String,
+        #[cfg(test)] reload_batch_sync: Option<(Sender<()>, crossbeam_channel::Receiver<()>)>,
+        #[cfg(test)] drop_join_started: Option<Sender<()>>,
+    ) -> io::Result<Self> {
         let (reload_sender, reload_receiver) = unbounded::<()>();
         let (filter_sender, filter_receiver) = unbounded::<Option<String>>();
         let (search_sender, search_receiver) = unbounded::<SearchCommand>();
+        let (reload_shutdown_sender, reload_shutdown_receiver) = unbounded::<()>();
+        let (filter_shutdown_sender, filter_shutdown_receiver) = unbounded::<()>();
+        let (search_shutdown_sender, search_shutdown_receiver) = unbounded::<()>();
         let log_file = Arc::new(RwLock::new(LogFile::new(path.clone())?));
         info!("File {path} loaded");
 
@@ -33,9 +54,28 @@ impl LogFileHandler {
         let search_write_ops = FileWriteOps::new(Arc::clone(&log_file));
         let write_ops = FileWriteOps::new(Arc::clone(&log_file));
 
-        spawn_reload_worker(reload_write_ops, reload_receiver, filter_sender.clone());
-        spawn_filter_worker(filter_write_ops, filter_receiver);
-        spawn_search_worker(search_write_ops, search_receiver);
+        let reload_worker = spawn_reload_worker(
+            reload_write_ops,
+            reload_receiver,
+            filter_sender.clone(),
+            reload_shutdown_receiver,
+            #[cfg(test)]
+            reload_batch_sync,
+        );
+        let filter_worker = spawn_filter_worker(
+            filter_write_ops,
+            filter_receiver,
+            filter_shutdown_receiver,
+            #[cfg(test)]
+            None,
+        );
+        let search_worker = spawn_search_worker(
+            search_write_ops,
+            search_receiver,
+            search_shutdown_receiver,
+            #[cfg(test)]
+            None,
+        );
 
         reload_sender.send(()).unwrap();
 
@@ -44,6 +84,14 @@ impl LogFileHandler {
             reload_sender,
             filter_sender,
             search_sender,
+            shutdown_senders: vec![
+                reload_shutdown_sender,
+                filter_shutdown_sender,
+                search_shutdown_sender,
+            ],
+            worker_handles: vec![reload_worker, filter_worker, search_worker],
+            #[cfg(test)]
+            drop_join_started,
             search_generation: 0,
             write_ops,
         })
@@ -117,5 +165,56 @@ impl LogFileHandler {
 
     pub fn search_previous(&mut self) {
         self.write_ops.search_previous();
+    }
+}
+
+impl Drop for LogFileHandler {
+    fn drop(&mut self) {
+        for sender in &self.shutdown_senders {
+            let _ = sender.send(());
+        }
+        #[cfg(test)]
+        if let Some(sender) = &self.drop_join_started {
+            let _ = sender.send(());
+        }
+        for worker in self.worker_handles.drain(..) {
+            let _ = worker.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossbeam_channel::TryRecvError;
+
+    #[test]
+    fn drop_joins_workers_while_initial_reload_is_active() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "line\n".repeat(3_000_000)).unwrap();
+
+        let (batch_started_sender, batch_started) = crossbeam_channel::bounded(1);
+        let (resume_sender, resume_receiver) = crossbeam_channel::bounded(1);
+        let (drop_join_started_sender, drop_join_started) = crossbeam_channel::bounded(1);
+        let handler = LogFileHandler::new_with_reload_batch_sync(
+            file.path().display().to_string(),
+            Some((batch_started_sender, resume_receiver)),
+            Some(drop_join_started_sender),
+        )
+        .unwrap();
+
+        batch_started.recv().unwrap();
+
+        let (drop_finished_sender, drop_finished) = crossbeam_channel::bounded(1);
+        let drop_thread = std::thread::spawn(move || {
+            drop(handler);
+            drop_finished_sender.send(()).unwrap();
+        });
+
+        drop_join_started.recv().unwrap();
+        assert_eq!(drop_finished.try_recv(), Err(TryRecvError::Empty));
+        resume_sender.send(()).unwrap();
+        drop_finished.recv().unwrap();
+        drop_thread.join().unwrap();
     }
 }

--- a/logmancer-core/src/handler.rs
+++ b/logmancer-core/src/handler.rs
@@ -166,6 +166,11 @@ impl LogFileHandler {
     pub fn search_previous(&mut self) {
         self.write_ops.search_previous();
     }
+
+    #[cfg(test)]
+    pub(crate) fn resource_weak(&self) -> std::sync::Weak<RwLock<LogFile>> {
+        Arc::downgrade(&self.log_file)
+    }
 }
 
 impl Drop for LogFileHandler {

--- a/logmancer-core/src/reader.rs
+++ b/logmancer-core/src/reader.rs
@@ -222,6 +222,13 @@ impl LogReader {
             style,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn resource_weak(
+        &self,
+    ) -> std::sync::Weak<std::sync::RwLock<crate::models::log_file::LogFile>> {
+        self.handler.resource_weak()
+    }
 }
 
 #[cfg(test)]

--- a/logmancer-core/src/reader.rs
+++ b/logmancer-core/src/reader.rs
@@ -244,9 +244,19 @@ mod tests {
     }
 
     fn keep_temp_file_for_background_workers(_path: PathBuf) {
-        // LogReader workers outlive the reader values in these tests. Removing
-        // the file before the test process exits can make the reload worker
-        // report a missing file even though the assertions already passed.
+        // Temp files are retained until their reader is dropped so background
+        // workers can finish their deterministic shutdown.
+    }
+
+    #[test]
+    fn dropping_a_reader_waits_for_its_workers_before_releasing_the_file() {
+        let path = temp_file_path("reader-worker-shutdown");
+        std::fs::write(&path, "line\n".repeat(3_000_000)).unwrap();
+
+        let reader = LogReader::new(path.to_string_lossy().into_owned()).unwrap();
+        drop(reader);
+
+        std::fs::remove_file(path).unwrap();
     }
 
     fn wait_search_ready(reader: &LogReader) {

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -30,6 +30,18 @@ struct ReaderLease {
     state: Arc<(Mutex<ReaderState>, Condvar)>,
 }
 
+struct RegistryLifecycle {
+    state: Mutex<RegistryLifecycleState>,
+    changed: Condvar,
+}
+
+struct RegistryLifecycleState {
+    #[cfg(test)]
+    opening_waiters: usize,
+    #[cfg(test)]
+    open_candidate_barrier: Option<Arc<std::sync::Barrier>>,
+}
+
 impl ReaderEntry {
     fn new(reader: LogReader) -> Self {
         Self {
@@ -57,11 +69,20 @@ impl ReaderEntry {
         })
     }
 
-    fn close_and_take(&self) -> Option<LogReader> {
+    fn begin_closing(&self) {
         let (state_lock, leases_drained) = &*self.state;
         let mut state = state_lock.lock().unwrap();
         state.closing = true;
         leases_drained.notify_all();
+    }
+
+    fn is_closing(&self) -> bool {
+        self.state.0.lock().unwrap().closing
+    }
+
+    fn wait_for_leases_and_take(&self) -> Option<LogReader> {
+        let (state_lock, leases_drained) = &*self.state;
+        let mut state = state_lock.lock().unwrap();
         while state.active_leases > 0 {
             state = leases_drained.wait(state).unwrap();
         }
@@ -71,11 +92,6 @@ impl ReaderEntry {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .take()
-    }
-
-    #[cfg(test)]
-    fn mark_closing(&self) {
-        self.state.0.lock().unwrap().closing = true;
     }
 
     #[cfg(test)]
@@ -118,6 +134,7 @@ impl Drop for ReaderLease {
 
 pub struct LogRegistry {
     open_files: Arc<DashMap<Uuid, Arc<ReaderEntry>>>,
+    lifecycle: Arc<RegistryLifecycle>,
     visual_rules_manager: Arc<VisualRulesManager>,
     file_open_policy: Option<Arc<dyn FileOpenPolicy>>,
     #[cfg(feature = "native-persistence")]
@@ -160,6 +177,15 @@ impl LogRegistryBuilder {
             .map(Arc::new);
         LogRegistry {
             open_files: Arc::new(DashMap::new()),
+            lifecycle: Arc::new(RegistryLifecycle {
+                state: Mutex::new(RegistryLifecycleState {
+                    #[cfg(test)]
+                    opening_waiters: 0,
+                    #[cfg(test)]
+                    open_candidate_barrier: None,
+                }),
+                changed: Condvar::new(),
+            }),
             visual_rules_manager,
             file_open_policy: self.file_open_policy,
             #[cfg(feature = "native-persistence")]
@@ -214,43 +240,50 @@ impl LogRegistry {
         file_id: &str,
         operation: impl FnOnce(&mut LogReader) -> T,
     ) -> Option<T> {
-        let entry = self.reader_entry(file_id)?;
-        let _lease = entry.acquire()?;
-        Some(operation(entry.reader.lock().unwrap().as_mut()?))
+        loop {
+            let entry = self.reader_entry(file_id)?;
+            if let Some(_lease) = entry.acquire() {
+                return Some(operation(entry.reader.lock().unwrap().as_mut()?));
+            }
+        }
     }
 
     pub fn remove_reader(&self, file_id: &str) -> Option<()> {
         let uuid = Uuid::parse_str(file_id).ok()?;
-        let entry = self.open_files.get(&uuid)?.clone();
-        let reader = entry.close_and_take()?;
+        let lifecycle = self.lifecycle.state.lock().unwrap();
+        let entry = self.open_files.get(&uuid).map(|entry| entry.clone())?;
+        entry.begin_closing();
+        drop(lifecycle);
+
+        let reader = entry.wait_for_leases_and_take()?;
+        drop(reader);
+
+        let lifecycle = self.lifecycle.state.lock().unwrap();
         self.open_files
             .remove_if(&uuid, |_, current| Arc::ptr_eq(current, &entry));
-        drop(reader);
+        self.lifecycle.changed.notify_all();
+        drop(lifecycle);
         Some(())
     }
 
     fn reader_entry(&self, file_id: &str) -> Option<Arc<ReaderEntry>> {
         let uuid = Uuid::parse_str(file_id).ok()?;
-        if let Some(entry) = self.open_files.get(&uuid) {
-            return Some(entry.clone());
+        loop {
+            if let Some(entry) = self.usable_entry(uuid) {
+                return Some(entry);
+            }
+            #[cfg(feature = "native-persistence")]
+            if let Some(manager) = &self.recent_files_manager {
+                let path = manager.path_for_id(file_id)?;
+                let path = self.resolve_path(&path).ok()?;
+                self.open_with_id(uuid, &path).ok()?;
+                manager
+                    .record(file_id.to_string(), path.to_string_lossy().into_owned())
+                    .ok()?;
+                continue;
+            }
+            return None;
         }
-        #[cfg(feature = "native-persistence")]
-        if let Some(manager) = &self.recent_files_manager {
-            let path = manager.path_for_id(file_id)?;
-            let path = self.resolve_path(&path).ok()?;
-            self.open_with_id(uuid, &path).ok()?;
-            manager
-                .record(file_id.to_string(), path.to_string_lossy().into_owned())
-                .ok()?;
-        }
-        self.open_files.get(&uuid).map(|entry| entry.clone())
-    }
-
-    #[cfg(test)]
-    fn mark_closing(&self, file_id: &str) -> Option<()> {
-        let uuid = Uuid::parse_str(file_id).ok()?;
-        self.open_files.get(&uuid)?.mark_closing();
-        Some(())
     }
 
     #[cfg(test)]
@@ -275,6 +308,41 @@ impl LogRegistry {
         Some(self.open_files.get(&uuid)?.resource_weak())
     }
 
+    #[cfg(test)]
+    fn wait_for_open_waiter(&self) {
+        let mut lifecycle = self.lifecycle.state.lock().unwrap();
+        while lifecycle.opening_waiters == 0 {
+            lifecycle = self.lifecycle.changed.wait(lifecycle).unwrap();
+        }
+    }
+
+    #[cfg(test)]
+    fn pause_open_candidates(&self, barrier: Arc<std::sync::Barrier>) {
+        self.lifecycle.state.lock().unwrap().open_candidate_barrier = Some(barrier);
+    }
+
+    #[cfg(test)]
+    fn reader_entry_for_test(&self, uuid: Uuid) -> Option<Arc<ReaderEntry>> {
+        self.open_files.get(&uuid).map(|entry| entry.clone())
+    }
+
+    #[cfg(test)]
+    fn open_file_count(&self) -> usize {
+        self.open_files.len()
+    }
+
+    #[cfg(test)]
+    fn replace_reader_for_test(&self, file_id: &str, path: &Path) -> io::Result<Arc<ReaderEntry>> {
+        let uuid = Uuid::parse_str(file_id).map_err(io::Error::other)?;
+        let reader = LogReader::with_manager(
+            path.to_string_lossy().into_owned(),
+            self.visual_rules_manager.clone(),
+        )?;
+        let entry = Arc::new(ReaderEntry::new(reader));
+        self.open_files.insert(uuid, entry.clone());
+        Ok(entry)
+    }
+
     fn resolve_path(&self, path: &str) -> io::Result<PathBuf> {
         match &self.file_open_policy {
             Some(policy) => policy.validate(Path::new(path)),
@@ -283,16 +351,59 @@ impl LogRegistry {
     }
 
     fn open_with_id(&self, uuid: Uuid, path: &Path) -> io::Result<()> {
-        if self.open_files.contains_key(&uuid) {
+        loop {
+            if self.usable_entry(uuid).is_some() {
+                return Ok(());
+            }
+
+            let reader = LogReader::with_manager(
+                path.to_string_lossy().into_owned(),
+                self.visual_rules_manager.clone(),
+            )?;
+            let candidate = Arc::new(ReaderEntry::new(reader));
+            #[cfg(test)]
+            let open_candidate_barrier = self
+                .lifecycle
+                .state
+                .lock()
+                .unwrap()
+                .open_candidate_barrier
+                .clone();
+            #[cfg(test)]
+            if let Some(barrier) = open_candidate_barrier {
+                barrier.wait();
+            }
+
+            let lifecycle = self.lifecycle.state.lock().unwrap();
+            if self.open_files.contains_key(&uuid) {
+                drop(lifecycle);
+                drop(candidate);
+                continue;
+            }
+            self.open_files.insert(uuid, candidate);
+            drop(lifecycle);
             return Ok(());
         }
-        let reader = LogReader::with_manager(
-            path.to_string_lossy().into_owned(),
-            self.visual_rules_manager.clone(),
-        )?;
-        self.open_files
-            .insert(uuid, Arc::new(ReaderEntry::new(reader)));
-        Ok(())
+    }
+
+    fn usable_entry(&self, uuid: Uuid) -> Option<Arc<ReaderEntry>> {
+        let mut lifecycle = self.lifecycle.state.lock().unwrap();
+        loop {
+            let entry = self.open_files.get(&uuid).map(|entry| entry.clone())?;
+            if !entry.is_closing() {
+                return Some(entry);
+            }
+            #[cfg(test)]
+            {
+                lifecycle.opening_waiters += 1;
+                self.lifecycle.changed.notify_all();
+            }
+            lifecycle = self.lifecycle.changed.wait(lifecycle).unwrap();
+            #[cfg(test)]
+            {
+                lifecycle.opening_waiters -= 1;
+            }
+        }
     }
 
     pub fn visual_rules_state(&self) -> VisualRulesState {
@@ -330,7 +441,7 @@ impl Default for LogRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc::TryRecvError;
+    use std::sync::{Barrier, mpsc::TryRecvError};
 
     struct RedirectPolicy {
         path: PathBuf,
@@ -402,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn closing_reader_rejects_new_access_while_an_operation_is_active() {
+    fn access_during_removal_waits_until_the_reader_is_removed() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("application.log");
         std::fs::write(&path, "ready\n").unwrap();
@@ -421,12 +532,28 @@ mod tests {
         });
         started_rx.recv().unwrap();
 
-        registry.mark_closing(&file_id).unwrap();
+        let removing_registry = registry.clone();
+        let removing_file_id = file_id.clone();
+        let removal =
+            std::thread::spawn(move || removing_registry.remove_reader(&removing_file_id));
+        registry.wait_for_closing(&file_id).unwrap();
 
-        assert!(registry.with_reader(&file_id, |_| ()).is_none());
+        let accessing_registry = registry.clone();
+        let accessing_file_id = file_id.clone();
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let access = std::thread::spawn(move || {
+            completed_tx
+                .send(accessing_registry.with_reader(&accessing_file_id, |_| ()))
+                .unwrap();
+        });
+        registry.wait_for_open_waiter();
+
+        assert_eq!(completed_rx.try_recv(), Err(TryRecvError::Empty));
         release_tx.send(()).unwrap();
-        active_operation.join().unwrap();
-        assert_eq!(registry.active_leases(&file_id), Some(0));
+        assert!(active_operation.join().unwrap().is_some());
+        assert!(removal.join().unwrap().is_some());
+        assert!(completed_rx.recv().unwrap().is_none());
+        access.join().unwrap();
     }
 
     #[test]
@@ -476,13 +603,171 @@ mod tests {
         registry.wait_for_closing(&file_id).unwrap();
 
         assert_eq!(removed_rx.try_recv(), Err(TryRecvError::Empty));
-        assert!(registry.with_reader(&file_id, |_| ()).is_none());
-
         release_tx.send(()).unwrap();
         active_operation.join().unwrap();
         assert!(removed_rx.recv().unwrap().is_some());
         removal.join().unwrap();
         assert!(resources.upgrade().is_none());
+    }
+
+    #[test]
+    fn reopening_during_removal_waits_for_a_usable_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = Arc::new(LogRegistry::new());
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let active_registry = registry.clone();
+        let active_file_id = file_id.clone();
+        let active_operation = std::thread::spawn(move || {
+            active_registry.with_reader(&active_file_id, |_| {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })
+        });
+        started_rx.recv().unwrap();
+
+        let removing_registry = registry.clone();
+        let removing_file_id = file_id.clone();
+        let removal =
+            std::thread::spawn(move || removing_registry.remove_reader(&removing_file_id));
+        registry.wait_for_closing(&file_id).unwrap();
+
+        let reopening_registry = registry.clone();
+        let reopening_path = path.clone();
+        let reopening_file_id = file_id.clone();
+        let (opened_tx, opened_rx) = std::sync::mpsc::channel();
+        let reopening = std::thread::spawn(move || {
+            opened_tx.send(reopening_registry.open_with_id(
+                Uuid::parse_str(&reopening_file_id).unwrap(),
+                &reopening_path,
+            ))
+        });
+        registry.wait_for_open_waiter();
+
+        assert!(matches!(opened_rx.try_recv(), Err(TryRecvError::Empty)));
+        release_tx.send(()).unwrap();
+        active_operation.join().unwrap();
+        assert!(removal.join().unwrap().is_some());
+        assert!(opened_rx.recv().unwrap().is_ok());
+        assert!(reopening.join().unwrap().is_ok());
+        assert!(registry.with_reader(&file_id, |_| ()).is_some());
+    }
+
+    #[cfg(feature = "native-persistence")]
+    #[test]
+    fn persisted_access_during_removal_waits_for_restoration() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let store = crate::ConfigStore::new(directory.path().join("config"));
+        store.prepare().unwrap();
+        let registry = Arc::new(LogRegistry::builder().config_store(store).build());
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let active_registry = registry.clone();
+        let active_file_id = file_id.clone();
+        let active_operation = std::thread::spawn(move || {
+            active_registry.with_reader(&active_file_id, |_| {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })
+        });
+        started_rx.recv().unwrap();
+
+        let removing_registry = registry.clone();
+        let removing_file_id = file_id.clone();
+        let removal =
+            std::thread::spawn(move || removing_registry.remove_reader(&removing_file_id));
+        registry.wait_for_closing(&file_id).unwrap();
+
+        let restoring_registry = registry.clone();
+        let restoring_file_id = file_id.clone();
+        let (completed_tx, completed_rx) = std::sync::mpsc::channel();
+        let restoration = std::thread::spawn(move || {
+            completed_tx
+                .send(restoring_registry.with_reader(&restoring_file_id, |_| "restored"))
+                .unwrap()
+        });
+        registry.wait_for_open_waiter();
+
+        assert!(matches!(completed_rx.try_recv(), Err(TryRecvError::Empty)));
+        release_tx.send(()).unwrap();
+        assert!(active_operation.join().unwrap().is_some());
+        assert!(removal.join().unwrap().is_some());
+        assert_eq!(completed_rx.recv().unwrap(), Some("restored"));
+        restoration.join().unwrap();
+    }
+
+    #[test]
+    fn concurrent_opens_keep_the_installed_reader_instance() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = Arc::new(LogRegistry::new());
+        let uuid = Uuid::new_v4();
+        let barrier = Arc::new(Barrier::new(2));
+        registry.pause_open_candidates(barrier);
+
+        let first_registry = registry.clone();
+        let first_path = path.clone();
+        let first = std::thread::spawn(move || first_registry.open_with_id(uuid, &first_path));
+        let second_registry = registry.clone();
+        let second_path = path.clone();
+        let second = std::thread::spawn(move || second_registry.open_with_id(uuid, &second_path));
+
+        assert!(first.join().unwrap().is_ok());
+        assert!(second.join().unwrap().is_ok());
+        let installed = registry.reader_entry_for_test(uuid).unwrap();
+
+        registry.open_with_id(uuid, &path).unwrap();
+
+        assert_eq!(registry.open_file_count(), 1);
+        assert!(Arc::ptr_eq(
+            &installed,
+            &registry.reader_entry_for_test(uuid).unwrap()
+        ));
+    }
+
+    #[test]
+    fn removal_keeps_a_replacement_installed_while_the_original_closes() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = Arc::new(LogRegistry::new());
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let active_registry = registry.clone();
+        let active_file_id = file_id.clone();
+        let active_operation = std::thread::spawn(move || {
+            active_registry.with_reader(&active_file_id, |_| {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })
+        });
+        started_rx.recv().unwrap();
+
+        let removing_registry = registry.clone();
+        let removing_file_id = file_id.clone();
+        let removal =
+            std::thread::spawn(move || removing_registry.remove_reader(&removing_file_id));
+        registry.wait_for_closing(&file_id).unwrap();
+        let replacement = registry.replace_reader_for_test(&file_id, &path).unwrap();
+
+        release_tx.send(()).unwrap();
+        active_operation.join().unwrap();
+        assert!(removal.join().unwrap().is_some());
+        assert!(Arc::ptr_eq(
+            &replacement,
+            &registry
+                .reader_entry_for_test(Uuid::parse_str(&file_id).unwrap())
+                .unwrap()
+        ));
+        assert!(registry.with_reader(&file_id, |_| ()).is_some());
     }
 
     #[cfg(feature = "native-persistence")]

--- a/logmancer-core/src/registry.rs
+++ b/logmancer-core/src/registry.rs
@@ -7,7 +7,7 @@ use crate::{
 use dashmap::DashMap;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -16,8 +16,8 @@ pub trait FileOpenPolicy: Send + Sync {
 }
 
 struct ReaderEntry {
-    reader: Mutex<LogReader>,
-    state: Arc<Mutex<ReaderState>>,
+    reader: Mutex<Option<LogReader>>,
+    state: Arc<(Mutex<ReaderState>, Condvar)>,
 }
 
 struct ReaderState {
@@ -27,23 +27,26 @@ struct ReaderState {
 }
 
 struct ReaderLease {
-    state: Arc<Mutex<ReaderState>>,
+    state: Arc<(Mutex<ReaderState>, Condvar)>,
 }
 
 impl ReaderEntry {
     fn new(reader: LogReader) -> Self {
         Self {
-            reader: Mutex::new(reader),
-            state: Arc::new(Mutex::new(ReaderState {
-                active_leases: 0,
-                closing: false,
-                last_access: Instant::now(),
-            })),
+            reader: Mutex::new(Some(reader)),
+            state: Arc::new((
+                Mutex::new(ReaderState {
+                    active_leases: 0,
+                    closing: false,
+                    last_access: Instant::now(),
+                }),
+                Condvar::new(),
+            )),
         }
     }
 
     fn acquire(&self) -> Option<ReaderLease> {
-        let mut state = self.state.lock().unwrap();
+        let mut state = self.state.0.lock().unwrap();
         if state.closing {
             return None;
         }
@@ -54,20 +57,62 @@ impl ReaderEntry {
         })
     }
 
+    fn close_and_take(&self) -> Option<LogReader> {
+        let (state_lock, leases_drained) = &*self.state;
+        let mut state = state_lock.lock().unwrap();
+        state.closing = true;
+        leases_drained.notify_all();
+        while state.active_leases > 0 {
+            state = leases_drained.wait(state).unwrap();
+        }
+        drop(state);
+
+        self.reader
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
     #[cfg(test)]
     fn mark_closing(&self) {
-        self.state.lock().unwrap().closing = true;
+        self.state.0.lock().unwrap().closing = true;
     }
 
     #[cfg(test)]
     fn active_leases(&self) -> usize {
-        self.state.lock().unwrap().active_leases
+        self.state.0.lock().unwrap().active_leases
+    }
+
+    #[cfg(test)]
+    fn wait_for_closing(&self) {
+        let (state_lock, closing_changed) = &*self.state;
+        let mut state = state_lock.lock().unwrap();
+        while !state.closing {
+            state = closing_changed.wait(state).unwrap();
+        }
+    }
+
+    #[cfg(test)]
+    fn resource_weak(
+        &self,
+    ) -> std::sync::Weak<std::sync::RwLock<crate::models::log_file::LogFile>> {
+        self.reader
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .resource_weak()
     }
 }
 
 impl Drop for ReaderLease {
     fn drop(&mut self) {
-        self.state.lock().unwrap().active_leases -= 1;
+        let (state_lock, leases_drained) = &*self.state;
+        let mut state = state_lock.lock().unwrap();
+        state.active_leases -= 1;
+        if state.active_leases == 0 {
+            leases_drained.notify_all();
+        }
     }
 }
 
@@ -171,7 +216,17 @@ impl LogRegistry {
     ) -> Option<T> {
         let entry = self.reader_entry(file_id)?;
         let _lease = entry.acquire()?;
-        Some(operation(&mut entry.reader.lock().unwrap()))
+        Some(operation(entry.reader.lock().unwrap().as_mut()?))
+    }
+
+    pub fn remove_reader(&self, file_id: &str) -> Option<()> {
+        let uuid = Uuid::parse_str(file_id).ok()?;
+        let entry = self.open_files.get(&uuid)?.clone();
+        let reader = entry.close_and_take()?;
+        self.open_files
+            .remove_if(&uuid, |_, current| Arc::ptr_eq(current, &entry));
+        drop(reader);
+        Some(())
     }
 
     fn reader_entry(&self, file_id: &str) -> Option<Arc<ReaderEntry>> {
@@ -202,6 +257,22 @@ impl LogRegistry {
     fn active_leases(&self, file_id: &str) -> Option<usize> {
         let uuid = Uuid::parse_str(file_id).ok()?;
         Some(self.open_files.get(&uuid)?.active_leases())
+    }
+
+    #[cfg(test)]
+    fn wait_for_closing(&self, file_id: &str) -> Option<()> {
+        let uuid = Uuid::parse_str(file_id).ok()?;
+        self.open_files.get(&uuid)?.wait_for_closing();
+        Some(())
+    }
+
+    #[cfg(test)]
+    fn resource_weak(
+        &self,
+        file_id: &str,
+    ) -> Option<std::sync::Weak<std::sync::RwLock<crate::models::log_file::LogFile>>> {
+        let uuid = Uuid::parse_str(file_id).ok()?;
+        Some(self.open_files.get(&uuid)?.resource_weak())
     }
 
     fn resolve_path(&self, path: &str) -> io::Result<PathBuf> {
@@ -259,6 +330,7 @@ impl Default for LogRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::mpsc::TryRecvError;
 
     struct RedirectPolicy {
         path: PathBuf,
@@ -355,6 +427,62 @@ mod tests {
         release_tx.send(()).unwrap();
         active_operation.join().unwrap();
         assert_eq!(registry.active_leases(&file_id), Some(0));
+    }
+
+    #[test]
+    fn removing_an_idle_reader_releases_its_resources() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = LogRegistry::new();
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+        let resources = registry.resource_weak(&file_id).unwrap();
+
+        assert!(registry.remove_reader(&file_id).is_some());
+
+        assert!(resources.upgrade().is_none());
+        assert!(registry.with_reader(&file_id, |_| ()).is_none());
+    }
+
+    #[test]
+    fn removing_a_reader_waits_for_an_active_lease() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("application.log");
+        std::fs::write(&path, "ready\n").unwrap();
+        let registry = Arc::new(LogRegistry::new());
+        let file_id = registry.open_file(path.to_str().unwrap()).unwrap();
+        let resources = registry.resource_weak(&file_id).unwrap();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let active_registry = registry.clone();
+        let active_file_id = file_id.clone();
+
+        let active_operation = std::thread::spawn(move || {
+            active_registry.with_reader(&active_file_id, |_| {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+            })
+        });
+        started_rx.recv().unwrap();
+
+        let removing_registry = registry.clone();
+        let removing_file_id = file_id.clone();
+        let (removed_tx, removed_rx) = std::sync::mpsc::channel();
+        let removal = std::thread::spawn(move || {
+            removed_tx
+                .send(removing_registry.remove_reader(&removing_file_id))
+                .unwrap();
+        });
+        registry.wait_for_closing(&file_id).unwrap();
+
+        assert_eq!(removed_rx.try_recv(), Err(TryRecvError::Empty));
+        assert!(registry.with_reader(&file_id, |_| ()).is_none());
+
+        release_tx.send(()).unwrap();
+        active_operation.join().unwrap();
+        assert!(removed_rx.recv().unwrap().is_some());
+        removal.join().unwrap();
+        assert!(resources.upgrade().is_none());
     }
 
     #[cfg(feature = "native-persistence")]

--- a/logmancer-core/src/workers/filter.rs
+++ b/logmancer-core/src/workers/filter.rs
@@ -1,28 +1,38 @@
 use crate::file_ops::write::FileWriteOps;
 use crate::workers::common::wait;
-use crossbeam_channel::{Receiver, select};
+#[cfg(test)]
+use crossbeam_channel::Sender;
+use crossbeam_channel::{Receiver, TryRecvError, select};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
-pub fn spawn_filter_worker(mut write_ops: FileWriteOps, filter_receiver: Receiver<Option<String>>) {
+#[cfg(test)]
+pub(crate) struct BatchSync {
+    started: Sender<()>,
+    resume: Receiver<()>,
+}
+
+pub fn spawn_filter_worker(
+    mut write_ops: FileWriteOps,
+    filter_receiver: Receiver<Option<String>>,
+    shutdown_receiver: Receiver<()>,
+    #[cfg(test)] batch_sync: Option<BatchSync>,
+) -> JoinHandle<()> {
     std::thread::spawn(move || {
         loop {
             select! {
+                recv(shutdown_receiver) -> _ => break,
                 recv(filter_receiver) -> msg => {
                     match msg {
                         Ok(pattern) => {
                             write_ops.filter(pattern).unwrap();
-                            loop {
-                                match write_ops.index_filter() {
-                                    Ok(end_reached) => {
-                                        if end_reached {
-                                            break;
-                                        }
-                                        wait(1);
-                                    }
-                                    Err(error) => {
-                                        panic!("Error indexing filtered lines: {error}")
-                                    }
-                                }
+                            if !index_filter_until_complete(
+                                &mut write_ops,
+                                &shutdown_receiver,
+                                #[cfg(test)]
+                                batch_sync.as_ref(),
+                            ) {
+                                return;
                             }
                         }
                         Err(_) => break,
@@ -31,5 +41,68 @@ pub fn spawn_filter_worker(mut write_ops: FileWriteOps, filter_receiver: Receive
                 default(Duration::from_secs(5)) => {}
             }
         }
-    });
+    })
+}
+
+fn index_filter_until_complete(
+    write_ops: &mut FileWriteOps,
+    shutdown_receiver: &Receiver<()>,
+    #[cfg(test)] batch_sync: Option<&BatchSync>,
+) -> bool {
+    loop {
+        match write_ops.index_filter() {
+            Ok(end_reached) => {
+                if end_reached {
+                    return true;
+                }
+                #[cfg(test)]
+                if let Some(batch_sync) = batch_sync {
+                    let _ = batch_sync.started.send(());
+                    let _ = batch_sync.resume.recv();
+                }
+                if !matches!(shutdown_receiver.try_recv(), Err(TryRecvError::Empty)) {
+                    return false;
+                }
+                wait(1);
+            }
+            Err(error) => panic!("Error indexing filtered lines: {error}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::log_file::LogFile;
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn stops_spawned_worker_during_an_active_filter_batch() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "matching line\n".repeat(2_001)).unwrap();
+        let log_file = Arc::new(RwLock::new(
+            LogFile::new(file.path().display().to_string()).unwrap(),
+        ));
+        let mut write_ops = FileWriteOps::new(log_file);
+        while !write_ops.index_lines().unwrap() {}
+        let (filter_sender, filter_receiver) = crossbeam_channel::unbounded();
+        let (shutdown_sender, shutdown_receiver) = crossbeam_channel::unbounded();
+        let (batch_started_sender, batch_started) = crossbeam_channel::bounded(1);
+        let (resume_sender, resume_receiver) = crossbeam_channel::bounded(1);
+        let worker = spawn_filter_worker(
+            write_ops,
+            filter_receiver,
+            shutdown_receiver,
+            Some(BatchSync {
+                started: batch_started_sender,
+                resume: resume_receiver,
+            }),
+        );
+
+        filter_sender.send(Some("matching".to_string())).unwrap();
+        batch_started.recv().unwrap();
+        shutdown_sender.send(()).unwrap();
+        resume_sender.send(()).unwrap();
+        worker.join().unwrap();
+    }
 }

--- a/logmancer-core/src/workers/reload.rs
+++ b/logmancer-core/src/workers/reload.rs
@@ -1,32 +1,34 @@
 use crate::file_ops::write::FileWriteOps;
 use crate::workers::common::wait;
-use crossbeam_channel::{Receiver, Sender, select};
+use crossbeam_channel::{Receiver, Sender, TryRecvError, select};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 pub fn spawn_reload_worker(
     mut write_ops: FileWriteOps,
     reload_receiver: Receiver<()>,
     filter_sender: Sender<Option<String>>,
-) {
+    shutdown_receiver: Receiver<()>,
+    #[cfg(test)] batch_sync: Option<(Sender<()>, Receiver<()>)>,
+) -> JoinHandle<()> {
     std::thread::spawn(move || {
         loop {
             select! {
-                recv(reload_receiver) -> _ => {
+                recv(shutdown_receiver) -> _ => break,
+                recv(reload_receiver) -> message => {
+                    if message.is_err() {
+                        break;
+                    }
                     match write_ops.reload() {
                         Ok(()) => {
-                            loop {
-                                match write_ops.index_lines() {
-                                    Ok(end_reached) => {
-                                        filter_sender.send(None).unwrap();
-                                        if end_reached {
-                                            break;
-                                        }
-                                        wait(1);
-                                    }
-                                    Err(error) => {
-                                        panic!("Error indexing file: {error}")
-                                    }
-                                }
+                            if !index_lines_until_complete(
+                                &mut write_ops,
+                                &filter_sender,
+                                &shutdown_receiver,
+                                #[cfg(test)]
+                                batch_sync.as_ref(),
+                            ) {
+                                return;
                             }
                         }
                         Err(error) => {
@@ -37,5 +39,92 @@ pub fn spawn_reload_worker(
                 default(Duration::from_secs(5)) => {}
             }
         }
-    });
+    })
+}
+
+fn index_lines_until_complete(
+    write_ops: &mut FileWriteOps,
+    filter_sender: &Sender<Option<String>>,
+    shutdown_receiver: &Receiver<()>,
+    #[cfg(test)] batch_sync: Option<&(Sender<()>, Receiver<()>)>,
+) -> bool {
+    loop {
+        match write_ops.index_lines() {
+            Ok(end_reached) => {
+                if filter_sender.send(None).is_err() {
+                    return false;
+                }
+                if end_reached {
+                    return true;
+                }
+                #[cfg(test)]
+                if let Some(batch_sync) = batch_sync {
+                    let _ = batch_sync.0.send(());
+                    let _ = batch_sync.1.recv();
+                }
+                if !matches!(shutdown_receiver.try_recv(), Err(TryRecvError::Empty)) {
+                    return false;
+                }
+                wait(1);
+            }
+            Err(error) => panic!("Error indexing file: {error}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::log_file::LogFile;
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn stops_spawned_worker_during_an_active_index_batch() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "line\n".repeat(3_000_000)).unwrap();
+        let log_file = Arc::new(RwLock::new(
+            LogFile::new(file.path().display().to_string()).unwrap(),
+        ));
+        let write_ops = FileWriteOps::new(log_file);
+        let (reload_sender, reload_receiver) = crossbeam_channel::unbounded();
+        let (filter_sender, _filter_receiver) = crossbeam_channel::unbounded();
+        let (shutdown_sender, shutdown_receiver) = crossbeam_channel::unbounded();
+        let (batch_started_sender, batch_started) = crossbeam_channel::bounded(1);
+        let (resume_sender, resume_receiver) = crossbeam_channel::bounded(1);
+        let worker = spawn_reload_worker(
+            write_ops,
+            reload_receiver,
+            filter_sender,
+            shutdown_receiver,
+            Some((batch_started_sender, resume_receiver)),
+        );
+
+        reload_sender.send(()).unwrap();
+        batch_started.recv().unwrap();
+        shutdown_sender.send(()).unwrap();
+        resume_sender.send(()).unwrap();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn exits_when_reload_channel_is_disconnected() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let log_file = Arc::new(RwLock::new(
+            LogFile::new(file.path().display().to_string()).unwrap(),
+        ));
+        let write_ops = FileWriteOps::new(log_file);
+        let (reload_sender, reload_receiver) = crossbeam_channel::unbounded();
+        let (filter_sender, _) = crossbeam_channel::unbounded();
+        let (_shutdown_sender, shutdown_receiver) = crossbeam_channel::unbounded();
+        let worker = spawn_reload_worker(
+            write_ops,
+            reload_receiver,
+            filter_sender,
+            shutdown_receiver,
+            None,
+        );
+
+        drop(reload_sender);
+        worker.join().unwrap();
+    }
 }

--- a/logmancer-core/src/workers/search.rs
+++ b/logmancer-core/src/workers/search.rs
@@ -1,8 +1,23 @@
 use crate::file_ops::read::FileReadOps;
 use crate::file_ops::write::FileWriteOps;
 use crate::workers::common::wait;
-use crossbeam_channel::{Receiver, select};
+#[cfg(test)]
+use crossbeam_channel::Sender;
+use crossbeam_channel::{Receiver, TryRecvError, select};
+use std::thread::JoinHandle;
 use std::time::Duration;
+
+#[cfg(test)]
+pub(crate) struct BatchSync {
+    started: Sender<()>,
+    resume: Receiver<()>,
+}
+
+struct ShutdownContext<'a> {
+    receiver: &'a Receiver<()>,
+    #[cfg(test)]
+    batch_sync: Option<&'a BatchSync>,
+}
 
 pub enum SearchCommand {
     Start {
@@ -13,10 +28,16 @@ pub enum SearchCommand {
     },
 }
 
-pub fn spawn_search_worker(mut write_ops: FileWriteOps, search_receiver: Receiver<SearchCommand>) {
+pub fn spawn_search_worker(
+    mut write_ops: FileWriteOps,
+    search_receiver: Receiver<SearchCommand>,
+    shutdown_receiver: Receiver<()>,
+    #[cfg(test)] batch_sync: Option<BatchSync>,
+) -> JoinHandle<()> {
     std::thread::spawn(move || {
         loop {
             select! {
+                recv(shutdown_receiver) -> _ => break,
                 recv(search_receiver) -> msg => {
                     match msg {
                         Ok(SearchCommand::Start { generation, query, origin_line, indexed_lines }) => {
@@ -28,16 +49,37 @@ pub fn spawn_search_worker(mut write_ops: FileWriteOps, search_receiver: Receive
                             let total_content_lines = indexed_lines - 1;
                             let origin = origin_line.min(total_content_lines.saturating_sub(1));
 
-                            process_range(
+                            if !process_range(
                                 &mut write_ops,
                                 generation,
                                 &query,
                                 origin,
                                 total_content_lines,
                                 false,
-                            );
+                                ShutdownContext {
+                                    receiver: &shutdown_receiver,
+                                    #[cfg(test)]
+                                    batch_sync: batch_sync.as_ref(),
+                                },
+                            ) {
+                                return;
+                            }
                             if origin > 0 {
-                                process_range(&mut write_ops, generation, &query, 0, origin, true);
+                                if !process_range(
+                                    &mut write_ops,
+                                    generation,
+                                    &query,
+                                    0,
+                                    origin,
+                                    true,
+                                    ShutdownContext {
+                                        receiver: &shutdown_receiver,
+                                        #[cfg(test)]
+                                        batch_sync: batch_sync.as_ref(),
+                                    },
+                                ) {
+                                    return;
+                                }
                             } else {
                                 write_ops.merge_search_batch(generation, Vec::new(), true);
                             }
@@ -48,7 +90,7 @@ pub fn spawn_search_worker(mut write_ops: FileWriteOps, search_receiver: Receive
                 default(Duration::from_secs(5)) => {}
             }
         }
-    });
+    })
 }
 
 fn process_range(
@@ -58,7 +100,8 @@ fn process_range(
     start: usize,
     end: usize,
     finalize_last_batch: bool,
-) {
+    shutdown: ShutdownContext<'_>,
+) -> bool {
     let mut cursor = start;
     while cursor < end {
         let batch_end = usize::min(cursor + crate::file_ops::write::SEARCH_BATCH_MAX_LINES, end);
@@ -76,6 +119,60 @@ fn process_range(
             break;
         }
         cursor = batch_end;
+        #[cfg(test)]
+        if let Some(batch_sync) = shutdown.batch_sync {
+            let _ = batch_sync.started.send(());
+            let _ = batch_sync.resume.recv();
+        }
+        if !matches!(shutdown.receiver.try_recv(), Err(TryRecvError::Empty)) {
+            return false;
+        }
         wait(1);
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::log_file::LogFile;
+    use std::sync::{Arc, RwLock};
+
+    #[test]
+    fn stops_spawned_worker_during_an_active_search_batch() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(file.path(), "match\n".repeat(2_001)).unwrap();
+        let log_file = Arc::new(RwLock::new(
+            LogFile::new(file.path().display().to_string()).unwrap(),
+        ));
+        let mut write_ops = FileWriteOps::new(log_file);
+        while !write_ops.index_lines().unwrap() {}
+        write_ops.begin_search(1, "match".to_string(), 0);
+        let (search_sender, search_receiver) = crossbeam_channel::unbounded();
+        let (shutdown_sender, shutdown_receiver) = crossbeam_channel::unbounded();
+        let (batch_started_sender, batch_started) = crossbeam_channel::bounded(1);
+        let (resume_sender, resume_receiver) = crossbeam_channel::bounded(1);
+        let worker = spawn_search_worker(
+            write_ops,
+            search_receiver,
+            shutdown_receiver,
+            Some(BatchSync {
+                started: batch_started_sender,
+                resume: resume_receiver,
+            }),
+        );
+
+        search_sender
+            .send(SearchCommand::Start {
+                generation: 1,
+                query: "match".to_string(),
+                origin_line: 0,
+                indexed_lines: 2_002,
+            })
+            .unwrap();
+        batch_started.recv().unwrap();
+        shutdown_sender.send(()).unwrap();
+        resume_sender.send(()).unwrap();
+        worker.join().unwrap();
     }
 }


### PR DESCRIPTION
Closes #96

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Give `LogRegistry` ownership of safe reader closing, lease draining, removal, and resource release.
- Shut down and join reload, filter, and search workers deterministically before releasing mmap and index state.
- Coordinate same-ID opening and persisted restoration with concurrent removal without replacing the installed reader.

## Changes

| File | Change |
|------|--------|
| `logmancer-core/src/registry.rs` | Add lifecycle coordination, safe removal, atomic installation/restoration, and concurrency tests. |
| `logmancer-core/src/handler.rs` | Own worker handles, signal shutdown, join workers, and expose test-only resource observation. |
| `logmancer-core/src/reader.rs` | Verify standalone reader teardown and resource release. |
| `logmancer-core/src/workers/reload.rs` | Add responsive shutdown/disconnect handling and deterministic active-work tests. |
| `logmancer-core/src/workers/filter.rs` | Add responsive shutdown handling and deterministic active-work tests. |
| `logmancer-core/src/workers/search.rs` | Add responsive shutdown handling across search batches and deterministic tests. |
| `logmancer-core/src/file_ops/write.rs` | Update search worker lifecycle coverage. |
| `CHANGELOG.md` | Document safe release of inactive reader resources. |

## Test Plan

- [x] `cargo fmt`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test`
- [x] Deterministic tests cover active reload/filter/search shutdown, idle removal, lease-draining removal, exact-instance removal, concurrent same-ID opening, and persisted restoration during removal.
- [x] Large-file responsiveness test remains intentionally ignored unless `LOGMANCER_LARGE_LOG_PATH` is provided.
- [x] Runtime harness: N/A; this is an internal core lifecycle boundary covered by deterministic multithreaded and workspace integration tests.

## Review Size Exception

The maintainer explicitly accepted a single-PR `size:exception` for this 990-line diff. The PR contains three ordered, tightly dependent work units: worker shutdown, safe registry removal, and restoration coordination. Each is isolated in its own conventional commit for review and rollback.

## Scope

- Start: registry-owned leased reader access from #95.
- End: readers can be closed, drained, shut down, removed, and restored safely.
- Out of scope: TTL/LRU selection, memory-budget accounting, periodic reapers, HTTP close endpoints, and actionable persisted-route errors tracked by #99.

## Contributor Checklist

- [x] Linked approved issue #96.
- [x] Exactly one PR type selected and one `type:*` label applied.
- [x] Formatting, full workspace tests, and Clippy pass.
- [x] User-facing behavior is documented in `CHANGELOG.md`.
- [x] Commits follow Conventional Commit format.
- [x] No AI attribution or `Co-Authored-By` trailers.
- [x] Unrelated untracked workspace files are excluded.